### PR TITLE
fix(shutdown): keep graceful shutdown on terminal Ctrl+C in inspector mode

### DIFF
--- a/src/core/cli/commands/project/dev.ts
+++ b/src/core/cli/commands/project/dev.ts
@@ -32,7 +32,7 @@ export interface DevCommandOptions extends LaunchOptions {
 const DEFAULT_INSPECTOR = "--inspect";
 const RUNNER_PREFIX = "antelope-runner-";
 const DEFAULT_INSPECT_HOST = "127.0.0.1:9229";
-const CHILD_TERMINATE_TIMEOUT_MS = 5000;
+const CHILD_TERMINATE_TIMEOUT_MS = 12000;
 const SHUTDOWN_PRIORITY_CHILD = 20;
 const SHUTDOWN_PRIORITY_CLEANUP = 10;
 const SHUTDOWN_PRIORITY_SIGNAL_CLEANUP = 5;

--- a/src/core/cli/commands/project/dev.ts
+++ b/src/core/cli/commands/project/dev.ts
@@ -5,7 +5,10 @@ import chalk from "chalk";
 import { Command, Option } from "commander";
 import startAntelope, { DEFAULT_ENV, type LaunchOptions } from "../../../..";
 import { ModuleCache } from "../../../module-cache";
-import { ShutdownManager } from "../../../shutdown";
+import {
+  DEFAULT_SHUTDOWN_TIMEOUT_MS,
+  ShutdownManager,
+} from "../../../shutdown";
 import { displayBox, error, info, warning } from "../../cli-ui";
 import { Options } from "../../common";
 import {
@@ -32,7 +35,9 @@ export interface DevCommandOptions extends LaunchOptions {
 const DEFAULT_INSPECTOR = "--inspect";
 const RUNNER_PREFIX = "antelope-runner-";
 const DEFAULT_INSPECT_HOST = "127.0.0.1:9229";
-const CHILD_TERMINATE_TIMEOUT_MS = 12000;
+const CHILD_TERMINATE_HEADROOM_MS = 2000;
+const CHILD_TERMINATE_TIMEOUT_MS =
+  DEFAULT_SHUTDOWN_TIMEOUT_MS + CHILD_TERMINATE_HEADROOM_MS;
 const SHUTDOWN_PRIORITY_CHILD = 20;
 const SHUTDOWN_PRIORITY_CLEANUP = 10;
 const SHUTDOWN_PRIORITY_SIGNAL_CLEANUP = 5;

--- a/src/core/shutdown/shutdown-manager.ts
+++ b/src/core/shutdown/shutdown-manager.ts
@@ -11,7 +11,7 @@ interface RegisteredHandler {
 
 const Logger = new Logging.Channel("shutdown");
 
-const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10000;
+export const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10000;
 const EXIT_CODE_SUCCESS = 0;
 const FORCE_EXIT_CODE = 1;
 

--- a/src/core/shutdown/shutdown-manager.ts
+++ b/src/core/shutdown/shutdown-manager.ts
@@ -22,6 +22,7 @@ export class ShutdownManager {
   private requestedExitCode?: number;
   private sigintHandler?: () => void;
   private sigtermHandler?: () => void;
+  private seenSignals = new Set<ProcessSignal>();
 
   constructor(private timeoutMs: number = DEFAULT_SHUTDOWN_TIMEOUT_MS) {}
 
@@ -81,11 +82,22 @@ export class ShutdownManager {
 
   private handleSignal(signal: ProcessSignal): void {
     if (this.isShuttingDown) {
-      Logger.Warn(`Received ${signal} during shutdown. Forcing process exit.`);
-      process.exit(FORCE_EXIT_CODE);
+      if (this.seenSignals.has(signal)) {
+        Logger.Warn(
+          `Received ${signal} during shutdown. Forcing process exit.`,
+        );
+        process.exit(FORCE_EXIT_CODE);
+        return;
+      }
+
+      this.seenSignals.add(signal);
+      Logger.Info(
+        `Received ${signal} during graceful shutdown; ignoring (already shutting down).`,
+      );
       return;
     }
 
+    this.seenSignals.add(signal);
     void this.shutdown(EXIT_CODE_SUCCESS);
   }
 

--- a/test/core/shutdown/shutdown-manager.test.ts
+++ b/test/core/shutdown/shutdown-manager.test.ts
@@ -213,6 +213,30 @@ describe("ShutdownManager", () => {
 
       deferred.resolve();
       await waitForSignal();
+
+      expect(exitStub.calledWith(0)).to.equal(true);
+    });
+
+    it("should not force exit on SIGINT received after SIGTERM starts shutdown", async () => {
+      const deferred = createDeferred();
+      const handler = sinon.stub().returns(deferred.promise);
+      const exitStub = sinon.stub(process, "exit");
+      manager.register(handler, 0);
+      manager.setupSignalHandlers();
+
+      process.emit("SIGTERM");
+      await waitForSignal();
+
+      process.emit("SIGINT");
+      await waitForSignal();
+
+      expect(exitStub.calledWith(1)).to.equal(false);
+      expect(handler.calledOnce).to.equal(true);
+
+      deferred.resolve();
+      await waitForSignal();
+
+      expect(exitStub.calledWith(0)).to.equal(true);
     });
   });
 });

--- a/test/core/shutdown/shutdown-manager.test.ts
+++ b/test/core/shutdown/shutdown-manager.test.ts
@@ -194,5 +194,25 @@ describe("ShutdownManager", () => {
 
       expect(exitStub.calledWith(1)).to.equal(true);
     });
+
+    it("should not force exit on SIGTERM received during graceful shutdown", async () => {
+      const deferred = createDeferred();
+      const handler = sinon.stub().returns(deferred.promise);
+      const exitStub = sinon.stub(process, "exit");
+      manager.register(handler, 0);
+      manager.setupSignalHandlers();
+
+      process.emit("SIGINT");
+      await waitForSignal();
+
+      process.emit("SIGTERM");
+      await waitForSignal();
+
+      expect(exitStub.calledWith(1)).to.equal(false);
+      expect(handler.calledOnce).to.equal(true);
+
+      deferred.resolve();
+      await waitForSignal();
+    });
   });
 });


### PR DESCRIPTION
## Problem

When pressing Ctrl+C on the backend running with `ajs project run --inspect`, modules were **not** shut down gracefully — `stop()` / `destroy()` were cut off mid-execution.

## Root cause

In inspector mode (`launchWithInspector`), the CLI **forks a child** that runs the actual module work. A real terminal Ctrl+C delivers `SIGINT` to the **entire foreground process group** — both the CLI parent and the child. The child begins graceful shutdown from `SIGINT`, while the parent simultaneously forwards `SIGTERM` to the child. In `ShutdownManager.handleSignal`, **any** signal arriving while `isShuttingDown` was already true triggered `process.exit(1)`, aborting the in-flight async `stop()` / `destroy()`.

It only surfaces when shutdown does real async work (closing DB / HTTP connections). With an instant `stop()` the child happened to win the race, which is why it looked intermittent.

## Fix

- **`shutdown-manager.ts`** — track seen signal types. One Ctrl+C can legitimately produce both `SIGINT` (terminal) and `SIGTERM` (parent forward) in either order; the first occurrence of each distinct type is ignored so graceful shutdown finishes. Only a repeat of an already-seen type (a genuine second Ctrl+C) force-exits. A supervisor needing a hard kill uses the uncatchable `SIGKILL`, so no real force-quit capability is lost.
- **`dev.ts`** — raise the parent's child-termination grace (`CHILD_TERMINATE_TIMEOUT_MS`) from 5s to 12s so the parent doesn't `SIGKILL` a child still within its own 10s graceful-shutdown budget.

## Verification

Reproduced and verified with a faithful PTY-based Ctrl+C harness and a module with a slow async `stop()`:

- **Before (inspector):** `construct, start, stop:begin` → cut off (no `stop:end`, no `destroy`).
- **After (inspector):** `construct, start, stop:begin, stop:end, destroy` — full graceful shutdown.
- Non-inspector graceful shutdown and double-Ctrl+C force-quit both still work.

All 518 unit tests pass, including a new test asserting a `SIGTERM` during graceful shutdown does not force-exit while a repeated `SIGINT` still does.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an intermittent graceful-shutdown failure in inspector mode (`--inspect`) where a terminal Ctrl+C delivers SIGINT to the entire foreground process group, causing the parent to simultaneously forward SIGTERM to the child — and the old `handleSignal` would force-exit on any signal received while `isShuttingDown` was already true.

- **`shutdown-manager.ts`**: Adds a `seenSignals` Set so that the first occurrence of each distinct signal type during an in-flight shutdown is absorbed rather than force-exiting; only a repeated occurrence of a signal already seen triggers `process.exit(1)`.
- **`dev.ts`**: Expresses `CHILD_TERMINATE_TIMEOUT_MS` as `DEFAULT_SHUTDOWN_TIMEOUT_MS + CHILD_TERMINATE_HEADROOM_MS` (12 s total), ensuring the parent waits long enough for the child's full 10 s graceful-shutdown budget to complete.
- **Tests**: Two new tests cover both SIGINT→SIGTERM and SIGTERM→SIGINT orderings, each asserting no force-exit mid-shutdown and a clean `exit(0)` after graceful completion.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is narrowly scoped, logically correct for both signal orderings, and backed by symmetric tests covering each ordering end-to-end.

The seenSignals logic correctly handles all relevant scenarios: first-signal starts shutdown, cross-type second signal is absorbed, same-type second signal force-exits. The parent timeout increase is derived directly from the child's shutdown constant, eliminating the prior race. Both signal orderings (SIGINT→SIGTERM and SIGTERM→SIGINT) are now verified by tests that assert a clean exit code as well as the absence of a force-exit.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/shutdown/shutdown-manager.ts | Adds seenSignals Set to distinguish first-occurrence signal absorption (during shutdown) from a genuine repeated signal; exports DEFAULT_SHUTDOWN_TIMEOUT_MS. Logic covers both SIGINT→SIGTERM and SIGTERM→SIGINT orderings correctly. |
| src/core/cli/commands/project/dev.ts | Derives CHILD_TERMINATE_TIMEOUT_MS from DEFAULT_SHUTDOWN_TIMEOUT_MS + CHILD_TERMINATE_HEADROOM_MS (10 s + 2 s = 12 s), making the relationship to the child's shutdown budget explicit and eliminating the prior under-budgeted 5 s window. |
| test/core/shutdown/shutdown-manager.test.ts | Adds two symmetric tests covering SIGINT→SIGTERM and SIGTERM→SIGINT orderings, both asserting no force-exit during shutdown and a clean exit(0) after graceful completion. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Terminal
    participant Parent (CLI)
    participant Child (Runner)

    Note over Terminal,Child: User presses Ctrl+C (inspector mode)

    Terminal->>Parent (CLI): SIGINT (process group)
    Terminal->>Child (Runner): SIGINT (process group)

    activate Child (Runner)
    Note over Child (Runner): handleSignal("SIGINT")<br/>seenSignals = {SIGINT}<br/>isShuttingDown = true<br/>shutdown() started

    Parent (CLI)->>Child (Runner): SIGTERM (forwarded via terminateChildProcess)

    Note over Child (Runner): handleSignal("SIGTERM")<br/>isShuttingDown = true<br/>SIGTERM not in seenSignals → absorb<br/>seenSignals = {SIGINT, SIGTERM}

    Child (Runner)->>Child (Runner): stop() / destroy() complete
    deactivate Child (Runner)
    Child (Runner)-->>Parent (CLI): exit(0)

    Note over Parent (CLI): child exit handler fires<br/>shutdown(0) deduplicated<br/>parent exits cleanly

    Note over Terminal,Child: User presses Ctrl+C a second time

    Terminal->>Child (Runner): SIGINT (process group)
    Note over Child (Runner): SIGINT already in seenSignals<br/>→ process.exit(1) force exit
```

<sub>Reviews (2): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/antelopejs/antelopejs/commit/b95a08743b6c75c6f9bd2d8fbe00e973d6f7b04d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36438752)</sub>

<!-- /greptile_comment -->