### PR TITLE
feat(watch): serialize per-module reloads + reloadCommand support

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test:coverage": "c8 --check-coverage --lines 90 --functions 90 --branches 90 --statements 90 mocha --require ts-node/register --require test/setup.ts 'test/**/*.test.ts' --exit"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.3",
+    "@antelopejs/interface-core": "^0.0.4",
     "@types/proper-lockfile": "^4.1.4",
     "boxen": "^8.0.1",
     "chalk": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.0.4
+        version: 0.0.4
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
@@ -105,8 +105,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.3':
-    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
+  '@antelopejs/interface-core@0.0.4':
+    resolution: {integrity: sha512-RNptIsG3Luwy5XR4dIOvWPbVntWrpuCAOOK+49wmd0sOxMJ8lqtTaOarFCRvxN61uPEt8f8tzx7059mTtnjoig==}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -1728,7 +1728,7 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.3':
+  '@antelopejs/interface-core@0.0.4':
     dependencies:
       reflect-metadata: 0.2.2
 

--- a/src/core/downloaders/local-folder.ts
+++ b/src/core/downloaders/local-folder.ts
@@ -62,6 +62,7 @@ export function registerLocalFolderDownloader(
           path: folder,
           watchDir: source.watchDir,
           installCommand: source.installCommand,
+          reloadCommand: source.reloadCommand,
         };
         const manifest = await ModuleManifest.create(
           folder,

--- a/src/core/downloaders/local-folder.ts
+++ b/src/core/downloaders/local-folder.ts
@@ -9,10 +9,9 @@ import { ExecuteCMD } from "../cli/command";
 import { NodeFileSystem } from "../filesystem";
 import type { ModuleCache } from "../module-cache";
 import { ModuleManifest } from "../module-manifest";
-import type { DownloaderRegistry } from "./registry";
+import type { DownloaderRegistry, LoadOptions } from "./registry";
 import type { CommandRunner } from "./types";
 import { expandHome, runInstallCommands } from "./utils";
-import type { LoadOptions } from "./registry";
 
 const Logger = new Logging.Channel("loader.local-folder");
 

--- a/src/core/downloaders/local-folder.ts
+++ b/src/core/downloaders/local-folder.ts
@@ -12,6 +12,7 @@ import { ModuleManifest } from "../module-manifest";
 import type { DownloaderRegistry } from "./registry";
 import type { CommandRunner } from "./types";
 import { expandHome, runInstallCommands } from "./utils";
+import type { LoadOptions } from "./registry";
 
 const Logger = new Logging.Channel("loader.local-folder");
 
@@ -30,10 +31,18 @@ export function registerLocalFolderDownloader(
   registry.register(
     "local-folder",
     "path",
-    async (_cache: ModuleCache, source: ModuleSourceLocalFolder) => {
+    async (
+      _cache: ModuleCache,
+      source: ModuleSourceLocalFolder,
+      options?: LoadOptions,
+    ) => {
       const searchPath = expandHome(source.path);
       const entries = await fs.readdir(searchPath);
       const manifests: ModuleManifest[] = [];
+
+      const installCommand = options?.reload
+        ? (source.reloadCommand ?? source.installCommand)
+        : source.installCommand;
 
       for (const name of entries) {
         const folder = path.join(searchPath, name);
@@ -46,7 +55,7 @@ export function registerLocalFolderDownloader(
           Logger,
           moduleName,
           folder,
-          source.installCommand,
+          installCommand,
         );
         const moduleSource: ModuleSourceLocal = {
           type: "local",

--- a/src/core/downloaders/local.ts
+++ b/src/core/downloaders/local.ts
@@ -43,23 +43,17 @@ export function registerLocalDownloader(
         );
       }
 
-      if (!options?.reload) {
-        await runInstallCommands(
-          exec,
-          Logger,
-          formattedPath,
-          formattedPath,
-          source.installCommand,
-        );
-      } else {
-        await runInstallCommands(
-          exec,
-          Logger,
-          formattedPath,
-          formattedPath,
-          source.reloadCommand ?? source.installCommand,
-        );
-      }
+      const installCommand = options?.reload
+        ? (source.reloadCommand ?? source.installCommand)
+        : source.installCommand;
+
+      await runInstallCommands(
+        exec,
+        Logger,
+        formattedPath,
+        formattedPath,
+        installCommand,
+      );
 
       const name = source.id ?? path.basename(formattedPath);
       const manifest = await ModuleManifest.create(

--- a/src/core/downloaders/local.ts
+++ b/src/core/downloaders/local.ts
@@ -9,6 +9,7 @@ import { ModuleManifest } from "../module-manifest";
 import type { DownloaderRegistry } from "./registry";
 import type { CommandRunner } from "./types";
 import { expandHome, runInstallCommands } from "./utils";
+import type { LoadOptions } from "./registry";
 
 const Logger = new Logging.Channel("loader.local");
 
@@ -27,7 +28,11 @@ export function registerLocalDownloader(
   registry.register(
     "local",
     "path",
-    async (_cache: ModuleCache, source: ModuleSourceLocal) => {
+    async (
+      _cache: ModuleCache,
+      source: ModuleSourceLocal,
+      options?: LoadOptions,
+    ) => {
       const formattedPath = expandHome(source.path);
       if (!(await fs.exists(formattedPath))) {
         Logger.Error(
@@ -38,13 +43,23 @@ export function registerLocalDownloader(
         );
       }
 
-      await runInstallCommands(
-        exec,
-        Logger,
-        formattedPath,
-        formattedPath,
-        source.installCommand,
-      );
+      if (!options?.reload) {
+        await runInstallCommands(
+          exec,
+          Logger,
+          formattedPath,
+          formattedPath,
+          source.installCommand,
+        );
+      } else {
+        await runInstallCommands(
+          exec,
+          Logger,
+          formattedPath,
+          formattedPath,
+          source.reloadCommand ?? source.installCommand,
+        );
+      }
 
       const name = source.id ?? path.basename(formattedPath);
       const manifest = await ModuleManifest.create(

--- a/src/core/downloaders/local.ts
+++ b/src/core/downloaders/local.ts
@@ -6,10 +6,9 @@ import { ExecuteCMD } from "../cli/command";
 import { NodeFileSystem } from "../filesystem";
 import type { ModuleCache } from "../module-cache";
 import { ModuleManifest } from "../module-manifest";
-import type { DownloaderRegistry } from "./registry";
+import type { DownloaderRegistry, LoadOptions } from "./registry";
 import type { CommandRunner } from "./types";
 import { expandHome, runInstallCommands } from "./utils";
-import type { LoadOptions } from "./registry";
 
 const Logger = new Logging.Channel("loader.local");
 

--- a/src/core/downloaders/registry.ts
+++ b/src/core/downloaders/registry.ts
@@ -6,14 +6,20 @@ import type { ModuleManifest } from "../module-manifest";
 
 const Logger = new Logging.Channel("loader.common");
 
+export interface LoadOptions {
+  reload?: boolean;
+}
+
 export type ModuleLoader<T extends ModuleSource = ModuleSource> = (
   cache: ModuleCache,
   source: T,
+  options?: LoadOptions,
 ) => Promise<ModuleManifest[]>;
 
 type WaitingType = {
   cache: ModuleCache;
   source: ModuleSource;
+  options?: LoadOptions;
   resolve: (info: ModuleManifest[]) => void;
   reject: (error?: unknown) => void;
 };
@@ -34,7 +40,7 @@ export class DownloaderRegistry {
     const waitingList = this.waiting.get(type);
     if (waitingList) {
       for (const waiter of waitingList) {
-        void loader(waiter.cache, waiter.source as T).then(
+        void loader(waiter.cache, waiter.source as T, waiter.options).then(
           waiter.resolve,
           waiter.reject,
         );
@@ -47,6 +53,7 @@ export class DownloaderRegistry {
     projectFolder: string,
     cache: ModuleCache,
     source: ModuleSource,
+    options?: LoadOptions,
   ): Promise<ModuleManifest[]> {
     Logger.Debug(`LoadModule called for type ${source.type}`);
     const type = this.knownTypes.get(source.type);
@@ -61,7 +68,7 @@ export class DownloaderRegistry {
           );
         }
       }
-      return type.loader(cache, source as any);
+      return type.loader(cache, source as any, options);
     }
 
     Logger.Info(`No loader found for type ${source.type}, adding to waitlist`);
@@ -71,7 +78,7 @@ export class DownloaderRegistry {
         waitingList = [];
         this.waiting.set(source.type, waitingList);
       }
-      waitingList.push({ cache, source, resolve, reject });
+      waitingList.push({ cache, source, options, resolve, reject });
     });
   }
 

--- a/src/core/runtime/module-loading.ts
+++ b/src/core/runtime/module-loading.ts
@@ -307,6 +307,7 @@ async function loadModuleManifestFromSource(
   loaderContext: LoaderContext,
   source: ModuleSource,
   moduleId: string,
+  reload = false,
 ): Promise<ModuleManifest> {
   const manifests = await loaderContext.registry.load(
     loaderContext.projectFolder,
@@ -315,6 +316,7 @@ async function loadModuleManifestFromSource(
       ...source,
       id: moduleId,
     },
+    { reload },
   );
   const [manifest] = manifests;
   if (!manifest) {
@@ -349,6 +351,7 @@ async function reloadLoadedModuleFromSource(
     loaderContext,
     entry.module.manifest.source,
     moduleId,
+    true,
   );
   const replacement = new Module(manifest);
   ensureReloadedModuleId(replacement, moduleId);

--- a/src/core/watch/hot-reload.ts
+++ b/src/core/watch/hot-reload.ts
@@ -7,7 +7,10 @@ const Logger = new Logging.Channel("loader.hot-reload");
 
 export class HotReload {
   private pending = new Set<string>();
+  private inFlight = new Set<string>();
+  private rePending = new Set<string>();
   private timer?: NodeJS.Timeout;
+  private flushing = false;
 
   constructor(
     private reload: ReloadHandler,
@@ -15,21 +18,12 @@ export class HotReload {
   ) {}
 
   queue(moduleId: string): void {
-    this.pending.add(moduleId);
-    if (!this.timer) {
-      this.timer = setTimeout(async () => {
-        const modules = Array.from(this.pending);
-        this.pending.clear();
-        this.timer = undefined;
-        for (const id of modules) {
-          try {
-            await this.reload(id);
-          } catch (err) {
-            Logger.Error(`Failed to reload module ${id}:`, err);
-          }
-        }
-      }, this.debounceMs);
+    if (this.inFlight.has(moduleId)) {
+      this.rePending.add(moduleId);
+      return;
     }
+    this.pending.add(moduleId);
+    this.scheduleFlush();
   }
 
   clear(): void {
@@ -38,5 +32,51 @@ export class HotReload {
       this.timer = undefined;
     }
     this.pending.clear();
+    this.rePending.clear();
+  }
+
+  private scheduleFlush(): void {
+    if (this.timer || this.flushing) {
+      return;
+    }
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      void this.flush();
+    }, this.debounceMs);
+  }
+
+  private async flush(): Promise<void> {
+    if (this.flushing) {
+      return;
+    }
+    this.flushing = true;
+    try {
+      while (this.pending.size > 0) {
+        const modules = Array.from(this.pending);
+        this.pending.clear();
+        for (const id of modules) {
+          await this.reloadOne(id);
+        }
+        if (this.rePending.size > 0) {
+          for (const id of this.rePending) {
+            this.pending.add(id);
+          }
+          this.rePending.clear();
+        }
+      }
+    } finally {
+      this.flushing = false;
+    }
+  }
+
+  private async reloadOne(moduleId: string): Promise<void> {
+    this.inFlight.add(moduleId);
+    try {
+      await this.reload(moduleId);
+    } catch (err) {
+      Logger.Error(`Failed to reload module ${moduleId}:`, err);
+    } finally {
+      this.inFlight.delete(moduleId);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Serialize hot-reload per `moduleId` so concurrent file changes can't race on `tsc` output and the module lifecycle.
- Add `LoadOptions { reload?: boolean }` plumbed through `DownloaderRegistry.load` / `ModuleLoader`. On the hot-reload path, `local` and `local-folder` downloaders prefer `source.reloadCommand` over `source.installCommand` so projects can skip `pnpm install` (and similar) during dev.

The `reloadCommand` field itself is added in https://github.com/AntelopeJS/interface-core/pull/2 — merging this PR without that one is harmless (the field is read as `undefined` and we fall back to `installCommand`, current behaviour).

## Why

In watch mode, rapid back-to-back edits to a module were producing overlapping reload cycles. Each reload runs the configured install commands (e.g. `pnpm install && pnpm exec tsc`), destroys the live module, swaps in a fresh `Module`, then constructs. Two of these in flight at once would:
- race on the module's `dist/` output (concurrent `tsc` invocations writing the same files)
- leave the lifecycle in an indeterminate state if destroy of one overlapped with construct of the next
- produce double-registrations against shared maps

Reproduced cleanly against cms-back + cms-automation: 5 saves within 5s used to fire 5 overlapping `LoadModule` calls; now they queue and run one-at-a-time.

Separately, every reload was re-running the full `installCommand` (typically `pnpm install` + `pnpm exec tsc`). The `pnpm install` is a no-op in the common dev loop but still costs ~1s. `reloadCommand` lets the project opt into a cheaper command on reload.

## Test plan

- [x] Manual: cms-back watch loop — single edit reloads in ~1s (was ~2s) with `reloadCommand: [\"pnpm exec tsc\"]`
- [x] Manual: 5 rapid edits to one module — 5 sequential reloads, no overlapping `LoadModule` (was 5 overlapping before)
- [x] Manual: edit broken → fix → reload recovers cleanly (no orphan state)
- [x] Module without `reloadCommand` set still runs `installCommand` (no behaviour change)
- [ ] CI test suite

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two independent improvements to watch/hot-reload: it serialises all module reloads through a `while`-loop flush with per-module `inFlight`/`rePending` tracking to eliminate overlapping reload cycles, and it plumbs a new `LoadOptions { reload? }` flag through the downloader stack so that `local` and `local-folder` sources can prefer a cheaper `reloadCommand` instead of the full `installCommand` during dev reloads.

- **`HotReload` serialisation** (`hot-reload.ts`): replaces the single-shot `setTimeout` callback with a `flush()` while-loop that processes pending modules sequentially; concurrent file changes for the same module accumulate in `rePending` and replay exactly once after the in-progress reload finishes, preventing overlapping `tsc` invocations and module lifecycle races.
- **`reloadCommand` plumbing** (`registry.ts`, `local.ts`, `local-folder.ts`, `module-loading.ts`): the `reload` flag is threaded from `reloadWatchedModule` → `DownloaderRegistry.load` → each downloader; `local-folder` correctly propagates `reloadCommand` onto each sub-module's stored `moduleSource` so subsequent per-module hot-reloads also use the cheaper command.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the serialisation logic is correct and the reloadCommand fallback is backwards-compatible.

The flush() while-loop correctly handles every interleaving: new pending items added while flushing are picked up by the next while iteration, rePending items are always moved to pending before the while condition is re-evaluated, and the inFlight invariant guarantees that any module appearing in rePending will always be processed. The reloadCommand propagation is complete — the field is stored on sub-module sources in local-folder and applied at the correct layer in both downloaders, with a correct fallback to installCommand when absent. No existing call sites were broken; the reload flag defaults to false everywhere except the explicit hot-reload path.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/core/watch/hot-reload.ts | Replaced the single-shot debounce with a while-loop flush that serializes all reloads; adds inFlight/rePending tracking so concurrent file changes for the same module queue up and replay exactly once after the in-progress reload finishes. |
| src/core/downloaders/registry.ts | Exports new LoadOptions interface and threads options through WaitingType, ModuleLoader, and both the eager and waitlisted loader dispatch paths — clean, correct plumbing. |
| src/core/downloaders/local.ts | Selects reloadCommand ?? installCommand when options.reload is true, falling back gracefully when reloadCommand is absent — correct. |
| src/core/downloaders/local-folder.ts | Applies the same reloadCommand selection for all sub-folder installs and also persists reloadCommand onto each sub-module's stored moduleSource, ensuring sub-modules can also use the cheaper reload command on subsequent hot-reloads. |
| src/core/runtime/module-loading.ts | Adds reload = false default param to loadModuleManifestFromSource and passes { reload: true } on the hot-reload path only — no change on initial load or the LoadModule API path. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/core/downloaders/local-folder.ts`, line 60-65 ([link](https://github.com/antelopejs/antelopejs/blob/bb34f0db0efa9155fa761c95c2447da9eccf3c45/src/core/downloaders/local-folder.ts#L60-L65)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`reloadCommand` not propagated to per-folder `moduleSource`**

   The `installCommand` is correctly resolved at download time using the `reloadCommand`/`installCommand` selection, but the `moduleSource` object stored in each submodule's manifest only copies `installCommand` from the parent source — `reloadCommand` is dropped. When `reloadLoadedModuleFromSource` later reloads one of these submodules it passes `entry.module.manifest.source` (the stored `moduleSource`) to the `local` downloader with `reload: true`. Because `source.reloadCommand` is `undefined` on that stored source, the `local` downloader unconditionally falls back to `source.installCommand`, silently ignoring the `reloadCommand` field and negating the entire optimization for `local-folder` modules.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/core/downloaders/local-folder.ts
   Line: 60-65

   Comment:
   **`reloadCommand` not propagated to per-folder `moduleSource`**

   The `installCommand` is correctly resolved at download time using the `reloadCommand`/`installCommand` selection, but the `moduleSource` object stored in each submodule's manifest only copies `installCommand` from the parent source — `reloadCommand` is dropped. When `reloadLoadedModuleFromSource` later reloads one of these submodules it passes `entry.module.manifest.source` (the stored `moduleSource`) to the `local` downloader with `reload: true`. Because `source.reloadCommand` is `undefined` on that stored source, the `local` downloader unconditionally falls back to `source.installCommand`, silently ignoring the `reloadCommand` field and negating the entire optimization for `local-folder` modules.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/antelopejs/antelopejs/commit/decca2abf5f2d228e5443a56fd6790440ca3e070) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35610137)</sub>

<!-- /greptile_comment -->