### PR TITLE
Refactor config rewrite

### DIFF
--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -60,7 +60,7 @@ export namespace Options {
 
 async function writeJsonFile(filePath: string, data: unknown): Promise<void> {
   const indentation = await detectIndentation(filePath);
-  await writeFile(filePath, JSON.stringify(data, null, indentation));
+  await writeFile(filePath, JSON.stringify(data, null, indentation) + '\n');
 }
 
 async function readJsonFile<T>(filePath: string): Promise<T | undefined> {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

New:
A newline is added before the end of file when rewriting a json config file (`antelope.json`/`package.json`).

Changes:
Factorized some duplicated code blocs used to read/write json configs

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
