### PR TITLE
feat: let source config specify a different entry point

### DIFF
--- a/src/common/downloader/local.ts
+++ b/src/common/downloader/local.ts
@@ -10,6 +10,7 @@ import { Logging } from '../../interfaces/logging/beta';
 export interface ModuleSourceLocal extends ModuleSource {
   type: 'local';
   path: string;
+  main?: string;
   watchDir?: string | string[];
   installCommand?: string | string[];
 }

--- a/src/common/manifest.ts
+++ b/src/common/manifest.ts
@@ -38,6 +38,7 @@ export class ModuleManifest {
   public readonly name: string;
   public version: string;
   public readonly folder: string;
+  public readonly main: string;
 
   public readonly baseUrl: string;
   public readonly paths: {
@@ -75,6 +76,7 @@ export class ModuleManifest {
     this.version = this.manifest.version;
     this.exportsPath = path.join(this.folder, this.manifest.antelopeJs?.exportsPath || 'interfaces');
     this.imports = this.manifest.antelopeJs?.imports?.map(mapModuleImport) ?? [];
+    this.main = typeof (<any>source).main === 'string' ? path.join(this.folder, (<any>source).main!) : this.folder;
 
     this.baseUrl = path.join(this.folder, this.manifest.antelopeJs?.baseUrl ?? '');
     if (this.manifest.antelopeJs?.paths) {

--- a/src/loader/module.ts
+++ b/src/loader/module.ts
@@ -66,7 +66,7 @@ export class Module {
       Logging.inline.Debug(`Module ${this.id} already constructed`);
       return;
     }
-    await import(this.manifest.folder)
+    await import(this.manifest.main)
       .then((mod) => {
         this.object = mod;
         Logging.inline.Info(`Successfully loaded module ${this.id}`);


### PR DESCRIPTION
<!---
☝️ PR let source config specify a different entry point
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With this feature you can now start a projet antelope with others entrypoint.
For example:

```
(package.json)

"scripts": {
  "dev": "ajs project run -w --inspect",
  "migrate": "ajs project run -w --inspect --env MIGRATION"
}
```

```
(antelope.json)

"modules": {"YOUR-LOCAL-PORJECT": {}},
"environments": {
  "MIGRATION": {
    "modules": {
      "YOUR-LOCAL-PORJECT": {
        "source": {
           "main": "dist/migrate.js"
         }
     },
     ...
  }
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
