### PR TITLE
Fix module loader return type

### DIFF
--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -323,11 +323,12 @@ export class ModuleManager {
             }
             return modules;
           })
-          .catch((err) => {
-            Logging.Error(`Failed to load module ${source.id}:`);
-            Logging.Error(err);
-            process.exit(1);
-          });
+            .catch((err) => {
+              Logging.Error(`Failed to load module ${source.id}:`);
+              Logging.Error(err);
+              process.exit(1);
+              return [] as Module[]; // ensure consistent return type
+            });
 
         return createdModules.map((ref) => ({ ref, config: manifest.configs[ref.id] || {} }));
       } catch (err) {

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -323,12 +323,12 @@ export class ModuleManager {
             }
             return modules;
           })
-            .catch((err) => {
-              Logging.Error(`Failed to load module ${source.id}:`);
-              Logging.Error(err);
-              process.exit(1);
-              return [] as Module[]; // ensure consistent return type
-            });
+          .catch((err) => {
+            Logging.Error(`Failed to load module ${source.id}:`);
+            Logging.Error(err);
+            process.exit(1);
+            return [] as Module[]; // ensure consistent return type
+          });
 
         return createdModules.map((ref) => ({ ref, config: manifest.configs[ref.id] || {} }));
       } catch (err) {


### PR DESCRIPTION
## Summary
- add missing return type for module loading error path

## Testing
- `npm run build` *(fails: Cannot find module 'commander' or its corresponding type declarations)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f5012bd8c83248d4ca934ca12b16b