### PR TITLE
fix(cli): propagate module test failures as non-zero exit code

### DIFF
--- a/src/core/cli/commands/module/test.ts
+++ b/src/core/cli/commands/module/test.ts
@@ -40,7 +40,10 @@ export async function moduleTestCommand(
     `Valid module found: ${chalk.cyan(moduleManifest.name)}`,
   );
 
-  await TestModule(resolvedPath, options.file);
+  const failures = await TestModule(resolvedPath, options.file);
+  if (failures > 0) {
+    process.exitCode = 1;
+  }
 }
 
 const filesOption = new Option(

--- a/test/core/cli/commands/module/test.behavior.test.ts
+++ b/test/core/cli/commands/module/test.behavior.test.ts
@@ -43,6 +43,28 @@ describe("module test behavior", () => {
     expect(testStub.firstCall.args[1]).to.deep.equal(["/tmp/test.ts"]);
   });
 
+  it("sets exitCode=1 when TestModule reports failures", async () => {
+    sinon.stub(common, "readModuleManifest").resolves({ name: "modA" } as any);
+    sinon.stub(cliUi.Spinner.prototype, "start").resolves();
+    sinon.stub(cliUi.Spinner.prototype, "succeed").resolves();
+    sinon.stub(testModuleModule, "TestModule").resolves(3);
+
+    await moduleTestCommand("/tmp/module", { file: [] });
+
+    expect(process.exitCode).to.equal(1);
+  });
+
+  it("leaves exitCode unset when TestModule reports zero failures", async () => {
+    sinon.stub(common, "readModuleManifest").resolves({ name: "modA" } as any);
+    sinon.stub(cliUi.Spinner.prototype, "start").resolves();
+    sinon.stub(cliUi.Spinner.prototype, "succeed").resolves();
+    sinon.stub(testModuleModule, "TestModule").resolves(0);
+
+    await moduleTestCommand("/tmp/module", { file: [] });
+
+    expect(process.exitCode).to.equal(undefined);
+  });
+
   it("parses file options and forwards them", async () => {
     sinon.stub(common, "readModuleManifest").resolves({ name: "modA" } as any);
     sinon.stub(cliUi.Spinner.prototype, "start").resolves();


### PR DESCRIPTION
## Summary
- `ajs module test` awaited `TestModule` and discarded its return value, so mocha-reported failures were printed to stdout while the process still exited 0 — leaving CI green on red runs.
- Capture the failure count returned by `TestModule` and set `process.exitCode = 1` when non-zero. `TestModule` already used the same `EXIT_CODE_ERROR = 1` for harness-level errors (missing config, no test files), so both real failures and harness errors now surface to the shell.
- Added two regression tests in `test/core/cli/commands/module/test.behavior.test.ts` covering both branches.

## Test plan
- [x] `pnpm test:unit` — 514 passing (was 512; +2 new cases)
- [x] `pnpm lint` — clean
- [x] Confirm a downstream interface repo (e.g. `interface-database` on the pre-1.2.1 branch where 32 tests failed silently) now exits non-zero when invoked through the published CLI

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent CI failure where `ajs module test` would print mocha failures to stdout but exit with code 0, leaving pipelines green on red runs. The fix is minimal and correct: capture the return value of `TestModule` and set `process.exitCode = 1` when it is non-zero.

- **`src/core/cli/commands/module/test.ts`**: Captures the numeric return of `TestModule` (failure count or harness-error sentinel `1`) and sets `process.exitCode = 1` for any non-zero value.
- **`test/core/cli/commands/module/test.behavior.test.ts`**: Adds two regression tests — one asserting `process.exitCode === 1` when `TestModule` resolves with `3`, and one asserting it remains `undefined` when `TestModule` resolves with `0`. Both tests are properly isolated via the existing `afterEach` that resets `process.exitCode`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a three-line addition that captures a previously discarded return value and propagates it to the shell exit code.

The fix is minimal and targeted: it only adds a capture of TestModule's numeric return value and a conditional process.exitCode assignment. TestModule already documented and consistently returned a failure count (or the harness-error sentinel 1), so the new failures > 0 guard maps cleanly onto both error cases. The two new regression tests cover the happy path and the failure path with proper afterEach isolation, and the existing suite continues to pass.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/cli/commands/module/test.ts | Captures the return value of TestModule and sets process.exitCode = 1 for non-zero failure counts; change is minimal and correct. |
| test/core/cli/commands/module/test.behavior.test.ts | Adds two regression tests covering both the failure-count (>0) and zero-failure branches; afterEach correctly resets process.exitCode between tests. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Shell
    participant moduleTestCommand
    participant TestModule

    Shell->>moduleTestCommand: ajs module test [path]
    moduleTestCommand->>moduleTestCommand: readModuleManifest()
    alt manifest missing
        moduleTestCommand->>Shell: "process.exitCode = 1, return"
    end
    moduleTestCommand->>TestModule: await TestModule(resolvedPath, files)
    TestModule-->>moduleTestCommand: "failures (0 = all pass, >0 = failures or harness error)"
    alt "failures > 0"
        moduleTestCommand->>Shell: "process.exitCode = 1"
    else "failures === 0"
        moduleTestCommand->>Shell: process.exitCode unchanged (0)
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(cli): propagate test failures as non..."](https://github.com/antelopejs/antelopejs/commit/d6ba262d36dd5a5c18d8e53e3e8ae480814b9bf3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35645255)</sub>

<!-- /greptile_comment -->