### PR TITLE
fix(watch): prevent HMR reload loop from atomic-write temp files

### DIFF
--- a/src/core/watch/file-watcher.ts
+++ b/src/core/watch/file-watcher.ts
@@ -14,7 +14,6 @@ export class FileWatcher {
   private excludedDirs = new Set(EXCLUDED_WATCH_DIRS);
   private watchers = new Map<string, FSWatcher>();
   private watchedDirs = new Set<string>();
-  private watchedDirModules = new Map<string, Set<string>>();
   private watchedFiles = new Map<
     string,
     { hash: string; listeners: FileChangeListener[] }
@@ -103,12 +102,13 @@ export class FileWatcher {
     }
 
     const entry = this.filesHash.get(filePath);
+    if (!entry) {
+      return;
+    }
 
     if (!(await this.fs.exists(filePath))) {
-      if (entry) {
-        this.filesHash.delete(filePath);
-        this.notifyModuleChange(entry.moduleId);
-      }
+      this.filesHash.delete(filePath);
+      this.notifyModuleChange(entry.moduleId);
       return;
     }
 
@@ -118,16 +118,6 @@ export class FileWatcher {
     }
 
     const newHash = await this.hasher.hashFile(filePath);
-    if (!entry) {
-      const moduleId = this.getModuleIdForPath(filePath);
-      if (!moduleId) {
-        return;
-      }
-      this.filesHash.set(filePath, { moduleId, hash: newHash });
-      this.notifyModuleChange(moduleId);
-      return;
-    }
-
     if (newHash !== entry.hash) {
       this.filesHash.set(filePath, { moduleId: entry.moduleId, hash: newHash });
       this.notifyModuleChange(entry.moduleId);
@@ -155,7 +145,7 @@ export class FileWatcher {
   }
 
   private async exploreDir(moduleId: string, dirPath: string): Promise<void> {
-    this.trackWatchedDir(dirPath, moduleId);
+    this.watchedDirs.add(dirPath);
     const entries = await this.fs.readdir(dirPath);
     for (const entry of entries) {
       const fullPath = path.join(dirPath, entry);
@@ -169,31 +159,6 @@ export class FileWatcher {
         const hash = await this.hasher.hashFile(fullPath);
         this.filesHash.set(fullPath, { moduleId, hash });
       }
-    }
-  }
-
-  private trackWatchedDir(dirPath: string, moduleId: string): void {
-    this.watchedDirs.add(dirPath);
-    const existing = this.watchedDirModules.get(dirPath);
-    if (existing) {
-      existing.add(moduleId);
-    } else {
-      this.watchedDirModules.set(dirPath, new Set([moduleId]));
-    }
-  }
-
-  private getModuleIdForPath(filePath: string): string | undefined {
-    let current = path.dirname(path.resolve(filePath));
-    while (true) {
-      const entry = this.watchedDirModules.get(current);
-      if (entry && entry.size > 0) {
-        return entry.values().next().value;
-      }
-      const parent = path.dirname(current);
-      if (parent === current) {
-        return undefined;
-      }
-      current = parent;
     }
   }
 

--- a/test/core/watch/file-watcher.test.ts
+++ b/test/core/watch/file-watcher.test.ts
@@ -102,6 +102,44 @@ describe("FileWatcher", () => {
     expect(listener2).to.have.lengthOf(1);
   });
 
+  it("does not notify when an untracked temp file appears", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile("/mod/index.js", "v1");
+
+    const watcher = new FileWatcher(fs);
+    await watcher.scanModule("mod", "/mod");
+
+    const changes: string[] = [];
+    watcher.onModuleChanged((id) => changes.push(id));
+
+    await fs.writeFile("/mod/_tmp_1234_abcdef", "intermediate");
+    await watcher.handleFileChange("/mod/_tmp_1234_abcdef");
+    await fs.rm("/mod/_tmp_1234_abcdef");
+    await watcher.handleFileChange("/mod/_tmp_1234_abcdef");
+
+    expect(changes).to.deep.equal([]);
+  });
+
+  it("notifies exactly once for an atomic-write rename over a tracked file", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile("/mod/index.js", "v1");
+
+    const watcher = new FileWatcher(fs);
+    await watcher.scanModule("mod", "/mod");
+
+    const changes: string[] = [];
+    watcher.onModuleChanged((id) => changes.push(id));
+
+    await fs.writeFile("/mod/index.js.tmp.5678", "v2");
+    await watcher.handleFileChange("/mod/index.js.tmp.5678");
+    await fs.writeFile("/mod/index.js", "v2");
+    await fs.rm("/mod/index.js.tmp.5678");
+    await watcher.handleFileChange("/mod/index.js");
+    await watcher.handleFileChange("/mod/index.js.tmp.5678");
+
+    expect(changes).to.deep.equal(["mod"]);
+  });
+
   it("skips excluded directories when scanning", async () => {
     const fs = new InMemoryFileSystem();
     await fs.writeFile("/mod/.git/ignored.txt", "x");

--- a/test/integration/hmr.test.ts
+++ b/test/integration/hmr.test.ts
@@ -6,6 +6,7 @@ import launch, { type ModuleManager } from "../../src";
 
 const MARKER_TIMEOUT_MS = 8000;
 const MARKER_POLL_MS = 50;
+const NO_RELOAD_WINDOW_MS = 3000;
 
 async function waitFor(
   predicate: () => Promise<boolean>,
@@ -26,6 +27,23 @@ async function readMarker(markerPath: string): Promise<string | undefined> {
     return await fs.readFile(markerPath, "utf-8");
   } catch {
     return undefined;
+  }
+}
+
+async function assertStableStartCount(
+  startCountPath: string,
+  expected: number,
+  windowMs: number,
+): Promise<void> {
+  const deadline = Date.now() + windowMs;
+  while (Date.now() < deadline) {
+    const current = parseInt(await fs.readFile(startCountPath, "utf-8"), 10);
+    if (current !== expected) {
+      throw new Error(
+        `Expected startCount to stay at ${expected}, observed ${current}`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, MARKER_POLL_MS));
   }
 }
 
@@ -146,7 +164,7 @@ exports.destroy = () => {};
       await fs.writeFile(tmpPath, "intermediate garbage");
       await fs.rm(tmpPath);
 
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+      await assertStableStartCount(startCountPath, 1, NO_RELOAD_WINDOW_MS);
 
       const startCount = parseInt(
         await fs.readFile(startCountPath, "utf-8"),

--- a/test/integration/hmr.test.ts
+++ b/test/integration/hmr.test.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect } from "chai";
+import launch, { type ModuleManager } from "../../src";
+
+const MARKER_TIMEOUT_MS = 8000;
+const MARKER_POLL_MS = 50;
+
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, MARKER_POLL_MS));
+  }
+  throw new Error(`Timed out waiting for condition after ${timeoutMs}ms`);
+}
+
+async function readMarker(markerPath: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(markerPath, "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+function moduleSource(version: string): string {
+  return `const fs = require("node:fs");
+let cfg;
+exports.construct = (c) => { cfg = c; };
+exports.start = () => { fs.writeFileSync(cfg.markerPath, "${version}"); };
+exports.stop = () => {};
+exports.destroy = () => {};
+`;
+}
+
+describe("HMR end-to-end", () => {
+  it("picks up module source edits and runs new code after reload", async function () {
+    this.timeout(20000);
+
+    const projectFolder = await fs.mkdtemp(path.join(os.tmpdir(), "ajs-hmr-"));
+    const modulePath = path.join(projectFolder, "mod");
+    const markerPath = path.join(projectFolder, "marker.txt");
+    const indexPath = path.join(modulePath, "index.js");
+
+    await fs.mkdir(modulePath, { recursive: true });
+    await fs.writeFile(
+      path.join(modulePath, "package.json"),
+      JSON.stringify({ name: "mod", version: "1.0.0", main: "index.js" }),
+    );
+    await fs.writeFile(indexPath, moduleSource("v1"));
+
+    const config = {
+      name: "hmr-test",
+      modules: {
+        mod: {
+          source: { type: "local", path: "./mod", main: "index.js" },
+          config: { markerPath },
+        },
+      },
+    };
+    await fs.writeFile(
+      path.join(projectFolder, "antelope.config.ts"),
+      `export default ${JSON.stringify(config)};\n`,
+    );
+
+    let manager: ModuleManager | undefined;
+    try {
+      manager = await launch(projectFolder, "default", { watch: true });
+
+      await waitFor(async () => (await readMarker(markerPath)) === "v1", 2000);
+
+      await fs.writeFile(indexPath, moduleSource("v2"));
+
+      await waitFor(
+        async () => (await readMarker(markerPath)) === "v2",
+        MARKER_TIMEOUT_MS,
+      );
+
+      expect(await readMarker(markerPath)).to.equal("v2");
+    } finally {
+      if (manager) {
+        await manager.stopAll();
+        await manager.destroyAll();
+      }
+      await fs.rm(projectFolder, { recursive: true, force: true });
+    }
+  });
+
+  it("does not reload when atomic-write temp files appear", async function () {
+    this.timeout(20000);
+
+    const projectFolder = await fs.mkdtemp(
+      path.join(os.tmpdir(), "ajs-hmr-atomic-"),
+    );
+    const modulePath = path.join(projectFolder, "mod");
+    const markerPath = path.join(projectFolder, "marker.txt");
+    const indexPath = path.join(modulePath, "index.js");
+    const startCountPath = path.join(projectFolder, "start-count.txt");
+
+    await fs.mkdir(modulePath, { recursive: true });
+    await fs.writeFile(
+      path.join(modulePath, "package.json"),
+      JSON.stringify({ name: "mod", version: "1.0.0", main: "index.js" }),
+    );
+    const src = `const fs = require("node:fs");
+let cfg;
+exports.construct = (c) => { cfg = c; };
+exports.start = () => {
+  const prev = fs.existsSync(cfg.startCountPath)
+    ? parseInt(fs.readFileSync(cfg.startCountPath, "utf-8"), 10) || 0
+    : 0;
+  fs.writeFileSync(cfg.startCountPath, String(prev + 1));
+  fs.writeFileSync(cfg.markerPath, "v1");
+};
+exports.stop = () => {};
+exports.destroy = () => {};
+`;
+    await fs.writeFile(indexPath, src);
+
+    const config = {
+      name: "hmr-atomic-test",
+      modules: {
+        mod: {
+          source: { type: "local", path: "./mod", main: "index.js" },
+          config: { markerPath, startCountPath },
+        },
+      },
+    };
+    await fs.writeFile(
+      path.join(projectFolder, "antelope.config.ts"),
+      `export default ${JSON.stringify(config)};\n`,
+    );
+
+    let manager: ModuleManager | undefined;
+    try {
+      manager = await launch(projectFolder, "default", { watch: true });
+      await waitFor(async () => (await readMarker(markerPath)) === "v1", 2000);
+
+      const tmpPath = path.join(modulePath, "index.js.tmp.9999");
+      await fs.writeFile(tmpPath, "intermediate garbage");
+      await fs.rm(tmpPath);
+
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      const startCount = parseInt(
+        await fs.readFile(startCountPath, "utf-8"),
+        10,
+      );
+      expect(startCount).to.equal(1);
+    } finally {
+      if (manager) {
+        await manager.stopAll();
+        await manager.destroyAll();
+      }
+      await fs.rm(projectFolder, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

HMR entered an infinite reload loop whenever a module was edited while
its source declared an `installCommand` (e.g. `npx tsc`):

- Editors (VSCode, etc.) write `<name>.tmp.<uuid>` then rename over the
  target — standard atomic write.
- `tsc` does the same with `_tmp_<pid>_<hash>` when emitting its output.

`FileWatcher.handleFileChange` treated any file not already in
`filesHash` as a module-level change and called `notifyModuleChange`,
so every transient temp file triggered a reload. Each reload ran the
install command (which re-ran tsc, producing new temp files, triggering
more reloads).

The fix: only notify for files that were indexed at `scanModule` time.
Real edits still propagate because the tracked target file's hash
changes when the rename lands; transient temp files are ignored. The
`watchedDirModules` map and `getModuleIdForPath` helper, only used by
the removed branch, are dropped.

Verified end-to-end on the playground (edit `start`, observe new
`console.log` executes, loop converges in 2 reloads instead of 40+).

### Tests

- `test/core/watch/file-watcher.test.ts`: unit tests for untracked temp
  files (no notify) and atomic-write rename over a tracked file
  (exactly one notify).
- `test/integration/hmr.test.ts`: new end-to-end suite that `launch`es a
  real project in watch mode, edits the module source, and asserts the
  new code runs by observing a marker file. Second case asserts a temp
  file create-then-delete does not cause any reload.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [ ] I have run \`ajs module exports generate\` and committed any updated interface files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an infinite HMR reload loop by making `FileWatcher.handleFileChange` ignore any path not already indexed in `filesHash` at `scanModule` time. The `watchedDirModules` map and `getModuleIdForPath` directory-walk helper are removed; the deletion and hash-change branches for tracked files are unchanged. Unit and integration tests cover both the positive (atomic-write triggers exactly one reload) and negative (temp file create-delete triggers no reload) cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is correct, well-tested, and all remaining observations are P2 style suggestions.

No P0 or P1 issues found. The early-return guard correctly preserves all existing tracked-file semantics (deletion and hash-change notifications) while eliminating the untracked-path code path that caused the loop. Unit and integration tests validate both the positive and negative cases. The known trade-off (new files added to a module dir mid-run won't trigger a reload) was discussed in a prior review thread and is an intentional choice.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/watch/file-watcher.ts | Removes watchedDirModules/getModuleIdForPath and adds an early-return guard for untracked paths; logic for tracked deletions and hash-change notifications is preserved correctly. |
| test/core/watch/file-watcher.test.ts | Adds two focused unit tests for the new behaviour: untracked temp files produce no notification, and atomic-rename over a tracked file produces exactly one notification. |
| test/integration/hmr.test.ts | New end-to-end HMR suite; uses polling for the positive case but assertStableStartCount lacks error-handling for a missing startCountPath file, though timing makes this safe in practice. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handleFileChange called] --> B{isExcludedPath?}
    B -- yes --> Z[return]
    B -- no --> C{watchedFiles has path?}
    C -- yes --> D[handleWatchedFileChange\nhash check → listener]
    D --> Z
    C -- no --> E{filesHash has entry?}
    E -- no --> Z
    E -- yes --> F{file exists?}
    F -- no --> G[delete from filesHash\nnotifyModuleChange]
    G --> Z
    F -- yes --> H{isDirectory?}
    H -- yes --> Z
    H -- no --> I[hashFile]
    I --> J{hash changed?}
    J -- no --> Z
    J -- yes --> K[update filesHash\nnotifyModuleChange]
    K --> Z
```

<sub>Reviews (2): Last reviewed commit: ["test(hmr): replace fixed sleep with stab..."](https://github.com/antelopejs/antelopejs/commit/7d70e675e36b50c827a2b48cd8e05ab3522726fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28992651)</sub>

<!-- /greptile_comment -->