### PR TITLE
fix(cli): handle ExitPromptError gracefully in CLI error handling

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -62,10 +62,11 @@ process.on('SIGINT', () => {
 
 // Run the CLI
 runCLI().catch((err) => {
-  // Only show error messages for errors other than ExitPromptError
-  if (err && typeof err === 'object' && 'name' in err && err.name !== 'ExitPromptError') {
-    console.error(chalk.red('Error:'), err.message || err);
-    process.exit(1);
+  // Don't show error messages for ExitPromptError
+  if (err && typeof err === 'object' && 'name' in err && err.name === 'ExitPromptError') {
+    process.exit(0);
   }
-  process.exit(0);
+
+  console.error(chalk.red('Error:'), err.message || err);
+  process.exit(1);
 });


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Invert error prompt to always show the cli error and skip the exit error

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
