### PR TITLE
feat(resolver): allow optional interface deps to stub at runtime

### DIFF
--- a/src/core/cli/commands/project/modules/install.ts
+++ b/src/core/cli/commands/project/modules/install.ts
@@ -89,9 +89,10 @@ async function analyzeConfig(
     id: m.name,
     folder: m.folder,
     dependencies: m.manifest.dependencies ?? {},
+    optionalDependencies: m.manifest.optionalDependencies ?? {},
   }));
 
-  const unresolved = findUnresolvedInterfaces(providers, consumers);
+  const { unresolved } = findUnresolvedInterfaces(providers, consumers);
   return {
     unresolvedImports: unresolved.map((u) => u.interfacePackage),
   };

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -14,7 +14,7 @@ import { Resolver } from "./resolution/resolver";
 import { ResolverDetour } from "./resolution/resolver-detour";
 import {
   logStubInterfaceWarningOnce,
-  neutralizeInterfaceAsyncProxies,
+  neutralizeInterfacePackage,
 } from "./resolution/stub-interface-runtime";
 
 const Logger = new Logging.Channel("loader");
@@ -223,14 +223,19 @@ export class ModuleManager {
   private applyInterfaceStubs(): void {
     for (const interfaceName of this.stubbedInterfaceNames) {
       try {
-        const exports = require(interfaceName);
-        neutralizeInterfaceAsyncProxies(exports, interfaceName);
+        require(interfaceName);
       } catch (err) {
         Logger.Error(
-          `Failed to stub optional interface '${interfaceName}':`,
+          `Failed to load optional interface '${interfaceName}':`,
           err,
         );
+        continue;
       }
+      const pkgRoot = this.resolver.interfacePackages.get(interfaceName);
+      if (!pkgRoot) {
+        continue;
+      }
+      neutralizeInterfacePackage(pkgRoot, interfaceName);
     }
   }
 

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -13,6 +13,7 @@ import { PathMapper } from "./resolution/path-mapper";
 import { Resolver } from "./resolution/resolver";
 import { ResolverDetour } from "./resolution/resolver-detour";
 import {
+  clearStubInterfaceWarnings,
   logStubInterfaceWarningOnce,
   neutralizeInterfacePackage,
 } from "./resolution/stub-interface-runtime";
@@ -46,7 +47,7 @@ export class ModuleManager {
   private readonly resolvedAssociations = new Map<string, Set<string>>();
   private readonly staticModules: ManagedModule[] = [];
   private readonly loaded = new Map<string, ManagedModule>();
-  private readonly stubbedInterfaceNames = new Set<string>();
+  private readonly stubbedInterfacePaths = new Map<string, string>();
   private startupOrder: string[] = [];
 
   constructor(deps: ModuleManagerDeps = {}) {
@@ -179,8 +180,7 @@ export class ModuleManager {
 
   registerStubbedInterfaces(stubbed: UnresolvedInterface[]): void {
     for (const { moduleId, interfacePackage } of stubbed) {
-      if (this.resolver.interfacePackages.has(interfacePackage)) {
-        this.stubbedInterfaceNames.add(interfacePackage);
+      if (this.stubbedInterfacePaths.has(interfacePackage)) {
         continue;
       }
       const consumerFolder = this.loaded.get(moduleId)?.module.manifest.folder;
@@ -194,8 +194,8 @@ export class ModuleManager {
       if (!pkgRoot) {
         continue;
       }
+      this.stubbedInterfacePaths.set(interfacePackage, pkgRoot);
       this.resolver.interfacePackages.set(interfacePackage, pkgRoot);
-      this.stubbedInterfaceNames.add(interfacePackage);
       logStubInterfaceWarningOnce(interfacePackage);
     }
   }
@@ -221,7 +221,15 @@ export class ModuleManager {
   }
 
   private applyInterfaceStubs(): void {
-    for (const interfaceName of this.stubbedInterfaceNames) {
+    const implemented = this.collectImplementedInterfaces();
+    for (const [interfaceName, pkgRoot] of [...this.stubbedInterfacePaths]) {
+      if (implemented.has(interfaceName)) {
+        this.stubbedInterfacePaths.delete(interfaceName);
+        continue;
+      }
+      if (!this.resolver.interfacePackages.has(interfaceName)) {
+        this.resolver.interfacePackages.set(interfaceName, pkgRoot);
+      }
       try {
         require(interfaceName);
       } catch (err) {
@@ -231,12 +239,20 @@ export class ModuleManager {
         );
         continue;
       }
-      const pkgRoot = this.resolver.interfacePackages.get(interfaceName);
-      if (!pkgRoot) {
-        continue;
-      }
       neutralizeInterfacePackage(pkgRoot, interfaceName);
     }
+  }
+
+  private collectImplementedInterfaces(): Set<string> {
+    const implemented = new Set<string>();
+    for (const { module, config } of this.getAllManagedModules()) {
+      for (const iface of module.manifest.implements ?? []) {
+        if (!config.disabledExports?.has(iface)) {
+          implemented.add(iface);
+        }
+      }
+    }
+    return implemented;
   }
 
   async constructAll(): Promise<void> {
@@ -330,6 +346,8 @@ export class ModuleManager {
       }
     } finally {
       this.startupOrder = [];
+      this.stubbedInterfacePaths.clear();
+      clearStubInterfaceWarnings();
       this.resolverDetour.detach();
     }
   }

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -8,9 +8,14 @@ import { Module } from "./module";
 import type { ModuleManifest } from "./module-manifest";
 import { ModuleRegistry } from "./module-registry";
 import { ModuleTracker } from "./module-tracker";
+import type { UnresolvedInterface } from "./resolution/interface-resolution";
 import { PathMapper } from "./resolution/path-mapper";
 import { Resolver } from "./resolution/resolver";
 import { ResolverDetour } from "./resolution/resolver-detour";
+import {
+  logStubInterfaceWarningOnce,
+  neutralizeInterfaceAsyncProxies,
+} from "./resolution/stub-interface-runtime";
 
 const Logger = new Logging.Channel("loader");
 
@@ -41,6 +46,7 @@ export class ModuleManager {
   private readonly resolvedAssociations = new Map<string, Set<string>>();
   private readonly staticModules: ManagedModule[] = [];
   private readonly loaded = new Map<string, ManagedModule>();
+  private readonly stubbedInterfaceNames = new Set<string>();
   private startupOrder: string[] = [];
 
   constructor(deps: ModuleManagerDeps = {}) {
@@ -171,8 +177,66 @@ export class ModuleManager {
     return this.resolvedAssociations.get(moduleId)?.has(interfaceName) ?? false;
   }
 
+  registerStubbedInterfaces(stubbed: UnresolvedInterface[]): void {
+    for (const { moduleId, interfacePackage } of stubbed) {
+      if (this.resolver.interfacePackages.has(interfacePackage)) {
+        this.stubbedInterfaceNames.add(interfacePackage);
+        continue;
+      }
+      const consumerFolder = this.loaded.get(moduleId)?.module.manifest.folder;
+      if (!consumerFolder) {
+        continue;
+      }
+      const pkgRoot = this.resolveInterfacePackageRoot(
+        interfacePackage,
+        consumerFolder,
+      );
+      if (!pkgRoot) {
+        continue;
+      }
+      this.resolver.interfacePackages.set(interfacePackage, pkgRoot);
+      this.stubbedInterfaceNames.add(interfacePackage);
+      logStubInterfaceWarningOnce(interfacePackage);
+    }
+  }
+
+  private resolveInterfacePackageRoot(
+    ifacePkg: string,
+    fromFolder: string,
+  ): string | undefined {
+    try {
+      const mainPath = require.resolve(ifacePkg, { paths: [fromFolder] });
+      const pkgNameSegments = ifacePkg.split("/");
+      const scopePrefix = ifacePkg.startsWith("@")
+        ? `${pkgNameSegments[0]}/${pkgNameSegments[1]}`
+        : pkgNameSegments[0];
+      const scopeIndex = mainPath.lastIndexOf(scopePrefix);
+      if (scopeIndex === -1) {
+        return undefined;
+      }
+      return mainPath.substring(0, scopeIndex + scopePrefix.length);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private applyInterfaceStubs(): void {
+    for (const interfaceName of this.stubbedInterfaceNames) {
+      try {
+        const exports = require(interfaceName);
+        neutralizeInterfaceAsyncProxies(exports, interfaceName);
+      } catch (err) {
+        Logger.Error(
+          `Failed to stub optional interface '${interfaceName}':`,
+          err,
+        );
+      }
+    }
+  }
+
   async constructAll(): Promise<void> {
     this.resolverDetour.attach();
+    this.applyInterfaceStubs();
     try {
       await Promise.all(
         [...this.loaded.values()].map(({ module, config }) =>
@@ -193,6 +257,7 @@ export class ModuleManager {
 
   async constructModules(modules: ManagedModule[]): Promise<void> {
     this.resolverDetour.attach();
+    this.applyInterfaceStubs();
     await Promise.all(
       modules.map(({ module, config }) =>
         module.construct(config.config).catch((err) => {

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -206,15 +206,7 @@ export class ModuleManager {
   ): string | undefined {
     try {
       const mainPath = require.resolve(ifacePkg, { paths: [fromFolder] });
-      const pkgNameSegments = ifacePkg.split("/");
-      const scopePrefix = ifacePkg.startsWith("@")
-        ? `${pkgNameSegments[0]}/${pkgNameSegments[1]}`
-        : pkgNameSegments[0];
-      const scopeIndex = mainPath.lastIndexOf(scopePrefix);
-      if (scopeIndex === -1) {
-        return undefined;
-      }
-      return mainPath.substring(0, scopeIndex + scopePrefix.length);
+      return extractPackageRoot(mainPath, ifacePkg);
     } catch {
       return undefined;
     }
@@ -413,18 +405,8 @@ export class ModuleManager {
         const mainPath = require.resolve(ifacePkg, {
           paths: [module.manifest.folder],
         });
-        // Walk up from the resolved main entry to find the package root
-        // by looking for the package name in the path
-        const pkgNameSegments = ifacePkg.split("/");
-        const scopePrefix = ifacePkg.startsWith("@")
-          ? `${pkgNameSegments[0]}/${pkgNameSegments[1]}`
-          : pkgNameSegments[0];
-        const scopeIndex = mainPath.lastIndexOf(scopePrefix);
-        if (scopeIndex !== -1) {
-          const pkgRoot = mainPath.substring(
-            0,
-            scopeIndex + scopePrefix.length,
-          );
+        const pkgRoot = extractPackageRoot(mainPath, ifacePkg);
+        if (pkgRoot) {
           this.resolver.interfacePackages.set(ifacePkg, pkgRoot);
         }
       } catch {
@@ -498,4 +480,16 @@ export class ModuleManager {
     }
     return normalizedFile.startsWith(normalizedDir + path.sep);
   }
+}
+
+function extractPackageRoot(
+  mainPath: string,
+  ifacePkg: string,
+): string | undefined {
+  const marker = `${path.sep}${ifacePkg.replace("/", path.sep)}${path.sep}`;
+  const scopeIndex = mainPath.indexOf(marker);
+  if (scopeIndex === -1) {
+    return undefined;
+  }
+  return mainPath.substring(0, scopeIndex + marker.length - 1);
 }

--- a/src/core/module-manifest.ts
+++ b/src/core/module-manifest.ts
@@ -15,6 +15,7 @@ export interface ModulePackageJson {
   author?: string | string[];
 
   dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
 
   antelopeJs?: {
     implements?: string[];

--- a/src/core/resolution/interface-resolution.ts
+++ b/src/core/resolution/interface-resolution.ts
@@ -9,6 +9,7 @@ export interface InterfaceConsumer {
   id: string;
   folder: string;
   dependencies: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
 }
 
 export interface UnresolvedInterface {
@@ -16,11 +17,28 @@ export interface UnresolvedInterface {
   interfacePackage: string;
 }
 
+export interface InterfaceResolutionResult {
+  unresolved: UnresolvedInterface[];
+  stubbed: UnresolvedInterface[];
+}
+
+function isInterfacePackage(dep: string, consumerFolder: string): boolean {
+  try {
+    const pkgJsonPath = require.resolve(`${dep}/package.json`, {
+      paths: [consumerFolder],
+    });
+    const depPkg = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+    return Boolean(depPkg.antelopeJs);
+  } catch {
+    return false;
+  }
+}
+
 export function findUnresolvedInterfaces(
   providers: InterfaceProvider[],
   consumers: InterfaceConsumer[],
   knownResolved?: Iterable<string>,
-): UnresolvedInterface[] {
+): InterfaceResolutionResult {
   const implementedInterfaces = new Set<string>(knownResolved);
   for (const provider of providers) {
     for (const iface of provider.implements) {
@@ -31,22 +49,21 @@ export function findUnresolvedInterfaces(
   }
 
   const unresolved: UnresolvedInterface[] = [];
+  const stubbed: UnresolvedInterface[] = [];
   for (const consumer of consumers) {
     for (const dep of Object.keys(consumer.dependencies)) {
       if (implementedInterfaces.has(dep)) continue;
-      try {
-        const pkgJsonPath = require.resolve(`${dep}/package.json`, {
-          paths: [consumer.folder],
-        });
-        const depPkg = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
-        if (depPkg.antelopeJs) {
-          unresolved.push({ moduleId: consumer.id, interfacePackage: dep });
-        }
-      } catch {
-        // Not resolvable — not an interface package
-      }
+      if (!isInterfacePackage(dep, consumer.folder)) continue;
+      unresolved.push({ moduleId: consumer.id, interfacePackage: dep });
+    }
+
+    const optional = consumer.optionalDependencies ?? {};
+    for (const dep of Object.keys(optional)) {
+      if (implementedInterfaces.has(dep)) continue;
+      if (!isInterfacePackage(dep, consumer.folder)) continue;
+      stubbed.push({ moduleId: consumer.id, interfacePackage: dep });
     }
   }
 
-  return unresolved;
+  return { unresolved, stubbed };
 }

--- a/src/core/resolution/stub-interface-runtime.ts
+++ b/src/core/resolution/stub-interface-runtime.ts
@@ -101,3 +101,7 @@ export function logStubInterfaceWarningOnce(interfaceName: string): void {
       `async calls on it will reject, sync usage will no-op.`,
   );
 }
+
+export function clearStubInterfaceWarnings(): void {
+  warned.clear();
+}

--- a/src/core/resolution/stub-interface-runtime.ts
+++ b/src/core/resolution/stub-interface-runtime.ts
@@ -1,3 +1,5 @@
+import Module from "node:module";
+import path from "node:path";
 import {
   AsyncProxy,
   EventProxy,
@@ -62,6 +64,31 @@ export function neutralizeInterfaceAsyncProxies(
   interfaceName: string,
 ): void {
   walk(exports, interfaceName, new WeakSet());
+}
+
+function isWithin(filePath: string, dirPath: string): boolean {
+  const normalizedDir = path.resolve(dirPath);
+  const normalizedFile = path.resolve(filePath);
+  if (normalizedFile === normalizedDir) {
+    return true;
+  }
+  return normalizedFile.startsWith(normalizedDir + path.sep);
+}
+
+export function neutralizeInterfacePackage(
+  packageRoot: string,
+  interfaceName: string,
+): void {
+  const cache = (Module as unknown as { _cache: Record<string, NodeModule> })
+    ._cache;
+  const seen = new WeakSet<object>();
+  for (const filename of Object.keys(cache)) {
+    if (!isWithin(filename, packageRoot)) {
+      continue;
+    }
+    const cachedModule = cache[filename];
+    walk(cachedModule.exports, interfaceName, seen);
+  }
 }
 
 export function logStubInterfaceWarningOnce(interfaceName: string): void {

--- a/src/core/resolution/stub-interface-runtime.ts
+++ b/src/core/resolution/stub-interface-runtime.ts
@@ -1,0 +1,76 @@
+import {
+  AsyncProxy,
+  EventProxy,
+  RegisteringProxy,
+} from "@antelopejs/interface-core";
+import { Logging } from "@antelopejs/interface-core/logging";
+
+const Logger = new Logging.Channel("loader");
+const warned = new Set<string>();
+
+function makeRejection(interfaceName: string): Promise<never> {
+  return Promise.reject(
+    new Error(
+      `Optional interface '${interfaceName}' has no provider; ` +
+        `async calls reject. Load an implementing module to enable this interface.`,
+    ),
+  );
+}
+
+function neutralizeAsyncProxy(proxy: AsyncProxy, interfaceName: string): void {
+  proxy.onCall(() => makeRejection(interfaceName), true);
+}
+
+function walk(
+  value: unknown,
+  interfaceName: string,
+  seen: WeakSet<object>,
+): void {
+  if (value === null || value === undefined) {
+    return;
+  }
+  if (typeof value === "function") {
+    const maybeProxy = (value as { proxy?: unknown }).proxy;
+    if (maybeProxy instanceof AsyncProxy) {
+      neutralizeAsyncProxy(maybeProxy as AsyncProxy, interfaceName);
+    }
+    return;
+  }
+  if (typeof value !== "object") {
+    return;
+  }
+  if (seen.has(value as object)) {
+    return;
+  }
+  seen.add(value as object);
+
+  if (value instanceof AsyncProxy) {
+    neutralizeAsyncProxy(value, interfaceName);
+    return;
+  }
+  if (value instanceof RegisteringProxy || value instanceof EventProxy) {
+    return;
+  }
+
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    walk((value as Record<string, unknown>)[key], interfaceName, seen);
+  }
+}
+
+export function neutralizeInterfaceAsyncProxies(
+  exports: unknown,
+  interfaceName: string,
+): void {
+  walk(exports, interfaceName, new WeakSet());
+}
+
+export function logStubInterfaceWarningOnce(interfaceName: string): void {
+  if (warned.has(interfaceName)) {
+    return;
+  }
+  warned.add(interfaceName);
+  Logger.Warn(
+    `Optional interface '${interfaceName}' has no provider; ` +
+      `async calls on it will reject, sync usage will no-op.`,
+  );
+}

--- a/src/core/runtime/module-loading.ts
+++ b/src/core/runtime/module-loading.ts
@@ -422,9 +422,14 @@ export function ensureGraphIsValid(manager: ModuleManager): void {
     id: module.id,
     folder: module.manifest.folder,
     dependencies: module.manifest.manifest.dependencies ?? {},
+    optionalDependencies: module.manifest.manifest.optionalDependencies ?? {},
   }));
 
-  const unresolved = findUnresolvedInterfaces(providers, consumers, staticDeps);
+  const { unresolved, stubbed } = findUnresolvedInterfaces(
+    providers,
+    consumers,
+    staticDeps,
+  );
   if (unresolved.length > 0) {
     const details = unresolved
       .map(
@@ -435,5 +440,9 @@ export function ensureGraphIsValid(manager: ModuleManager): void {
     throw new Error(
       `Unresolved interface dependencies:\n${details}\n\nRun 'ajs project modules install' to resolve missing dependencies.`,
     );
+  }
+
+  if (stubbed.length > 0) {
+    manager.registerStubbedInterfaces(stubbed);
   }
 }

--- a/test/core/resolution/interface-resolution.test.ts
+++ b/test/core/resolution/interface-resolution.test.ts
@@ -1,0 +1,127 @@
+import path from "node:path";
+import { expect } from "chai";
+import {
+  findUnresolvedInterfaces,
+  type InterfaceConsumer,
+  type InterfaceProvider,
+} from "../../../src/core/resolution/interface-resolution";
+
+const CORE_INTERFACE_PKG = "@antelopejs/interface-core";
+const CONSUMER_FOLDER = path.resolve(__dirname, "..", "..", "..");
+
+describe("findUnresolvedInterfaces", () => {
+  it("places missing required deps into unresolved", () => {
+    const providers: InterfaceProvider[] = [];
+    const consumers: InterfaceConsumer[] = [
+      {
+        id: "consumer",
+        folder: CONSUMER_FOLDER,
+        dependencies: { [CORE_INTERFACE_PKG]: "*" },
+      },
+    ];
+
+    const result = findUnresolvedInterfaces(providers, consumers);
+
+    expect(result.unresolved).to.have.lengthOf(1);
+    expect(result.unresolved[0]).to.deep.equal({
+      moduleId: "consumer",
+      interfacePackage: CORE_INTERFACE_PKG,
+    });
+    expect(result.stubbed).to.have.lengthOf(0);
+  });
+
+  it("places missing optional deps into stubbed, not unresolved", () => {
+    const providers: InterfaceProvider[] = [];
+    const consumers: InterfaceConsumer[] = [
+      {
+        id: "consumer",
+        folder: CONSUMER_FOLDER,
+        dependencies: {},
+        optionalDependencies: { [CORE_INTERFACE_PKG]: "*" },
+      },
+    ];
+
+    const result = findUnresolvedInterfaces(providers, consumers);
+
+    expect(result.unresolved).to.have.lengthOf(0);
+    expect(result.stubbed).to.have.lengthOf(1);
+    expect(result.stubbed[0]).to.deep.equal({
+      moduleId: "consumer",
+      interfacePackage: CORE_INTERFACE_PKG,
+    });
+  });
+
+  it("ignores deps that are not interface packages", () => {
+    const providers: InterfaceProvider[] = [];
+    const consumers: InterfaceConsumer[] = [
+      {
+        id: "consumer",
+        folder: CONSUMER_FOLDER,
+        dependencies: { chai: "*" },
+        optionalDependencies: { mocha: "*" },
+      },
+    ];
+
+    const result = findUnresolvedInterfaces(providers, consumers);
+
+    expect(result.unresolved).to.have.lengthOf(0);
+    expect(result.stubbed).to.have.lengthOf(0);
+  });
+
+  it("skips deps that are implemented by a provider", () => {
+    const providers: InterfaceProvider[] = [
+      { implements: [CORE_INTERFACE_PKG] },
+    ];
+    const consumers: InterfaceConsumer[] = [
+      {
+        id: "consumer",
+        folder: CONSUMER_FOLDER,
+        dependencies: { [CORE_INTERFACE_PKG]: "*" },
+      },
+    ];
+
+    const result = findUnresolvedInterfaces(providers, consumers);
+
+    expect(result.unresolved).to.have.lengthOf(0);
+    expect(result.stubbed).to.have.lengthOf(0);
+  });
+
+  it("treats interface as missing when provider has disabled it", () => {
+    const providers: InterfaceProvider[] = [
+      {
+        implements: [CORE_INTERFACE_PKG],
+        disabledExports: new Set([CORE_INTERFACE_PKG]),
+      },
+    ];
+    const consumers: InterfaceConsumer[] = [
+      {
+        id: "consumer",
+        folder: CONSUMER_FOLDER,
+        dependencies: {},
+        optionalDependencies: { [CORE_INTERFACE_PKG]: "*" },
+      },
+    ];
+
+    const result = findUnresolvedInterfaces(providers, consumers);
+
+    expect(result.unresolved).to.have.lengthOf(0);
+    expect(result.stubbed).to.have.lengthOf(1);
+  });
+
+  it("honors knownResolved as already-implemented", () => {
+    const providers: InterfaceProvider[] = [];
+    const consumers: InterfaceConsumer[] = [
+      {
+        id: "consumer",
+        folder: CONSUMER_FOLDER,
+        dependencies: { [CORE_INTERFACE_PKG]: "*" },
+      },
+    ];
+
+    const result = findUnresolvedInterfaces(providers, consumers, [
+      CORE_INTERFACE_PKG,
+    ]);
+
+    expect(result.unresolved).to.have.lengthOf(0);
+  });
+});

--- a/test/core/resolution/stub-interface-runtime.test.ts
+++ b/test/core/resolution/stub-interface-runtime.test.ts
@@ -1,0 +1,94 @@
+import {
+  AsyncProxy,
+  EventProxy,
+  InterfaceFunction,
+  RegisteringProxy,
+} from "@antelopejs/interface-core";
+import { expect } from "chai";
+import { neutralizeInterfaceAsyncProxies } from "../../../src/core/resolution/stub-interface-runtime";
+
+describe("neutralizeInterfaceAsyncProxies", () => {
+  it("makes AsyncProxy-backed calls reject instead of queuing forever", async () => {
+    const iface = {
+      doThing: InterfaceFunction<(x: number) => string>(),
+    };
+    neutralizeInterfaceAsyncProxies(iface, "test-iface");
+
+    let error: Error | undefined;
+    try {
+      await iface.doThing(1);
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error).to.be.instanceOf(Error);
+    expect(error?.message).to.match(/test-iface/);
+    expect(error?.message).to.match(/no provider/);
+  });
+
+  it("recurses into nested namespaces", async () => {
+    const iface = {
+      group: {
+        nested: {
+          fn: InterfaceFunction<() => number>(),
+        },
+      },
+    };
+    neutralizeInterfaceAsyncProxies(iface, "nested-iface");
+
+    let rejected = false;
+    try {
+      await iface.group.nested.fn();
+    } catch {
+      rejected = true;
+    }
+    expect(rejected).to.equal(true);
+  });
+
+  it("leaves RegisteringProxy untouched", () => {
+    const reg = new RegisteringProxy<(id: string) => void>();
+    const iface = { reg };
+    neutralizeInterfaceAsyncProxies(iface, "reg-iface");
+
+    let called = false;
+    reg.onRegister(() => {
+      called = true;
+    }, true);
+    reg.register("id-1");
+    expect(called).to.equal(true);
+  });
+
+  it("leaves EventProxy untouched", () => {
+    const event = new EventProxy<() => void>();
+    const iface = { event };
+    neutralizeInterfaceAsyncProxies(iface, "evt-iface");
+
+    let fired = false;
+    event.register(() => {
+      fired = true;
+    });
+    event.emit();
+    expect(fired).to.equal(true);
+  });
+
+  it("neutralizes bare AsyncProxy instances (not wrapped in InterfaceFunction)", async () => {
+    const proxy = new AsyncProxy<() => number>();
+    const iface = { proxy };
+    neutralizeInterfaceAsyncProxies(iface, "bare-iface");
+
+    let rejected = false;
+    try {
+      await proxy.call();
+    } catch {
+      rejected = true;
+    }
+    expect(rejected).to.equal(true);
+  });
+
+  it("does not loop on circular structures", () => {
+    const iface: any = { a: {} };
+    iface.a.back = iface;
+    expect(() =>
+      neutralizeInterfaceAsyncProxies(iface, "cycle-iface"),
+    ).to.not.throw();
+  });
+});

--- a/test/integration/launch.test.ts
+++ b/test/integration/launch.test.ts
@@ -85,6 +85,131 @@ describe("Launch Function", () => {
     }
   });
 
+  it("loads an unimplemented optional interface and stubs its AsyncProxies", async () => {
+    const projectFolder = await fs.mkdtemp(
+      path.join(os.tmpdir(), "ajs-project-"),
+    );
+    try {
+      // An interface package: real files on disk that declare an AsyncProxy-
+      // backed InterfaceFunction and a synchronous RegisteringProxy. The
+      // presence of `antelopeJs` in package.json marks it as an interface.
+      const ifaceFolder = path.join(projectFolder, "iface-pkg");
+      await fs.mkdir(ifaceFolder, { recursive: true });
+      await fs.writeFile(
+        path.join(ifaceFolder, "package.json"),
+        JSON.stringify(
+          {
+            name: "iface-pkg",
+            version: "1.0.0",
+            main: "index.js",
+            antelopeJs: {},
+          },
+          null,
+          2,
+        ),
+      );
+      await fs.writeFile(
+        path.join(ifaceFolder, "index.js"),
+        `
+        const core = require("@antelopejs/interface-core");
+        exports.Iface = {
+          fetch: core.InterfaceFunction(),
+        };
+        exports.OnThing = new core.RegisteringProxy();
+        `,
+      );
+
+      // A consumer module that lists iface-pkg under optionalDependencies and
+      // captures the imported exports so the test can probe them.
+      const consumerFolder = path.join(projectFolder, "consumer");
+      await fs.mkdir(consumerFolder, { recursive: true });
+      await fs.writeFile(
+        path.join(consumerFolder, "package.json"),
+        JSON.stringify(
+          {
+            name: "consumer",
+            version: "1.0.0",
+            main: "index.js",
+            optionalDependencies: { "iface-pkg": "*" },
+          },
+          null,
+          2,
+        ),
+      );
+      await fs.writeFile(
+        path.join(consumerFolder, "index.js"),
+        `
+        const iface = require("iface-pkg");
+        module.exports = {
+          construct() {
+            global.__antelopeStubTest = iface;
+          },
+        };
+        `,
+      );
+
+      await fs.mkdir(path.join(consumerFolder, "node_modules"), {
+        recursive: true,
+      });
+      await fs.symlink(
+        ifaceFolder,
+        path.join(consumerFolder, "node_modules", "iface-pkg"),
+      );
+
+      await writeProjectConfig(projectFolder, {
+        name: "test-project",
+        modules: {
+          consumer: {
+            source: {
+              type: "local",
+              path: "./consumer",
+              main: "index.js",
+            },
+          },
+        },
+      });
+
+      const manager = await launch(projectFolder);
+      try {
+        expect(manager.resolver.interfacePackages.has("iface-pkg")).to.equal(
+          true,
+        );
+        const captured = (global as any).__antelopeStubTest;
+        expect(captured).to.exist;
+        expect(captured.Iface.fetch).to.be.a("function");
+
+        // RegisteringProxy is sync and should not be neutralized
+        let registered = false;
+        captured.OnThing.onRegister(() => {
+          registered = true;
+        }, true);
+        captured.OnThing.register("id-1");
+        expect(registered).to.equal(true);
+
+        // AsyncProxy-backed call should reject promptly instead of hanging
+        let asyncError: Error | undefined;
+        try {
+          await Promise.race([
+            captured.Iface.fetch(),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error("HANG")), 1000),
+            ),
+          ]);
+        } catch (e) {
+          asyncError = e as Error;
+        }
+        expect(asyncError?.message ?? "").to.match(/iface-pkg/);
+        expect(asyncError?.message ?? "").to.not.match(/HANG/);
+      } finally {
+        delete (global as any).__antelopeStubTest;
+        await manager.stopAll();
+        await manager.destroyAll();
+      }
+    } finally {
+      await fs.rm(projectFolder, { recursive: true, force: true });
+    }
+  });
+
   it("should respect environment option", async () => {
     const projectFolder = await fs.mkdtemp(
       path.join(os.tmpdir(), "ajs-project-"),


### PR DESCRIPTION
## Summary

- A module can list an antelopejs interface package under npm `optionalDependencies`. If no other module implements that interface, the framework no longer fails startup — it loads the interface's real files (so types, decorators, and sync helpers keep working) and neutralizes its `AsyncProxy` instances so async calls reject instead of hanging.
- `RegisteringProxy` and `EventProxy` are left untouched — they're synchronous and don't deadlock.
- A one-time warning is logged per missing optional interface via the existing `loader` channel.

## How it works

1. `findUnresolvedInterfaces()` now returns `{ unresolved, stubbed }`. Required missing deps still throw at startup; optional missing deps go into `stubbed`.
2. For each `stubbed` interface, the manager resolves the real npm package path from a consumer's `node_modules` and registers it in `resolver.interfacePackages` — every consumer shares the same physical copy, preserving the singleton property the framework relies on.
3. After `resolverDetour.attach()` and before consumer `construct()` runs, `applyInterfaceStubs()` requires each stubbed interface and walks its exports, calling `AsyncProxy.onCall(() => Promise.reject(...), true)` on every implementation point. Recursion uses a `WeakSet` for cycle safety; `RegisteringProxy` / `EventProxy` are skipped.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm test:unit` — 510 passing; new tests cover:
  - `findUnresolvedInterfaces`: required vs optional split, `knownResolved`, `disabledExports`
  - `neutralizeInterfaceAsyncProxies`: `InterfaceFunction` rejects, nested namespaces recursed, bare `AsyncProxy`, `RegisteringProxy`/`EventProxy` left intact, circular structures
  - End-to-end `launch.test.ts`: a consumer with an unimplemented optional dep launches, `RegisteringProxy.register` still fires its callback synchronously, `await iface.fetch()` rejects with the interface name (raced against a 1s timeout — no hang)
- [x] `pnpm test:playground` — three phases pass; no regression on the normal implemented-interface flow
- [x] `pnpm run lint` — exit 0; no new findings (2 pre-existing warnings in unrelated files remain)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the AntelopeJS module resolution system to treat unimplemented interface packages listed under npm `optionalDependencies` as "stubs" rather than fatal startup errors. When an optional interface has no provider, the framework loads its real files (preserving types, decorators, and sync helpers) and neutralizes all `AsyncProxy` instances to reject instead of hang.

- `findUnresolvedInterfaces` now returns `{ unresolved, stubbed }`, routing optional missing deps through `registerStubbedInterfaces` → `applyInterfaceStubs` instead of a startup exception.
- `extractPackageRoot` is refactored from `lastIndexOf(bare-name)` to `indexOf(/name/)` (slash-delimited marker), fixing the previously-reported `config/config.js` path-extraction bug while introducing a minor edge case noted below.
- A new `stub-interface-runtime.ts` module handles proxy neutralization with cycle-safe `WeakSet` recursion, and the module-level `warned` Set is cleared on framework shutdown via the now-exported `clearStubInterfaceWarnings`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the optional-interface stub flow is well-tested end-to-end and the lifetime management (clear on destroy, evict when a real provider loads) is correct.

The change correctly routes optional missing deps through a stub path rather than a fatal error, applies neutralization before `construct()` runs, and evicts stubs once a real provider is present. All new code paths are covered by unit tests and an integration test that races against a 1-second timeout to guard against hangs. The one remaining edge case — `extractPackageRoot` using `indexOf` instead of `lastIndexOf` — only affects unscoped interface packages installed in a project directory that shares the package name, an unlikely combination for most real-world Antelope setups.

The `extractPackageRoot` helper at the bottom of `src/core/module-manager.ts` is the only spot worth a second look.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/core/module-manager.ts | Core orchestration of stub registration and neutralization; `applyInterfaceStubs` correctly evicts a stub when a real provider loads; `extractPackageRoot` changes from `lastIndexOf` to `indexOf` with a slash-delimited marker — an improvement for the `config/config.js` case but adds a new edge case for unscoped packages when the project directory shares the package name. |
| src/core/resolution/stub-interface-runtime.ts | New file implementing proxy neutralization; `walk` correctly uses a WeakSet for cycle safety, skips RegisteringProxy/EventProxy, handles both bare AsyncProxy and InterfaceFunction wrapper patterns; the WeakSet is shared across the module cache walk, which is correct (same-object detection avoids double work and neutralization is idempotent). |
| src/core/resolution/interface-resolution.ts | Clean refactor splitting the old single array into `{ unresolved, stubbed }`; `isInterfacePackage` helper correctly catches resolution failures; optional and required deps are handled in separate loops without overlap for normal manifests. |
| src/core/runtime/module-loading.ts | Small, correct addition: passes `optionalDependencies` through to `findUnresolvedInterfaces` and calls `registerStubbedInterfaces` only when stubs exist, after confirming no required interfaces are unresolved. |
| test/integration/launch.test.ts | End-to-end test covering the happy path: optional interface stub loads, RegisteringProxy remains sync, async call rejects promptly; uses `Promise.race` with a 1-second timeout to guard against hangs. |
| test/core/resolution/stub-interface-runtime.test.ts | Unit tests cover AsyncProxy rejection, nested namespace recursion, RegisteringProxy/EventProxy left intact, bare AsyncProxy, and circular structure safety — comprehensive coverage of the new runtime module. |
| test/core/resolution/interface-resolution.test.ts | Unit tests cover all split cases: required-missing → unresolved, optional-missing → stubbed, non-interface dep ignored, implemented dep skipped, disabled provider treated as missing, knownResolved honored. |
| src/core/module-manifest.ts | Adds `optionalDependencies` field to the `ModulePackageJson` type; straightforward and correct. |
| src/core/cli/commands/project/modules/install.ts | Adapted to destructure `{ unresolved }` from the new return type; only the `unresolved` set is relevant for the install command, so `stubbed` is correctly ignored here. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ML as module-loading.ts
    participant MM as ModuleManager
    participant IR as interface-resolution.ts
    participant SR as stub-interface-runtime.ts
    participant Node as Node.js require

    ML->>IR: findUnresolvedInterfaces(providers, consumers, staticDeps)
    IR-->>ML: "{ unresolved[], stubbed[] }"
    ML->>ML: "throw if unresolved.length > 0"
    ML->>MM: registerStubbedInterfaces(stubbed)
    MM->>Node: "require.resolve(ifacePkg, {paths:[consumerFolder]})"
    Node-->>MM: mainPath
    MM->>MM: extractPackageRoot(mainPath, ifacePkg)
    MM->>MM: stubbedInterfacePaths.set(ifacePkg, pkgRoot)
    MM->>MM: resolver.interfacePackages.set(ifacePkg, pkgRoot)
    MM->>SR: logStubInterfaceWarningOnce(ifacePkg)

    Note over MM: constructAll() / constructModules()
    MM->>MM: resolverDetour.attach()
    MM->>MM: applyInterfaceStubs()
    MM->>MM: collectImplementedInterfaces()
    loop for each stubbed interface
        alt provider now loaded
            MM->>MM: stubbedInterfacePaths.delete(interfaceName)
        else still unimplemented
            MM->>Node: require(interfaceName) via resolver detour
            Node-->>MM: module exports loaded into cache
            MM->>SR: neutralizeInterfacePackage(pkgRoot, interfaceName)
            SR->>SR: walk Module._cache entries within pkgRoot
            SR->>SR: "AsyncProxy.onCall(() => Promise.reject(...), true)"
        end
    end
    MM->>MM: construct all modules (providers set real handlers)

    Note over MM: destroyAll() / stopAll()
    MM->>MM: stubbedInterfacePaths.clear()
    MM->>SR: clearStubInterfaceWarnings()
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/core/module-manager.ts`, line 433-446 ([link](https://github.com/antelopejs/antelopejs/blob/db3cbfe497fb9b9c79d0ff0d00774a1fb89fe0bc/src/core/module-manager.ts#L433-L446)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`addDefaultAssociations` ignores `optionalDependencies` even when a provider exists**

   When a provider IS loaded for an optional interface dep, `addDefaultAssociations` only inspects `module.manifest.manifest.dependencies`, so the consumer never gets an association or connection entry for that interface. Concretely, `hasResolvedInterface(moduleId, iface)` will return `false`, and import overrides configured for the optional interface won't be applied. The singleton redirect still works through `interfacePackages`, but the framework's module-association tracking is incomplete for optional deps. Checking `optionalDependencies` alongside `dependencies` here would make the behaviour consistent.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/core/module-manager.ts
   Line: 433-446

   Comment:
   **`addDefaultAssociations` ignores `optionalDependencies` even when a provider exists**

   When a provider IS loaded for an optional interface dep, `addDefaultAssociations` only inspects `module.manifest.manifest.dependencies`, so the consumer never gets an association or connection entry for that interface. Concretely, `hasResolvedInterface(moduleId, iface)` will return `false`, and import overrides configured for the optional interface won't be applied. The singleton redirect still works through `interfacePackages`, but the framework's module-association tracking is incomplete for optional deps. Checking `optionalDependencies` alongside `dependencies` here would make the behaviour consistent.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/core/module-manager.ts:489-490
`indexOf` finds the **first** occurrence of the slash-delimited marker. For scoped packages (`@scope/name`) this is always safe because `/` cannot appear in a directory name, so the marker can never match a single path component. For unscoped packages, however, if the project happens to live in a directory whose name equals the package name — e.g. `/home/user/config/node_modules/config/index.js` — `indexOf("/config/")` matches the project directory component first and returns `/home/user/config` instead of the actual package root. The stub is then registered with the wrong directory, `neutralizeInterfacePackage` finds no cached files within it, and async calls hang rather than reject. Using `lastIndexOf` with the same marker avoids the issue because the package's own `node_modules` entry is always the **last** occurrence of the pattern.

```suggestion
  const marker = `${path.sep}${ifacePkg.replace("/", path.sep)}${path.sep}`;
  const scopeIndex = mainPath.lastIndexOf(marker);
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/antelopejs/antelopejs/commit/f8468c6ff314ccd92d8b2d365c4c8429c06504d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31946836)</sub>

<!-- /greptile_comment -->