### PR TITLE
Fix/install command interface name

### DIFF
--- a/src/cli/module/imports/install.ts
+++ b/src/cli/module/imports/install.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
 import { Options, readModuleManifest, readUserConfig } from '../../common';
-import { installInterfaces, loadInterfacesFromGit } from '../../git';
+import { installInterfaces, InterfaceInfo, loadInterfacesFromGit } from '../../git';
 import { mapModuleImport } from '../../../common/manifest';
 import { error, warning, info, success, ProgressBar } from '../../../utils/cli-ui';
 import { existsSync } from 'fs';
@@ -72,7 +72,7 @@ export default function () {
 
       // Install missing interfaces
       const userConfig = await readUserConfig();
-      const interfacesToInstall: { interfaceInfo: any; version: string }[] = [];
+      const interfacesToInstall: { interfaceInfo: InterfaceInfo; version: string }[] = [];
       const failed: { name: string; reason: string }[] = [];
       const installed: string[] = [];
 
@@ -136,7 +136,7 @@ export default function () {
 
           // Add successfully installed interfaces to the installed list
           interfacesToInstall.forEach(({ interfaceInfo, version }) => {
-            installed.push(`${interfaceInfo.manifest.name}@${version}`);
+            installed.push(`${interfaceInfo.name}@${version}`);
           });
 
           // Clear the array for the next git repository

--- a/src/cli/module/test.ts
+++ b/src/cli/module/test.ts
@@ -31,8 +31,10 @@ export async function moduleTestCommand(modulePath = '.', options: TestOptions) 
   TestModule(resolvedPath, options.file);
 }
 
-const filesOption = new Option('-f, --file <path>', 'Specific test file to run')
-    .argParser((val, prev: string[]) => [...(prev ?? []), path.resolve(val)]);
+const filesOption = new Option('-f, --file <path>', 'Specific test file to run').argParser((val, prev: string[]) => [
+  ...(prev ?? []),
+  path.resolve(val),
+]);
 
 export default function () {
   return new Command('test')


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

**Fix missing interface names in CLI output of ajs module imports install**

Previously, when running the CLI command `ajs module imports install`, the list of successfully installed interfaces was displayed without their names.

This issue was resolved by using more precise typing in the code, which allowed accessing the interface names correctly.

Additionally, a linter issue introduced in a previous commit has also been fixed in this PR.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
