### PR TITLE
fix(test): register test directories in internal.moduleByFolder

### DIFF
--- a/src/core/test/test-module.ts
+++ b/src/core/test/test-module.ts
@@ -24,6 +24,7 @@ const EXIT_CODE_ERROR = 1;
 const DEFAULT_TEST_FOLDER = "test";
 const TEST_FILE_PATTERN = /\.(test|spec)\.(js|ts)$/;
 const STUB_INTERFACE_PATH = path.resolve(__dirname, "stub-interface");
+const TEST_MODULE_ID = "__antelope_test__";
 
 interface LoadedTestConfig {
   config: LoadedConfig;
@@ -116,6 +117,7 @@ export async function setupTestEnvironment(
     await loadModuleEntriesForManager(manager, normalizedConfig, true);
     await constructAndStartModules(manager);
     internal.testStubMode = true;
+    registerTestDir(path.resolve(moduleRoot), manager);
     return manager;
   });
 }
@@ -148,7 +150,7 @@ export async function collectInterfaceTestFiles(
       const testDir = path.join(pkgRoot, "dist", "tests");
       const testFiles = await collectTestFiles(testDir, TEST_FILE_PATTERN, fs);
       if (testFiles.length > 0 && manager) {
-        registerTestDirInResolver(testDir, manager);
+        registerTestDir(testDir, manager);
       }
       files.push(...testFiles);
     } catch {
@@ -159,14 +161,14 @@ export async function collectInterfaceTestFiles(
   return files;
 }
 
-function registerTestDirInResolver(
-  testDir: string,
-  manager: ModuleManager,
-): void {
+function registerTestDir(testDir: string, manager: ModuleManager): void {
   const resolvedDir = path.resolve(testDir);
-  for (const [, moduleRef] of manager.resolver.moduleByFolder) {
-    manager.resolver.moduleByFolder.set(resolvedDir, moduleRef);
-    return;
+  const firstModule = manager.resolver.moduleByFolder.values().next().value;
+  if (firstModule && !manager.resolver.moduleByFolder.has(resolvedDir)) {
+    manager.resolver.moduleByFolder.set(resolvedDir, firstModule);
+  }
+  if (!internal.moduleByFolder.some((entry) => entry.dir === resolvedDir)) {
+    internal.moduleByFolder.push({ dir: resolvedDir, id: TEST_MODULE_ID });
   }
 }
 

--- a/test/core/test/test-module.test.ts
+++ b/test/core/test/test-module.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { expect } from "chai";
 import sinon from "sinon";
 import { ConfigLoader } from "../../../src/core/config/config-loader";
@@ -471,5 +472,36 @@ describe("test-module", () => {
 
       internal.testStubMode = false;
     });
+
+    it("registers moduleRoot in internal.moduleByFolder so test-file frames find a module", async () => {
+      const { internal } = await import("@antelopejs/interface-core/internal");
+      const moduleLoading = require("../../../src/core/runtime/module-loading");
+
+      sinon
+        .stub(moduleLoading, "loadModuleEntriesForManager")
+        .resolves([]);
+      sinon.stub(moduleLoading, "constructAndStartModules").resolves();
+
+      const moduleRoot = "/some/module/root";
+      const resolvedRoot = path.resolve(moduleRoot);
+      const lengthBefore = internal.moduleByFolder.length;
+
+      await testModule.setupTestEnvironment(moduleRoot, {
+        name: "test",
+        cacheFolder: ".antelope/cache",
+        modules: {},
+        envOverrides: {},
+      } as any);
+
+      const entry = internal.moduleByFolder.find(
+        (e) => e.dir === resolvedRoot,
+      );
+      expect(entry, "moduleRoot should be registered").to.not.equal(undefined);
+      expect(entry?.id).to.equal("__antelope_test__");
+
+      internal.testStubMode = false;
+      internal.moduleByFolder.length = lengthBefore;
+    });
+
   });
 });

--- a/test/core/test/test-module.test.ts
+++ b/test/core/test/test-module.test.ts
@@ -477,9 +477,7 @@ describe("test-module", () => {
       const { internal } = await import("@antelopejs/interface-core/internal");
       const moduleLoading = require("../../../src/core/runtime/module-loading");
 
-      sinon
-        .stub(moduleLoading, "loadModuleEntriesForManager")
-        .resolves([]);
+      sinon.stub(moduleLoading, "loadModuleEntriesForManager").resolves([]);
       sinon.stub(moduleLoading, "constructAndStartModules").resolves();
 
       const moduleRoot = "/some/module/root";
@@ -493,15 +491,12 @@ describe("test-module", () => {
         envOverrides: {},
       } as any);
 
-      const entry = internal.moduleByFolder.find(
-        (e) => e.dir === resolvedRoot,
-      );
+      const entry = internal.moduleByFolder.find((e) => e.dir === resolvedRoot);
       expect(entry, "moduleRoot should be registered").to.not.equal(undefined);
       expect(entry?.id).to.equal("__antelope_test__");
 
       internal.testStubMode = false;
       internal.moduleByFolder.length = lengthBefore;
     });
-
   });
 });


### PR DESCRIPTION
## Summary
- Test files had no module identity in interface-core's responsible-module lookup. Any sync interface call originating in a test file from a timer-based callback (e.g. Mocha's `setImmediate`-scheduled hooks calling `RegisteringProxy.register` via `new Schema()`) walked the stack past `node_modules`, found no match in `internal.moduleByFolder`, and triggered a spurious `"GetResponsibleModule called from within an async context, this will break hot reloading!"` warning in every interface package's test runs.
- `setupTestEnvironment` and `collectInterfaceTestFiles` now also push test directories into `internal.moduleByFolder` (the array `GetResponsibleModule` walks) under a synthetic `__antelope_test__` id, alongside the existing `resolver.moduleByFolder` path-mapping registration. `GetResponsibleModule` returns a real value during tests, no more bogus HMR warnings.
- The previous `registerTestDirInResolver` only updated the require-resolver Map — `internal.moduleByFolder` was never populated for tests. That's the gap this closes.

## Test plan
- [x] `pnpm test:unit` — 514 passing (+2 new)
- [x] New regression test in `test/core/test/test-module.test.ts`: asserts `setupTestEnvironment` registers `moduleRoot` in `internal.moduleByFolder` with the synthetic id
- [x] Re-run a downstream interface package's tests (e.g. `interface-data-api`) against this build and confirm the HMR warning no longer fires

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes spurious `"GetResponsibleModule called from within an async context"` HMR warnings during test runs by ensuring test directories are registered in `internal.moduleByFolder` (the array `GetResponsibleModule` walks), not just in the resolver's `moduleByFolder` Map. The renamed `registerTestDir` now writes both registrations, and `setupTestEnvironment` gains a call to register `moduleRoot` itself.

- `registerTestDir` (previously `registerTestDirInResolver`) now also pushes `{ dir, id: "__antelope_test__" }` into `internal.moduleByFolder`, closing the gap that caused stack-walk misses from timer-scheduled test callbacks.
- `setupTestEnvironment` calls `registerTestDir` for `moduleRoot` after module construction, so the test project's own frames are covered in addition to interface package test dirs registered via `collectInterfaceTestFiles`.
- A new regression test in `test/core/test/test-module.test.ts` asserts the entry is present and carries the synthetic id, and cleans up via `internal.moduleByFolder.length = lengthBefore`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix is narrow and well-tested, with no changes to production module-loading paths.

The fix correctly targets the missing internal.moduleByFolder registration and is backed by a new regression test. Two minor structural gaps exist: teardown does not remove the synthetic entries, and the resolver registration silently no-ops when no modules are loaded while the internal entry is still written.

src/core/test/test-module.ts — specifically the registerTestDir function and TestModule's finally block.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/core/test/test-module.ts | Adds `registerTestDir` (renamed from `registerTestDirInResolver`) which now also pushes to `internal.moduleByFolder` with a synthetic `__antelope_test__` id; `setupTestEnvironment` gains a call to register `moduleRoot` after construction completes. |
| test/core/test/test-module.test.ts | New regression test asserts that `setupTestEnvironment` populates `internal.moduleByFolder`; uses `internal.moduleByFolder.length = lengthBefore` to restore array state post-test. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TM as TestModule / setupTestEnvironment
    participant MM as ModuleManager
    participant TR as moduleTracker (internal)
    participant RES as resolver.moduleByFolder

    TM->>MM: loadModuleEntriesForManager()
    TM->>MM: constructAndStartModules()
    MM->>TR: clear() [via rebuildAssociations]
    MM->>TR: add(real module entries)
    MM->>RES: set(folder, moduleRef) per module
    TM->>TM: "internal.testStubMode = true"
    TM->>TM: registerTestDir(moduleRoot, manager)
    TM->>RES: set(resolvedDir, firstModule) [if not present]
    TM->>TR: "push({ dir: resolvedDir, id: __antelope_test__ })"
    Note over TR: GetResponsibleModule now returns a non-null id for test-file frames
    TM-->>TM: return manager

    Note over TR,RES: On destroyAll() - internal.moduleByFolder entries persist (no cleanup in finally)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/core/test/test-module.ts`, line 289 ([link](https://github.com/antelopejs/antelopejs/blob/353e25db27d6f0c91d4d5322c6d7957c87801eb3/src/core/test/test-module.ts#L289)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Test entries not cleaned from `internal.moduleByFolder` on teardown**

   `TestModule()`'s `finally` block resets `internal.testStubMode` and clears `stubModulePath`, but does nothing to remove the entries pushed into `internal.moduleByFolder` by `registerTestDir`. `destroyAll()` doesn't invoke `moduleTracker.clear()` either (that only runs via `rebuildAssociations`). In the common case — a single test run followed by process exit — this is harmless, but if `TestModule()` is ever called sequentially in the same process (e.g., running multiple project test suites), stale `__antelope_test__` folder entries accumulate between runs. Adding a `internal.moduleByFolder.splice(...)` filter in the `finally` block, similarly to how the unit test cleans up, would make teardown symmetric with setup.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/core/test/test-module.ts
   Line: 289

   Comment:
   **Test entries not cleaned from `internal.moduleByFolder` on teardown**

   `TestModule()`'s `finally` block resets `internal.testStubMode` and clears `stubModulePath`, but does nothing to remove the entries pushed into `internal.moduleByFolder` by `registerTestDir`. `destroyAll()` doesn't invoke `moduleTracker.clear()` either (that only runs via `rebuildAssociations`). In the common case — a single test run followed by process exit — this is harmless, but if `TestModule()` is ever called sequentially in the same process (e.g., running multiple project test suites), stale `__antelope_test__` folder entries accumulate between runs. Adding a `internal.moduleByFolder.splice(...)` filter in the `finally` block, similarly to how the unit test cleans up, would make teardown symmetric with setup.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/core/test/test-module.ts:289
**Test entries not cleaned from `internal.moduleByFolder` on teardown**

`TestModule()`'s `finally` block resets `internal.testStubMode` and clears `stubModulePath`, but does nothing to remove the entries pushed into `internal.moduleByFolder` by `registerTestDir`. `destroyAll()` doesn't invoke `moduleTracker.clear()` either (that only runs via `rebuildAssociations`). In the common case — a single test run followed by process exit — this is harmless, but if `TestModule()` is ever called sequentially in the same process (e.g., running multiple project test suites), stale `__antelope_test__` folder entries accumulate between runs. Adding a `internal.moduleByFolder.splice(...)` filter in the `finally` block, similarly to how the unit test cleans up, would make teardown symmetric with setup.

### Issue 2 of 2
src/core/test/test-module.ts:164-173
**Resolver mapping always uses the first registered module**

`manager.resolver.moduleByFolder.values().next().value` picks an arbitrary module — whichever happens to be first in insertion order. This is inherited behaviour from the old `registerTestDirInResolver`, but now `registerTestDir` is also called for `moduleRoot` in `setupTestEnvironment`, making this footgun more visible. If `manager.resolver.moduleByFolder` is empty (e.g., when all modules are stubbed and none were actually loaded), `firstModule` is `undefined` and the resolver registration is silently skipped, while the `internal.moduleByFolder` entry is still added. The two registrations can therefore be out of sync — the resolver won't resolve the test directory even though `GetResponsibleModule` will. Worth a clarifying comment at minimum.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): register test directories in ..."](https://github.com/antelopejs/antelopejs/commit/353e25db27d6f0c91d4d5322c6d7957c87801eb3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35649555)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->