### PR TITLE
fix(test): run setupTestEnvironment when TestModule is invoked with file filter

### DIFF
--- a/src/core/test/test-module.ts
+++ b/src/core/test/test-module.ts
@@ -18,9 +18,7 @@ import {
   normalizeLoadedConfig,
   withRaisedMaxListeners,
 } from "../runtime/runtime-bootstrap";
-import { TestContext } from "./test-context";
 import * as self from "./test-module";
-import { TestRunner } from "./test-runner";
 
 const EXIT_CODE_ERROR = 1;
 const DEFAULT_TEST_FOLDER = "test";
@@ -177,19 +175,12 @@ export async function executeTests(
   test: AntelopeTestConfig,
   manager: ModuleManager | null,
   fs: IFileSystem,
+  files: string[] = [],
 ): Promise<number> {
-  const testFolder = path.join(moduleRoot, test.folder ?? DEFAULT_TEST_FOLDER);
-  const localTestFiles = await collectTestFiles(
-    testFolder,
-    TEST_FILE_PATTERN,
-    fs,
-  );
-  const interfaceTestFiles = await self.collectInterfaceTestFiles(
-    moduleRoot,
-    manager,
-    fs,
-  );
-  const testFiles = [...localTestFiles, ...interfaceTestFiles];
+  const testFiles =
+    files.length > 0
+      ? files
+      : await discoverTestFiles(moduleRoot, test, manager, fs);
 
   if (testFiles.length === 0) {
     console.error("No test files found");
@@ -205,6 +196,26 @@ export async function executeTests(
   return new Promise<number>((resolve) => {
     mocha.run((count) => resolve(count));
   });
+}
+
+async function discoverTestFiles(
+  moduleRoot: string,
+  test: AntelopeTestConfig,
+  manager: ModuleManager | null,
+  fs: IFileSystem,
+): Promise<string[]> {
+  const testFolder = path.join(moduleRoot, test.folder ?? DEFAULT_TEST_FOLDER);
+  const localTestFiles = await collectTestFiles(
+    testFolder,
+    TEST_FILE_PATTERN,
+    fs,
+  );
+  const interfaceTestFiles = await self.collectInterfaceTestFiles(
+    moduleRoot,
+    manager,
+    fs,
+  );
+  return [...localTestFiles, ...interfaceTestFiles];
 }
 
 function applySetupOverrides(
@@ -228,12 +239,6 @@ export async function TestModule(
   moduleFolder: string = ".",
   files: string[] = [],
 ): Promise<number> {
-  if (files.length > 0) {
-    const context = new TestContext({});
-    const runner = new TestRunner(context);
-    return runner.run(files);
-  }
-
   const moduleRoot = path.resolve(moduleFolder);
   const fs = new NodeFileSystem();
   const loadedConfig = await self.loadTestConfig(moduleRoot, fs);
@@ -263,6 +268,7 @@ export async function TestModule(
       loadedConfig.test,
       manager,
       fs,
+      files,
     );
     if (failures === EXIT_CODE_ERROR) {
       await manager.destroyAll();

--- a/test/core/test/test-module.test.ts
+++ b/test/core/test/test-module.test.ts
@@ -328,6 +328,36 @@ describe("test-module", () => {
       });
     });
 
+    it("forwards explicit file filter to executeTests after full bootstrap", async () => {
+      const destroyAllStub = sinon.stub().resolves();
+      const mockConfig = {
+        name: "test",
+        cacheFolder: ".antelope/cache",
+        modules: {},
+        envOverrides: {},
+        test: {},
+      };
+
+      sinon.stub(testModule, "loadTestConfig").resolves({
+        config: mockConfig as any,
+        test: mockConfig.test,
+      });
+
+      const setupEnvStub = sinon
+        .stub(testModule, "setupTestEnvironment")
+        .resolves({ destroyAll: destroyAllStub } as any);
+
+      const executeStub = sinon.stub(testModule, "executeTests").resolves(0);
+
+      const files = ["/module/test/only-this.test.js"];
+      const result = await testModule.TestModule("/module", files);
+
+      expect(result).to.equal(0);
+      expect(setupEnvStub.calledOnce).to.equal(true);
+      expect(executeStub.calledOnce).to.equal(true);
+      expect(executeStub.firstCall.args[4]).to.deep.equal(files);
+    });
+
     it("works without setup and cleanup hooks", async () => {
       const destroyAllStub = sinon.stub().resolves();
 

--- a/test/integration/test-module.test.ts
+++ b/test/integration/test-module.test.ts
@@ -5,12 +5,27 @@ import { expect } from "chai";
 import sinon from "sinon";
 import { TestModule } from "../../src";
 
+async function writeMinimalAntelopeModule(folder: string): Promise<void> {
+  await fs.writeFile(
+    path.join(folder, "package.json"),
+    JSON.stringify({
+      name: "tmp-module",
+      antelopeJs: { test: "./antelope.test.config.ts" },
+    }),
+  );
+  await fs.writeFile(
+    path.join(folder, "antelope.test.config.ts"),
+    `export default ${JSON.stringify({ name: "tmp-module", modules: {} })};\n`,
+  );
+}
+
 describe("TestModule Function", () => {
   it("should run tests and return success code", async () => {
     const moduleFolder = await fs.mkdtemp(
       path.join(os.tmpdir(), "ajs-module-"),
     );
     try {
+      await writeMinimalAntelopeModule(moduleFolder);
       const testFile = path.join(moduleFolder, "sample.test.js");
       await fs.writeFile(
         testFile,
@@ -23,6 +38,33 @@ describe("TestModule Function", () => {
       );
 
       const failures = await TestModule(moduleFolder, [testFile]);
+      expect(failures).to.equal(0);
+    } finally {
+      await fs.rm(moduleFolder, { recursive: true, force: true });
+    }
+  });
+
+  it("runs only filtered files and skips other tests in the folder", async () => {
+    const moduleFolder = await fs.mkdtemp(
+      path.join(os.tmpdir(), "ajs-filter-"),
+    );
+    try {
+      await writeMinimalAntelopeModule(moduleFolder);
+      const testFolder = path.join(moduleFolder, "test");
+      await fs.mkdir(testFolder, { recursive: true });
+
+      const selectedFile = path.join(testFolder, "selected.test.js");
+      const ignoredFile = path.join(testFolder, "ignored.test.js");
+      await fs.writeFile(
+        selectedFile,
+        "describe('selected', () => { it('runs', () => {}); });\n",
+      );
+      await fs.writeFile(
+        ignoredFile,
+        "describe('ignored', () => { it('fails', () => { throw new Error('should not run'); }); });\n",
+      );
+
+      const failures = await TestModule(moduleFolder, [selectedFile]);
       expect(failures).to.equal(0);
     } finally {
       await fs.rm(moduleFolder, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

`ajs module test -f <file>` (and any other call to `TestModule(folder, files)` with a non-empty file list) was taking an early-return branch in [`TestModule`](src/core/test/test-module.ts) that ran mocha directly, **skipping `loadTestConfig` and `setupTestEnvironment`**. Without the setup pass, module aliases (e.g. `@/*`) and interface decorators (`DashboardAuthUser`, etc.) were never registered, so any unit test that transitively imports compiled module code failed to load.

This PR routes the filter path through the same bootstrap as the default discovery path. The discovered file list is replaced with the explicit one when files are provided, so consumers still get to scope test runs without losing the antelope runtime context.

## Repro before the fix

```ts
// any unit test that does
const x = require("@/utils/api");

// then:
await TestModule(moduleRoot, ["dist/test/unit/foo.test.js"]);
// → Error: Cannot find module '@/utils/api'
```

Surfaced downstream on a project that upgraded to 1.2.0 and lost `ajs module test -f` for its unit suite.

## Changes

- [`src/core/test/test-module.ts`](src/core/test/test-module.ts):
  - Removed the early-return branch in `TestModule`.
  - `executeTests` now accepts an optional `files: string[]` parameter. When provided, discovery is skipped and only those files are passed to mocha.
  - Extracted discovery into a private `discoverTestFiles` helper to keep `executeTests` readable.
  - Dropped the now-unused `TestContext` / `TestRunner` imports. Both classes remain in the codebase and their own tests still pass; deleting them is left to a follow-up.
- [`test/core/test/test-module.test.ts`](test/core/test/test-module.test.ts): regression test verifying that `TestModule(folder, files)` calls `setupTestEnvironment` and forwards the file list to `executeTests`.
- [`test/integration/test-module.test.ts`](test/integration/test-module.test.ts): updated the existing happy-path test to set up a minimal antelope module (so the bootstrap can succeed) and added a second test that proves only the requested file runs even when other `.test.js` files exist in the test folder.

## Test plan

- [x] `pnpm build` — clean.
- [x] `pnpm test:unit` — passes (a couple of pre-existing flaky failures in `module-manager` and HMR tests, unrelated).
- [x] `biome check` on modified files reports zero issues.
- [ ] CI green on the PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression where calling `TestModule(folder, files)` with an explicit file list would hit an early-return branch that bypassed `loadTestConfig` and `setupTestEnvironment`, causing module aliases and interface decorators to go unregistered and making any test that imports compiled module code fail.

- **`src/core/test/test-module.ts`**: Removes the early-return branch that instantiated `TestContext`/`TestRunner` directly; adds an optional `files` parameter to `executeTests` (skipping discovery when populated); extracts `discoverTestFiles` as a private helper; removes now-unused `TestContext`/`TestRunner` imports.
- **`test/core/test/test-module.test.ts`**: Adds a unit test verifying that `setupTestEnvironment` is called and the explicit file list is forwarded as the 5th argument to `executeTests`.
- **`test/integration/test-module.test.ts`**: Introduces `writeMinimalAntelopeModule` so the bootstrap can succeed in integration tests, updates the existing happy-path test, and adds a new filter test that proves unrelated files are not executed.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it removes a well-scoped bypass branch, routes both code paths through the same bootstrap sequence, and adds regression tests that directly cover the fixed behavior.

The fix is minimal and targeted: removing an early-return path and adding one optional parameter to `executeTests`. The rest of the teardown and cleanup logic (`destroyAll`, `clearStubModulePath`, `test.cleanup`) is unchanged. Unit and integration tests verify the new behavior end-to-end.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/test/test-module.ts | Early-return bypass removed; `executeTests` gains an optional `files` parameter; `discoverTestFiles` extracted as a private helper. Logic is correct and cleanup/teardown paths are unaffected. |
| test/core/test/test-module.test.ts | New unit test stubs `loadTestConfig`, `setupTestEnvironment`, and `executeTests`, then asserts setup was called and the file list is forwarded as `args[4]`. Covers the regression path correctly. |
| test/integration/test-module.test.ts | Adds `writeMinimalAntelopeModule` helper so the full bootstrap can succeed; existing test updated and new filter test added. Tests are clean and isolated with proper `finally` cleanup. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant TestModule
    participant loadTestConfig
    participant setupTestEnvironment
    participant executeTests
    participant discoverTestFiles
    participant mocha

    Caller->>TestModule: TestModule(folder, files?)
    TestModule->>loadTestConfig: loadTestConfig(moduleRoot, fs)
    loadTestConfig-->>TestModule: LoadedTestConfig

    opt test.setup defined
        TestModule->>TestModule: applySetupOverrides(config, overrides)
    end

    TestModule->>setupTestEnvironment: setupTestEnvironment(moduleRoot, config)
    setupTestEnvironment-->>TestModule: ModuleManager

    TestModule->>executeTests: executeTests(moduleRoot, test, manager, fs, files)

    alt "files.length > 0"
        executeTests->>executeTests: use provided files directly
    else
        executeTests->>discoverTestFiles: discoverTestFiles(...)
        discoverTestFiles-->>executeTests: localFiles + interfaceFiles
    end

    executeTests->>mocha: mocha.run(testFiles)
    mocha-->>executeTests: failureCount

    executeTests-->>TestModule: failureCount
    TestModule->>TestModule: manager.destroyAll()

    opt test.cleanup defined
        TestModule->>TestModule: loadedConfig.test.cleanup()
    end

    TestModule-->>Caller: failureCount
```

<sub>Reviews (2): Last reviewed commit: ["fix(test): run setupTestEnvironment when..."](https://github.com/antelopejs/antelopejs/commit/330039d9e263077714ad4d055843ccdeb82d8a58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32575742)</sub>

<!-- /greptile_comment -->