### PR TITLE
feat: enhance module initialization with interface selection

### DIFF
--- a/src/cli/git.ts
+++ b/src/cli/git.ts
@@ -65,6 +65,7 @@ export interface Template {
   description: string;
   repository: string;
   branch: string;
+  interfaces: string[];
 }
 
 export async function loadManifestFromGit(git: string): Promise<GitManifest> {

--- a/src/cli/git.ts
+++ b/src/cli/git.ts
@@ -65,7 +65,7 @@ export interface Template {
   description: string;
   repository: string;
   branch: string;
-  interfaces: string[];
+  interfaces?: string[];
 }
 
 export async function loadManifestFromGit(git: string): Promise<GitManifest> {

--- a/src/cli/module/init.ts
+++ b/src/cli/module/init.ts
@@ -90,9 +90,32 @@ export async function moduleInitCommand(modulePath: string, options: InitOptions
     // Load and select interfaces
     console.log('');
     const interfacesInfo = await loadInterfacesFromGit(git, gitManifest.starredInterfaces);
-    const interfaceCount = Object.keys(interfacesInfo).length;
 
-    if (interfaceCount === 0) {
+    const [selectableInterfaces, nonSelectableInterfaces] = Object.values(interfacesInfo).reduce(
+      ([match, noMatch], interfaceInfo) => {
+        const formattedItem = {
+          name: `${chalk.cyan(interfaceInfo.name)} - ${chalk.dim(interfaceInfo.manifest.description)}`,
+          value: interfaceInfo.name,
+        };
+        if (!template.interfaces.includes(interfaceInfo.name)) {
+          match.push(formattedItem);
+        } else {
+          noMatch.push(formattedItem);
+        }
+        return [match, noMatch];
+      },
+      [[], []] as { name: string; value: string }[][],
+    );
+
+    if (nonSelectableInterfaces.length) {
+      console.log('');
+      console.log(chalk.bold('Already imported interfaces from template:'));
+      nonSelectableInterfaces.forEach((interfaceInfo) => {
+        console.log(`  • ${chalk.cyan(interfaceInfo.name)}`);
+      });
+    }
+
+    if (selectableInterfaces.length === 0) {
       warning('No interfaces available for import');
     } else {
       // Prompt for interface selection
@@ -102,10 +125,7 @@ export async function moduleInitCommand(modulePath: string, options: InitOptions
           type: 'checkbox',
           name: 'interfaces',
           message: 'Select interfaces to import into your module',
-          choices: Object.values(interfacesInfo).map((interfaceInfo) => ({
-            name: `${chalk.cyan(interfaceInfo.name)} - ${chalk.dim(interfaceInfo.manifest.description)}`,
-            value: interfaceInfo.name,
-          })),
+          choices: selectableInterfaces,
         },
       ]);
 

--- a/src/cli/module/init.ts
+++ b/src/cli/module/init.ts
@@ -90,6 +90,7 @@ export async function moduleInitCommand(modulePath: string, options: InitOptions
     // Load and select interfaces
     console.log('');
     const interfacesInfo = await loadInterfacesFromGit(git, gitManifest.starredInterfaces);
+    const templateInterfaces = template.interfaces || [];
 
     const [selectableInterfaces, nonSelectableInterfaces] = Object.values(interfacesInfo).reduce(
       ([match, noMatch], interfaceInfo) => {
@@ -97,7 +98,7 @@ export async function moduleInitCommand(modulePath: string, options: InitOptions
           name: `${chalk.cyan(interfaceInfo.name)} - ${chalk.dim(interfaceInfo.manifest.description)}`,
           value: interfaceInfo.name,
         };
-        if (!template.interfaces.includes(interfaceInfo.name)) {
+        if (!templateInterfaces.includes(interfaceInfo.name)) {
           match.push(formattedItem);
         } else {
           noMatch.push(formattedItem);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Added support for distinguishing between selectable and non-selectable interfaces during module initialization.
- Updated the interface structure to include an array of interfaces in the template.
- Improved user feedback by logging already imported interfaces from the template.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
