### PR TITLE
fix(test): set testStubMode after modules are loaded and started

### DIFF
--- a/src/core/test/test-module.ts
+++ b/src/core/test/test-module.ts
@@ -115,9 +115,9 @@ export async function setupTestEnvironment(
   return withRaisedMaxListeners(async () => {
     const manager = new ModuleManager();
     manager.resolver.stubModulePath = STUB_INTERFACE_PATH;
-    internal.testStubMode = true;
     await loadModuleEntriesForManager(manager, normalizedConfig, true);
     await constructAndStartModules(manager);
+    internal.testStubMode = true;
     return manager;
   });
 }


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Move `internal.testStubMode = true` in `setupTestEnvironment` so it is set **after** `loadModuleEntriesForManager` and `constructAndStartModules` complete, instead of before.

Previously, the stub mode flag was enabled before module loading and startup, which caused those phases to run under stub semantics. With this change, modules load and start in normal mode, and the stub flag is only flipped on for the actual test execution phase. The cleanup path in the `finally` block already resets `testStubMode = false`, so the lifecycle remains symmetric.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [ ] I have run `ajs module exports generate` and committed any updated interface files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the ordering of `internal.testStubMode = true` in `setupTestEnvironment`, moving it to after `loadModuleEntriesForManager` and `constructAndStartModules` complete. The previous placement caused module loading and startup to run under stub semantics, which is now corrected so those phases execute in normal mode.

- **Ordering fix**: `internal.testStubMode = true` is now assigned only after both async module-loading calls resolve successfully, ensuring modules construct and start in normal mode before stub semantics are activated for the test execution phase.
- **Cleanup symmetry preserved**: The `finally` block in `TestModule` continues to reset `testStubMode = false` unconditionally; if either loading call throws before the flag is set, the reset in `finally` is a harmless no-op and state remains clean.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the one-line reorder is intentional and well-scoped, and the existing test suite validates that the flag is correctly set after the function returns.

The change is a single-line reorder with no new code paths, no altered error handling, and no touched interfaces. The finally block in TestModule already resets the flag unconditionally, so failure paths remain clean. The unit test at line 440 directly asserts the post-call state and continues to pass under the new ordering.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/test/test-module.ts | Single-line reorder of `internal.testStubMode = true` to after module loading and startup; logic is correct and the existing test at line 440 continues to verify the flag is set after `setupTestEnvironment` returns. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TM as TestModule
    participant STE as setupTestEnvironment
    participant ML as loadModuleEntriesForManager
    participant CS as constructAndStartModules
    participant I as internal

    TM->>STE: setupTestEnvironment(root, config)
    STE->>ML: await loadModuleEntriesForManager(...)
    note over ML: runs in normal mode (testStubMode=false)
    ML-->>STE: entries loaded
    STE->>CS: await constructAndStartModules(manager)
    note over CS: constructs & starts in normal mode
    CS-->>STE: modules started
    STE->>I: "testStubMode = true"
    STE-->>TM: manager
    TM->>TM: executeTests(...)
    note over TM: tests run with testStubMode=true
    TM->>TM: "[finally] internal.testStubMode = false"
```

<sub>Reviews (1): Last reviewed commit: ["fix(test): set testStubMode after module..."](https://github.com/antelopejs/antelopejs/commit/3a950c977c68ce6d28e8bb6f504147e9913685a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31330474)</sub>

<!-- /greptile_comment -->