### PR TITLE
Refactor helpers

### DIFF
--- a/src/cli/module/imports/add.ts
+++ b/src/cli/module/imports/add.ts
@@ -11,6 +11,7 @@ import { loadInterfaceFromGit, installInterfaces } from '../../git';
 import { mapModuleImport, ModuleImport } from '../../../common/manifest';
 import semver from 'semver';
 import { error, warning, info, success, ProgressBar } from '../../../utils/cli-ui';
+import { ensureModuleImports } from '../../../utils/module';
 
 interface AddOptions {
   git?: string;
@@ -137,25 +138,11 @@ export async function moduleImportAddCommand(interfaces: string[], options: AddO
     return;
   }
 
-  // Initialize antelopeJs section if it doesn't exist
-  if (!moduleManifest.antelopeJs) {
-    moduleManifest.antelopeJs = {
-      imports: [],
-      importsOptional: [],
-    };
-  }
-
-  // Initialize imports arrays if they don't exist
-  if (!moduleManifest.antelopeJs.imports) {
-    moduleManifest.antelopeJs.imports = [];
-  }
-  if (!moduleManifest.antelopeJs.importsOptional) {
-    moduleManifest.antelopeJs.importsOptional = [];
-  }
+  const antelope = ensureModuleImports(moduleManifest);
 
   // Apply pending imports to the updated manifest
   for (const { importObj, isOptional } of pendingImports) {
-    const importArray = isOptional ? moduleManifest.antelopeJs.importsOptional : moduleManifest.antelopeJs.imports;
+    const importArray = isOptional ? antelope.importsOptional : antelope.imports;
 
     // Add import without checking again
     importArray.push(importObj);

--- a/src/cli/project/logging/set.ts
+++ b/src/cli/project/logging/set.ts
@@ -4,6 +4,7 @@ import { Options, readConfig, writeConfig } from '../../common';
 import { defaultConfigLogging } from '../../../logging';
 import inquirer from 'inquirer';
 import { displayBox, error, info, success, warning } from '../../../utils/cli-ui';
+import { selectEnvironment } from '../../../utils/module';
 
 interface SetOptions {
   project: string;
@@ -70,8 +71,7 @@ export default function () {
       }
 
       const projectName = config.name;
-      const env =
-        options.env && options.env !== 'default' ? config?.environments && config?.environments[options.env] : config;
+      const env = selectEnvironment(config, options.env);
 
       if (!env) {
         error(`Environment ${options.env || 'default'} not found in project config`);

--- a/src/cli/project/modules/add.ts
+++ b/src/cli/project/modules/add.ts
@@ -11,6 +11,7 @@ import { ModulePackageJson } from '../../../common/manifest';
 import { parsePackageInfoOutput } from '../../../utils/package-manager';
 import { ModuleCache } from '../../../common/cache';
 import LoadModule, { GetLoaderIdentifier } from '../../../common/downloader';
+import { selectEnvironment } from '../../../utils/module';
 
 interface AddOptions {
   mode: string;
@@ -54,8 +55,7 @@ export async function projectModulesAddCommand(modules: string[], options: AddOp
   sources = sources.filter((source): source is [string, AntelopeModuleSourceConfig] => source !== null);
 
   // Get correct environment config
-  const env =
-    options.env && options.env !== 'default' ? config?.environments && config?.environments[options.env] : config;
+  const env = selectEnvironment(config, options.env);
   if (!env) {
     error(`Environment ${options.env || 'default'} not found in project config`);
     return;

--- a/src/cli/project/modules/fix.ts
+++ b/src/cli/project/modules/fix.ts
@@ -10,6 +10,7 @@ import inquirer from 'inquirer';
 import { loadInterfaceFromGit } from '../../git';
 import { projectModulesAddCommand } from './add';
 import { error, warning, info, success } from '../../../utils/cli-ui';
+import { parseInterfaceRef } from '../../../utils/module';
 
 interface FixOptions {
   project: string;
@@ -117,14 +118,14 @@ export default function () {
           warning(chalk.yellow`Found ${unresolvedImports.length} unresolved imports:`);
 
           for (const imp of unresolvedImports) {
-            const m = imp.match(/^([^@]+)(?:@(.+))?$/);
-            if (!m || !m[1] || !m[2]) {
+            const ref = parseInterfaceRef(imp);
+            if (!ref?.name || !ref.version) {
               warning(`    ${chalk.yellow('↳')} Malformed interface name, skipping`);
               continue;
             }
 
             // Look for modules implementing this interface
-            const interfaceInfo = await loadInterfaceFromGit(git, m[1]);
+            const interfaceInfo = await loadInterfaceFromGit(git, ref.name);
 
             // Prepare choice for user to select a module
             const choices = [...(interfaceInfo?.manifest.modules.map((module) => module.name) || [])];

--- a/src/cli/project/modules/remove.ts
+++ b/src/cli/project/modules/remove.ts
@@ -3,6 +3,7 @@ import { Command, Option } from 'commander';
 import { Options, readConfig, writeConfig } from '../../common';
 import { LoadConfig } from '../../../common/config';
 import { error, warning, info, success } from '../../../utils/cli-ui';
+import { selectEnvironment } from '../../../utils/module';
 
 interface RemoveOptions {
   project: string;
@@ -20,8 +21,7 @@ export async function projectModulesRemoveCommand(modules: string[], options: Re
     return;
   }
 
-  const env =
-    options.env && options.env !== 'default' ? config?.environments && config?.environments[options.env] : config;
+  const env = selectEnvironment(config, options.env);
   if (!env) {
     error(chalk.red`Environment ${options.env || 'default'} not found in project config`);
     return;

--- a/src/cli/project/modules/update.ts
+++ b/src/cli/project/modules/update.ts
@@ -6,6 +6,7 @@ import { ExecuteCMD } from '../../../utils/command';
 import { ModuleSourcePackage } from '../../../common/downloader/package';
 import { parsePackageInfoOutput } from '../../../utils/package-manager';
 import { error as errorUI, warning, info, success } from '../../../utils/cli-ui';
+import { selectEnvironment } from '../../../utils/module';
 
 interface UpdateOptions {
   project: string;
@@ -30,7 +31,7 @@ export default function () {
         return;
       }
 
-      const env = options.env ? config?.environments && config?.environments[options.env] : config;
+      const env = selectEnvironment(config, options.env);
       if (!env) {
         errorUI(chalk.red`Environment ${options.env || 'default'} not found in project config`);
         return;

--- a/src/utils/module.ts
+++ b/src/utils/module.ts
@@ -1,0 +1,29 @@
+import { AntelopeConfig } from '../common/config';
+import { ModulePackageJson, ModuleImport } from '../common/manifest';
+
+export interface AntelopeJsImports {
+  imports: ModuleImport[];
+  importsOptional: ModuleImport[];
+}
+export function ensureModuleImports(manifest: ModulePackageJson): AntelopeJsImports {
+  if (!manifest.antelopeJs) {
+    manifest.antelopeJs = { imports: [], importsOptional: [] };
+  } else {
+    manifest.antelopeJs.imports = manifest.antelopeJs.imports || [];
+    manifest.antelopeJs.importsOptional = manifest.antelopeJs.importsOptional || [];
+  }
+  return manifest.antelopeJs as AntelopeJsImports;
+}
+
+export function selectEnvironment(
+  config: AntelopeConfig,
+  env?: string,
+): AntelopeConfig | import('../common/config').AntelopeProjectEnvConfig | undefined {
+  return env && env !== 'default' ? config.environments?.[env] : config;
+}
+
+export function parseInterfaceRef(value: string): { name?: string; version?: string } | undefined {
+  const match = value.match(/^([^@]+)(?:@(.+))?$/);
+  if (!match) return undefined;
+  return { name: match[1], version: match[2] };
+}


### PR DESCRIPTION
## Summary
- add `utils/module` with helper functions
- simplify imports commands using new helpers
- streamline project commands with `selectEnvironment`

## Testing
- `pnpm run lint`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f5f3aa56c8324b46de5f31f8138ac