### PR TITLE
feat: indentation type of config file is kept (tab/space)

### DIFF
--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -18,7 +18,6 @@ const DEFAULT_INDENTATION = '  ';
 export async function detectIndentation(filePath: string): Promise<string> {
   try {
     const content = (await readFile(filePath)).toString();
-    JSON.parse(content);
     const match = content.match(/\n([\t ]+)/);
 
     if (match && match[1]) {

--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -8,6 +8,29 @@ import { ModulePackageJson } from '../common/manifest';
 import { warning } from '../utils/cli-ui';
 import chalk from 'chalk';
 
+const DEFAULT_INDENTATION = '  ';
+
+/**
+ * Detects the indentation character from a file
+ * @param filePath Path to the file
+ * @returns The detected indentation character or default (2 spaces)
+ */
+export async function detectIndentation(filePath: string): Promise<string> {
+  try {
+    const content = (await readFile(filePath)).toString();
+    JSON.parse(content);
+    const match = content.match(/\n([\t ]+)/);
+
+    if (match && match[1]) {
+      const firstChar = match[1][0];
+      return firstChar === '\t' ? '\t' : '  ';
+    }
+  } catch {
+    //
+  }
+  return DEFAULT_INDENTATION;
+}
+
 // Definition of the default git repository
 export const DEFAULT_GIT_REPO = 'https://github.com/AntelopeJS/interfaces.git';
 
@@ -38,7 +61,8 @@ export namespace Options {
 
 export async function writeConfig(project: string, data: Partial<AntelopeConfig>): Promise<void> {
   const configPath = path.join(project, 'antelope.json');
-  await writeFile(configPath, JSON.stringify(data, null, '    '));
+  const indentation = await detectIndentation(configPath);
+  await writeFile(configPath, JSON.stringify(data, null, indentation));
 }
 
 export async function readConfig(project: string): Promise<AntelopeConfig | undefined> {
@@ -51,7 +75,8 @@ export async function readConfig(project: string): Promise<AntelopeConfig | unde
 
 export async function writeModuleManifest(module: string, data: ModulePackageJson): Promise<void> {
   const configPath = path.join(module, 'package.json');
-  await writeFile(configPath, JSON.stringify(data, null, '    '));
+  const indentation = await detectIndentation(configPath);
+  await writeFile(configPath, JSON.stringify(data, null, indentation));
 }
 
 export async function readModuleManifest(module: string): Promise<ModulePackageJson | undefined> {
@@ -80,7 +105,8 @@ export async function writeUserConfig(data: UserConfig): Promise<void> {
   if (!(await stat(folderPath).catch(() => false))) {
     mkdirSync(folderPath, { recursive: true });
   }
-  await writeFile(configPath, JSON.stringify(data, null, '    '));
+  const indentation = await detectIndentation(configPath);
+  await writeFile(configPath, JSON.stringify(data, null, indentation));
 }
 
 export async function readUserConfig(): Promise<UserConfig> {

--- a/src/common/cache.ts
+++ b/src/common/cache.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { satisfies } from 'semver';
+import { detectIndentation } from '../cli/common';
 
 /**
  * Module Cache management
@@ -38,9 +39,11 @@ export class ModuleCache {
       return;
     }
     this.saving = true;
-    setTimeout(() => {
+    setTimeout(async () => {
       this.saving = false;
-      fs.writeFile(join(this.path, 'manifest.json'), JSON.stringify(this.manifest));
+      const manifestPath = join(this.path, 'manifest.json');
+      const indentation = await detectIndentation(manifestPath);
+      fs.writeFile(manifestPath, JSON.stringify(this.manifest, null, indentation));
     }, 1);
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Now indentation is checked and kept, then configs re-generation is using the previous way to indent (tabs/2 space).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
