### PR TITLE
fix: now absolute, relative and paths containing // should work with …

### DIFF
--- a/src/cli/git.ts
+++ b/src/cli/git.ts
@@ -173,6 +173,8 @@ export async function installInterfaces(
   module: string,
   interfacesToInstall: { interfaceInfo: InterfaceInfo; version: string }[],
 ) {
+  const resolvedModulePath = path.resolve(module);
+
   // First collect all the dependencies to avoid redundant git operations
   const allDependencies: { interfaceInfo: InterfaceInfo; version: string }[] = [];
 
@@ -289,7 +291,7 @@ export async function installInterfaces(
     let folderPath = '';
 
     if (files.type === 'local') {
-      folderPath = interfaceInfo.folderPath;
+      folderPath = path.resolve(interfaceInfo.folderPath);
     } else if (files.type === 'git' && files.remote) {
       const releaseLock = await acquireLock(`git-${files.remote}`);
       try {
@@ -302,7 +304,7 @@ export async function installInterfaces(
       throw new Error('Invalid interface files type');
     }
 
-    const antelopePath = path.join(module, '.antelope');
+    const antelopePath = path.join(resolvedModulePath, '.antelope');
     const interfacesPath = path.join(antelopePath, 'interfaces.d');
 
     // Determine source and destination paths

--- a/src/cli/module/exports/set.ts
+++ b/src/cli/module/exports/set.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import { Options, readModuleManifest, writeModuleManifest } from '../../common';
 import { displayBox, error, success, keyValue } from '../../../utils/cli-ui';
+import path from 'path';
 
 interface SetOptions {
   module: string;
@@ -17,9 +18,12 @@ export default function () {
     .action(async (exportPath: string, options: SetOptions) => {
       console.log(''); // Add spacing for better readability
 
-      const manifest = await readModuleManifest(options.module);
+      const resolvedModulePath = path.resolve(options.module);
+      const resolvedExportPath = path.resolve(exportPath);
+
+      const manifest = await readModuleManifest(resolvedModulePath);
       if (!manifest) {
-        error(`No package.json found in ${chalk.bold(options.module)}`);
+        error(`No package.json found in ${chalk.bold(resolvedModulePath)}`);
         return;
       }
 
@@ -31,17 +35,17 @@ export default function () {
       }
 
       const oldPath = manifest.antelopeJs.exportsPath || '(not set)';
-      manifest.antelopeJs.exportsPath = exportPath;
-      await writeModuleManifest(options.module, manifest);
+      manifest.antelopeJs.exportsPath = resolvedExportPath;
+      await writeModuleManifest(resolvedModulePath, manifest);
 
       success(`Exports path updated successfully`);
 
       await displayBox(
-        keyValue('Module', chalk.cyan(options.module)) +
+        keyValue('Module', chalk.cyan(resolvedModulePath)) +
           '\n' +
           keyValue('Previous Path', chalk.dim(oldPath)) +
           '\n' +
-          keyValue('New Path', chalk.green(exportPath)),
+          keyValue('New Path', chalk.green(resolvedExportPath)),
         '🔄 Module Exports Updated',
         {
           padding: 1,

--- a/src/cli/module/test.ts
+++ b/src/cli/module/test.ts
@@ -3,25 +3,28 @@ import { Command } from 'commander';
 import { TestModule } from '../..';
 import { readModuleManifest } from '../common';
 import { error, info, Spinner } from '../../utils/cli-ui';
+import path from 'path';
 
 export async function moduleTestCommand(modulePath = '.') {
   console.log(''); // Add spacing for readability
 
+  const resolvedPath = path.resolve(modulePath);
+
   // Check if directory is a valid module
-  const moduleSpinner = new Spinner(`Checking module at ${chalk.cyan(modulePath)}`);
+  const moduleSpinner = new Spinner(`Checking module at ${chalk.cyan(resolvedPath)}`);
   await moduleSpinner.start();
 
-  const moduleManifest = await readModuleManifest(modulePath);
+  const moduleManifest = await readModuleManifest(resolvedPath);
   if (!moduleManifest) {
     await moduleSpinner.fail(`Invalid module directory`);
-    error(`Directory ${chalk.bold(modulePath)} does not contain a valid AntelopeJS module.`);
+    error(`Directory ${chalk.bold(resolvedPath)} does not contain a valid AntelopeJS module.`);
     info(`Make sure you're in a valid AntelopeJS module directory with package.json.`);
     return;
   }
 
   await moduleSpinner.succeed(`Valid module found: ${chalk.cyan(moduleManifest.name)}`);
 
-  TestModule(modulePath);
+  TestModule(resolvedPath);
 }
 
 export default function () {


### PR DESCRIPTION
…every command

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed some CLI commands when following paths were provided as args:
- Absolute paths, eg `/home/glastis/mymodule`
- Relative paths, eg `~/mymodule`
- Unoptimized paths, eg `/home/////glastis///mymodule`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
