### PR TITLE
fix(version-checker): surface npm registry failures during startup

### DIFF
--- a/src/core/version-checker.ts
+++ b/src/core/version-checker.ts
@@ -1,5 +1,5 @@
 import type { ModuleSourcePackage } from "@antelopejs/interface-core/config";
-import { warning } from "./cli/cli-ui";
+import { info as infoMessage, warning } from "./cli/cli-ui";
 import { ExecuteCMD } from "./cli/command";
 import { parsePackageInfoOutput } from "./cli/package-manager";
 import type { ExpandedModuleConfig } from "./config/config-parser";
@@ -13,19 +13,15 @@ export interface OutdatedModule {
 const NPM_VIEW_COMMAND = "npm view";
 const VERSION_ARGUMENT = "version";
 const UPDATE_COMMAND = "ajs project modules update";
+const SLOW_CHECK_THRESHOLD_MS = 15_000;
+const MAX_REASON_LENGTH = 200;
 
-export async function fetchLatestVersion(
-  packageName: string,
-): Promise<string | undefined> {
-  try {
-    const result = await ExecuteCMD(
-      `${NPM_VIEW_COMMAND} ${packageName} ${VERSION_ARGUMENT}`,
-      {},
-    );
-    return parsePackageInfoOutput(result.stdout);
-  } catch {
-    return undefined;
-  }
+export async function fetchLatestVersion(packageName: string): Promise<string> {
+  const result = await ExecuteCMD(
+    `${NPM_VIEW_COMMAND} ${packageName} ${VERSION_ARGUMENT}`,
+    {},
+  );
+  return parsePackageInfoOutput(result.stdout);
 }
 
 export async function checkOutdatedModules(
@@ -35,16 +31,46 @@ export async function checkOutdatedModules(
     ([, info]) => info.source?.type === "package",
   );
 
-  const results = await Promise.allSettled(
-    packageModules.map(([, info]) =>
-      fetchLatestVersion((info.source as ModuleSourcePackage).package),
-    ),
-  );
+  if (packageModules.length === 0) {
+    return [];
+  }
+
+  infoMessage("Checking for module updates...");
+
+  const slowWarning = setTimeout(() => {
+    warning(
+      "Module version check is taking longer than expected — the npm registry may be slow or unreachable. " +
+        "Set NPM_CONFIG_FETCH_RETRIES=0 to fail fast.",
+    );
+  }, SLOW_CHECK_THRESHOLD_MS);
+
+  let results: PromiseSettledResult<string>[];
+  try {
+    results = await Promise.allSettled(
+      packageModules.map(([, info]) =>
+        fetchLatestVersion((info.source as ModuleSourcePackage).package),
+      ),
+    );
+  } finally {
+    clearTimeout(slowWarning);
+  }
 
   return packageModules.reduce<OutdatedModule[]>(
     (outdated, [name, info], index) => {
       const result = results[index];
-      if (result.status !== "fulfilled" || !result.value) {
+      const packageName = (info.source as ModuleSourcePackage).package;
+      if (result.status === "rejected") {
+        const reason = String(result.reason ?? "unknown error");
+        const truncated =
+          reason.length > MAX_REASON_LENGTH
+            ? `${reason.slice(0, MAX_REASON_LENGTH)}…`
+            : reason;
+        warning(
+          `Could not check latest version of ${packageName}: ${truncated}`,
+        );
+        return outdated;
+      }
+      if (!result.value) {
         return outdated;
       }
       const current = (info.source as ModuleSourcePackage).version;

--- a/test/core/version-checker.test.ts
+++ b/test/core/version-checker.test.ts
@@ -170,6 +170,82 @@ describe("version-checker", () => {
       expect(warned).to.include("mod-a");
       expect(warned).to.include("network error");
     });
+
+    it("emits the slow-check warning when probes exceed the threshold", async () => {
+      const clock = sinon.useFakeTimers();
+      let resolveExec: (value: {
+        code: number;
+        stdout: string;
+        stderr: string;
+      }) => void = () => {};
+      sinon.stub(command, "ExecuteCMD").returns(
+        new Promise((resolve) => {
+          resolveExec = resolve;
+        }),
+      );
+      const warnStub = sinon.stub(cliUi, "warning");
+
+      const packageSource: ModuleSourcePackage = {
+        type: "package",
+        package: "mod-a",
+        version: "1.0.0",
+      };
+      const modules: Record<string, ExpandedModuleConfig> = {
+        "mod-a": {
+          source: packageSource,
+          config: {},
+          importOverrides: [],
+          disabledExports: [],
+        },
+      };
+
+      const pending = checkOutdatedModules(modules);
+
+      await clock.tickAsync(14_999);
+      expect(warnStub.called).to.equal(false);
+
+      await clock.tickAsync(2);
+      expect(warnStub.calledOnce).to.equal(true);
+      expect(String(warnStub.firstCall.args[0])).to.include(
+        "longer than expected",
+      );
+
+      resolveExec({ code: 0, stdout: "1.0.0\n", stderr: "" });
+      await clock.runAllAsync();
+      await pending;
+
+      expect(warnStub.calledOnce).to.equal(true);
+    });
+
+    it("does not emit the slow-check warning when probes finish quickly", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(command, "ExecuteCMD").resolves({
+        code: 0,
+        stdout: "1.0.0\n",
+        stderr: "",
+      });
+      const warnStub = sinon.stub(cliUi, "warning");
+
+      const packageSource: ModuleSourcePackage = {
+        type: "package",
+        package: "mod-a",
+        version: "1.0.0",
+      };
+      const modules: Record<string, ExpandedModuleConfig> = {
+        "mod-a": {
+          source: packageSource,
+          config: {},
+          importOverrides: [],
+          disabledExports: [],
+        },
+      };
+
+      const pending = checkOutdatedModules(modules);
+      await clock.runAllAsync();
+      await pending;
+
+      expect(warnStub.called).to.equal(false);
+    });
   });
 
   describe("warnOutdatedModules", () => {

--- a/test/core/version-checker.test.ts
+++ b/test/core/version-checker.test.ts
@@ -31,16 +31,23 @@ describe("version-checker", () => {
       expect(result).to.equal("1.2.3");
     });
 
-    it("returns undefined when npm view fails", async () => {
+    it("rejects when npm view fails", async () => {
       sinon.stub(command, "ExecuteCMD").rejects(new Error("network error"));
 
-      const result = await fetchLatestVersion("some-package");
-
-      expect(result).to.equal(undefined);
+      try {
+        await fetchLatestVersion("some-package");
+        expect.fail("expected fetchLatestVersion to reject");
+      } catch (err) {
+        expect(String(err)).to.include("network error");
+      }
     });
   });
 
   describe("checkOutdatedModules", () => {
+    beforeEach(() => {
+      sinon.stub(cliUi, "info");
+    });
+
     it("returns outdated modules only", async () => {
       const execStub = sinon.stub(command, "ExecuteCMD");
       execStub.callsFake(async (cmd: string) => {
@@ -122,12 +129,13 @@ describe("version-checker", () => {
       expect(result).to.deep.equal([]);
     });
 
-    it("handles fetch failures gracefully", async () => {
+    it("warns and skips packages whose version probe fails", async () => {
       const execStub = sinon.stub(command, "ExecuteCMD");
       execStub.callsFake(async (cmd: string) => {
         if (cmd.includes("mod-a")) throw new Error("network error");
         return { code: 0, stdout: "1.0.0\n", stderr: "" };
       });
+      const warnStub = sinon.stub(cliUi, "warning");
 
       const packageSourceA: ModuleSourcePackage = {
         type: "package",
@@ -157,6 +165,10 @@ describe("version-checker", () => {
       const result = await checkOutdatedModules(modules);
 
       expect(result).to.deep.equal([]);
+      expect(warnStub.calledOnce).to.equal(true);
+      const warned = String(warnStub.firstCall.args[0]);
+      expect(warned).to.include("mod-a");
+      expect(warned).to.include("network error");
     });
   });
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A — user-reported bug, no tracking issue.

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`ajs project run` would appear to freeze on `Starting AntelopeJS project` for ~70s with no output whenever the npm registry was slow or unreachable. Real-world trigger: `npm.antelopejs.cloud` started returning HTTP 525 (Cloudflare SSL handshake failed), each `npm view @antelopejs-private/...` retried 3× and timed out at ~70s, and `checkOutdatedModules` ran them in parallel via `Promise.allSettled` while silently discarding rejections.

The registry outage is external — the bug is that AntelopeJS gave the user zero feedback during the wait, so it looked like a freeze.

This PR keeps the same non-fatal semantics (startup still proceeds) but stops the silent failures:

- `fetchLatestVersion` no longer swallows errors with a bare `catch {}` — rejections propagate to `Promise.allSettled`.
- `checkOutdatedModules` now emits a per-package `⚠ Could not check latest version of <pkg>: <reason>` warning when a probe rejects (reason truncated to 200 chars so a registry-wide outage doesn't dump a wall of stderr).
- A status line `ℹ Checking for module updates…` is logged before the parallel probe so the user sees activity instead of silence.
- A one-shot 15s `setTimeout` fires a warning mid-wait hinting at `NPM_CONFIG_FETCH_RETRIES=0` for fail-fast. Cleared on settle.

All changes localised to `src/core/version-checker.ts`; caller signatures unchanged.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [ ] I have run \`ajs module exports generate\` and committed any updated interface files.

### Test plan

- Existing unit tests updated: \`fetchLatestVersion\` now asserts rejection (was \`undefined\`); the failure-handling \`checkOutdatedModules\` test now asserts a warning fires with the package name and error reason.
- Manual: ran locally with a temporary fake-lag/fake-fail env-var hook (now removed) to confirm the progress line, per-package warning, and 15s slow-warning all render correctly under simulated registry hangs.
- 512 unit tests pass; \`pnpm build\` clean; \`pnpm lint\` clean (no new findings).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UX regression where `ajs project run` would silently freeze for ~70 seconds when the npm registry was unreachable, because `fetchLatestVersion` swallowed all errors and `checkOutdatedModules` discarded `Promise.allSettled` rejections with no user feedback.

- **`fetchLatestVersion`** now lets errors propagate rather than returning `undefined`, so `Promise.allSettled` receives real rejections and the caller can inspect the reason.
- **`checkOutdatedModules`** now emits a status line before parallel probing, a per-package warning (truncated to 200 chars) when a probe rejects, and a 15-second slow-warning `setTimeout` that hints at `NPM_CONFIG_FETCH_RETRIES=0`; the timer is cancelled in a `finally` block so it never fires after the probes settle.
- Tests cover all new branches: rejection propagation from `fetchLatestVersion`, per-package failure warnings, the slow-warning firing after 15 s, and the timer being suppressed on fast completion.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are fully contained within version-checker.ts, startup still proceeds on registry failure, and no caller signatures are broken.

The diff replaces a silent error-swallow with user-visible warnings and a progress indicator. The finally clearTimeout pattern is correct, Promise.allSettled handles all settlement cases, and the new tests exercise every added branch including fake-timer paths for the slow-warning. No existing behaviour is removed; the change is strictly additive UX improvement.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/version-checker.ts | Removes silent error-swallowing from fetchLatestVersion, adds info/warn UX signals to checkOutdatedModules, and guards the 15s slow-warning timer with try/finally clearTimeout. Logic is correct and all edge cases (empty value, rejection, fast/slow probes) are handled. |
| test/core/version-checker.test.ts | Test suite updated to assert rejection from fetchLatestVersion, and adds four targeted tests for per-package failure warnings plus the slow-warning timer (both fire and no-fire paths). Uses sinon.useFakeTimers + clock.tickAsync correctly; afterEach(sinon.restore) cleans up fake clocks. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant checkOutdatedModules
    participant setTimeout as setTimeout (15 s)
    participant fetchLatestVersion
    participant ExecuteCMD
    participant cliUi

    Caller->>checkOutdatedModules: checkOutdatedModules(modules)
    checkOutdatedModules->>cliUi: info("Checking for module updates...")
    checkOutdatedModules->>setTimeout: schedule slow-warning (15 000 ms)
    checkOutdatedModules->>fetchLatestVersion: fetchLatestVersion(pkg) x N (parallel)
    fetchLatestVersion->>ExecuteCMD: npm view pkg version

    alt Registry responds quickly
        ExecuteCMD-->>fetchLatestVersion: stdout 1.2.3
        fetchLatestVersion-->>checkOutdatedModules: resolves 1.2.3
        checkOutdatedModules->>setTimeout: clearTimeout (cancels warning)
    else "Registry slow > 15 s"
        setTimeout-->>cliUi: warning taking longer than expected
        ExecuteCMD-->>fetchLatestVersion: stdout 1.2.3
        fetchLatestVersion-->>checkOutdatedModules: resolves 1.2.3
        checkOutdatedModules->>setTimeout: clearTimeout (already fired, no-op)
    else Registry unreachable
        ExecuteCMD-->>fetchLatestVersion: throws Error
        fetchLatestVersion-->>checkOutdatedModules: rejects (propagated)
        Note over checkOutdatedModules: Promise.allSettled captures rejection
        checkOutdatedModules->>setTimeout: clearTimeout
        checkOutdatedModules->>cliUi: warning Could not check latest version of pkg
    end

    checkOutdatedModules-->>Caller: OutdatedModule[]
```

<sub>Reviews (2): Last reviewed commit: ["test(version-checker): cover slow-check ..."](https://github.com/antelopejs/antelopejs/commit/e51b5d3b2ec1a94555d432c58e51a8d575af2ca9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35641126)</sub>

<!-- /greptile_comment -->