### PR TITLE
feat(resolution): allow interfaces to declare themselves standalone

### DIFF
--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -179,7 +179,7 @@ export class ModuleManager {
   }
 
   registerStubbedInterfaces(stubbed: UnresolvedInterface[]): void {
-    for (const { moduleId, interfacePackage } of stubbed) {
+    for (const { moduleId, interfacePackage, standalone } of stubbed) {
       if (this.stubbedInterfacePaths.has(interfacePackage)) {
         continue;
       }
@@ -196,7 +196,7 @@ export class ModuleManager {
       }
       this.stubbedInterfacePaths.set(interfacePackage, pkgRoot);
       this.resolver.interfacePackages.set(interfacePackage, pkgRoot);
-      logStubInterfaceWarningOnce(interfacePackage);
+      logStubInterfaceWarningOnce(interfacePackage, standalone);
     }
   }
 

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -225,10 +225,7 @@ export class ModuleManager {
       try {
         require(interfaceName);
       } catch (err) {
-        Logger.Error(
-          `Failed to load optional interface '${interfaceName}':`,
-          err,
-        );
+        Logger.Error(`Failed to load interface '${interfaceName}':`, err);
         continue;
       }
       neutralizeInterfacePackage(pkgRoot, interfaceName);

--- a/src/core/resolution/interface-resolution.ts
+++ b/src/core/resolution/interface-resolution.ts
@@ -15,6 +15,17 @@ export interface InterfaceConsumer {
 export interface UnresolvedInterface {
   moduleId: string;
   interfacePackage: string;
+  /**
+   * True when the interface package declares `antelopeJs.standalone`. Carried
+   * on stubbed entries so the runtime can log a standalone (expected) message
+   * rather than an optional-dependency warning. Has no effect on `unresolved`.
+   */
+  standalone?: boolean;
+}
+
+interface InterfacePackageInfo {
+  isInterface: boolean;
+  standalone: boolean;
 }
 
 export interface InterfaceResolutionResult {
@@ -22,15 +33,22 @@ export interface InterfaceResolutionResult {
   stubbed: UnresolvedInterface[];
 }
 
-function isInterfacePackage(dep: string, consumerFolder: string): boolean {
+function readInterfacePackageInfo(
+  dep: string,
+  consumerFolder: string,
+): InterfacePackageInfo {
   try {
     const pkgJsonPath = require.resolve(`${dep}/package.json`, {
       paths: [consumerFolder],
     });
     const depPkg = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
-    return Boolean(depPkg.antelopeJs);
+    const antelopeJs = depPkg.antelopeJs;
+    return {
+      isInterface: Boolean(antelopeJs),
+      standalone: Boolean(antelopeJs?.standalone),
+    };
   } catch {
-    return false;
+    return { isInterface: false, standalone: false };
   }
 }
 
@@ -53,15 +71,31 @@ export function findUnresolvedInterfaces(
   for (const consumer of consumers) {
     for (const dep of Object.keys(consumer.dependencies)) {
       if (implementedInterfaces.has(dep)) continue;
-      if (!isInterfacePackage(dep, consumer.folder)) continue;
-      unresolved.push({ moduleId: consumer.id, interfacePackage: dep });
+      const info = readInterfacePackageInfo(dep, consumer.folder);
+      if (!info.isInterface) continue;
+      // A standalone interface with no implementer self-hosts instead of
+      // blocking startup — route it through the stub/self-host path.
+      if (info.standalone) {
+        stubbed.push({
+          moduleId: consumer.id,
+          interfacePackage: dep,
+          standalone: true,
+        });
+      } else {
+        unresolved.push({ moduleId: consumer.id, interfacePackage: dep });
+      }
     }
 
     const optional = consumer.optionalDependencies ?? {};
     for (const dep of Object.keys(optional)) {
       if (implementedInterfaces.has(dep)) continue;
-      if (!isInterfacePackage(dep, consumer.folder)) continue;
-      stubbed.push({ moduleId: consumer.id, interfacePackage: dep });
+      const info = readInterfacePackageInfo(dep, consumer.folder);
+      if (!info.isInterface) continue;
+      stubbed.push({
+        moduleId: consumer.id,
+        interfacePackage: dep,
+        standalone: info.standalone,
+      });
     }
   }
 

--- a/src/core/resolution/stub-interface-runtime.ts
+++ b/src/core/resolution/stub-interface-runtime.ts
@@ -13,8 +13,8 @@ const warned = new Set<string>();
 function makeRejection(interfaceName: string): Promise<never> {
   return Promise.reject(
     new Error(
-      `Optional interface '${interfaceName}' has no provider; ` +
-        `async calls reject. Load an implementing module to enable this interface.`,
+      `Interface '${interfaceName}' has no provider for this async method; ` +
+        `the call was rejected. Load a module that implements it to enable this call.`,
     ),
   );
 }

--- a/src/core/resolution/stub-interface-runtime.ts
+++ b/src/core/resolution/stub-interface-runtime.ts
@@ -91,11 +91,23 @@ export function neutralizeInterfacePackage(
   }
 }
 
-export function logStubInterfaceWarningOnce(interfaceName: string): void {
+export function logStubInterfaceWarningOnce(
+  interfaceName: string,
+  standalone = false,
+): void {
   if (warned.has(interfaceName)) {
     return;
   }
   warned.add(interfaceName);
+  if (standalone) {
+    // Expected for standalone interfaces — they self-host without an
+    // implementing module. Only proxy methods needing a provider reject.
+    Logger.Trace(
+      `Interface '${interfaceName}' has no implementing module; running standalone. ` +
+        `Proxy methods that require a provider will reject.`,
+    );
+    return;
+  }
   Logger.Warn(
     `Optional interface '${interfaceName}' has no provider; ` +
       `async calls on it will reject, sync usage will no-op.`,

--- a/test/core/resolution/interface-resolution.test.ts
+++ b/test/core/resolution/interface-resolution.test.ts
@@ -1,3 +1,4 @@
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { expect } from "chai";
 import {
@@ -5,6 +6,7 @@ import {
   type InterfaceConsumer,
   type InterfaceProvider,
 } from "../../../src/core/resolution/interface-resolution";
+import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
 
 const CORE_INTERFACE_PKG = "@antelopejs/interface-core";
 const CONSUMER_FOLDER = path.resolve(__dirname, "..", "..", "..");
@@ -48,6 +50,7 @@ describe("findUnresolvedInterfaces", () => {
     expect(result.stubbed[0]).to.deep.equal({
       moduleId: "consumer",
       interfacePackage: CORE_INTERFACE_PKG,
+      standalone: false,
     });
   });
 
@@ -123,5 +126,111 @@ describe("findUnresolvedInterfaces", () => {
     ]);
 
     expect(result.unresolved).to.have.lengthOf(0);
+  });
+});
+
+describe("findUnresolvedInterfaces (standalone interfaces)", () => {
+  const STANDALONE_PKG = "@antelopejs/interface-standalone-fixture";
+  const PLAIN_PKG = "@antelopejs/interface-plain-fixture";
+  let consumerFolder: string;
+
+  function writeInterfacePackage(
+    root: string,
+    name: string,
+    antelopeJs: Record<string, unknown>,
+  ): void {
+    const dir = path.join(root, "node_modules", ...name.split("/"));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, "package.json"),
+      JSON.stringify({ name, version: "1.0.0", main: "index.js", antelopeJs }),
+    );
+    writeFileSync(path.join(dir, "index.js"), "module.exports = {};");
+  }
+
+  beforeEach(() => {
+    consumerFolder = makeTempDir("ajs-iface-standalone-");
+    writeInterfacePackage(consumerFolder, STANDALONE_PKG, { standalone: true });
+    writeInterfacePackage(consumerFolder, PLAIN_PKG, {});
+  });
+
+  afterEach(() => {
+    cleanupTempDir(consumerFolder);
+  });
+
+  it("routes a missing standalone required dep into stubbed, not unresolved", () => {
+    const consumers: InterfaceConsumer[] = [
+      {
+        id: "consumer",
+        folder: consumerFolder,
+        dependencies: { [STANDALONE_PKG]: "*" },
+      },
+    ];
+
+    const result = findUnresolvedInterfaces([], consumers);
+
+    expect(result.unresolved).to.have.lengthOf(0);
+    expect(result.stubbed).to.deep.equal([
+      {
+        moduleId: "consumer",
+        interfacePackage: STANDALONE_PKG,
+        standalone: true,
+      },
+    ]);
+  });
+
+  it("still errors (unresolved) for a missing non-standalone required dep", () => {
+    const consumers: InterfaceConsumer[] = [
+      {
+        id: "consumer",
+        folder: consumerFolder,
+        dependencies: { [PLAIN_PKG]: "*" },
+      },
+    ];
+
+    const result = findUnresolvedInterfaces([], consumers);
+
+    expect(result.stubbed).to.have.lengthOf(0);
+    expect(result.unresolved).to.deep.equal([
+      { moduleId: "consumer", interfacePackage: PLAIN_PKG },
+    ]);
+  });
+
+  it("lets an implementing module win over standalone self-hosting", () => {
+    const providers: InterfaceProvider[] = [{ implements: [STANDALONE_PKG] }];
+    const consumers: InterfaceConsumer[] = [
+      {
+        id: "consumer",
+        folder: consumerFolder,
+        dependencies: { [STANDALONE_PKG]: "*" },
+      },
+    ];
+
+    const result = findUnresolvedInterfaces(providers, consumers);
+
+    expect(result.unresolved).to.have.lengthOf(0);
+    expect(result.stubbed).to.have.lengthOf(0);
+  });
+
+  it("marks a missing standalone optional dep as standalone in stubbed", () => {
+    const consumers: InterfaceConsumer[] = [
+      {
+        id: "consumer",
+        folder: consumerFolder,
+        dependencies: {},
+        optionalDependencies: { [STANDALONE_PKG]: "*" },
+      },
+    ];
+
+    const result = findUnresolvedInterfaces([], consumers);
+
+    expect(result.unresolved).to.have.lengthOf(0);
+    expect(result.stubbed).to.deep.equal([
+      {
+        moduleId: "consumer",
+        interfacePackage: STANDALONE_PKG,
+        standalone: true,
+      },
+    ]);
   });
 });

--- a/test/integration/launch.test.ts
+++ b/test/integration/launch.test.ts
@@ -210,6 +210,128 @@ describe("Launch Function", () => {
     }
   });
 
+  it("self-hosts a standalone interface required with no implementer", async () => {
+    const projectFolder = await fs.mkdtemp(
+      path.join(os.tmpdir(), "ajs-project-"),
+    );
+    try {
+      // A standalone interface package: same shape as a normal interface, but
+      // its package.json declares `antelopeJs.standalone`. It exposes a plain
+      // sync RegisteringProxy (its real working surface) and an AsyncProxy
+      // method that would need an external provider.
+      const ifaceFolder = path.join(projectFolder, "iface-standalone");
+      await fs.mkdir(ifaceFolder, { recursive: true });
+      await fs.writeFile(
+        path.join(ifaceFolder, "package.json"),
+        JSON.stringify(
+          {
+            name: "iface-standalone",
+            version: "1.0.0",
+            main: "index.js",
+            antelopeJs: { standalone: true },
+          },
+          null,
+          2,
+        ),
+      );
+      await fs.writeFile(
+        path.join(ifaceFolder, "index.js"),
+        `
+        const core = require("@antelopejs/interface-core");
+        exports.Iface = {
+          fetch: core.InterfaceFunction(),
+        };
+        exports.OnThing = new core.RegisteringProxy();
+        `,
+      );
+
+      // A consumer that lists the interface under regular dependencies — the
+      // case that previously threw "Unresolved interface dependencies".
+      const consumerFolder = path.join(projectFolder, "consumer");
+      await fs.mkdir(consumerFolder, { recursive: true });
+      await fs.writeFile(
+        path.join(consumerFolder, "package.json"),
+        JSON.stringify(
+          {
+            name: "consumer",
+            version: "1.0.0",
+            main: "index.js",
+            dependencies: { "iface-standalone": "*" },
+          },
+          null,
+          2,
+        ),
+      );
+      await fs.writeFile(
+        path.join(consumerFolder, "index.js"),
+        `
+        const iface = require("iface-standalone");
+        module.exports = {
+          construct() {
+            global.__antelopeStandaloneTest = iface;
+          },
+        };
+        `,
+      );
+
+      await fs.mkdir(path.join(consumerFolder, "node_modules"), {
+        recursive: true,
+      });
+      await fs.symlink(
+        ifaceFolder,
+        path.join(consumerFolder, "node_modules", "iface-standalone"),
+      );
+
+      await writeProjectConfig(projectFolder, {
+        name: "test-project",
+        modules: {
+          consumer: {
+            source: { type: "local", path: "./consumer", main: "index.js" },
+          },
+        },
+      });
+
+      // Should NOT throw despite no module implementing iface-standalone.
+      const manager = await launch(projectFolder);
+      try {
+        expect(
+          manager.resolver.interfacePackages.has("iface-standalone"),
+        ).to.equal(true);
+        const captured = (global as any).__antelopeStandaloneTest;
+        expect(captured).to.exist;
+
+        // Sync RegisteringProxy surface works as normal (not neutralized).
+        let registered = false;
+        captured.OnThing.onRegister(() => {
+          registered = true;
+        }, true);
+        captured.OnThing.register("id-1");
+        expect(registered).to.equal(true);
+
+        // An AsyncProxy method with no provider still rejects promptly.
+        let asyncError: Error | undefined;
+        try {
+          await Promise.race([
+            captured.Iface.fetch(),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error("HANG")), 1000),
+            ),
+          ]);
+        } catch (e) {
+          asyncError = e as Error;
+        }
+        expect(asyncError?.message ?? "").to.match(/iface-standalone/);
+        expect(asyncError?.message ?? "").to.not.match(/HANG/);
+      } finally {
+        delete (global as any).__antelopeStandaloneTest;
+        await manager.stopAll();
+        await manager.destroyAll();
+      }
+    } finally {
+      await fs.rm(projectFolder, { recursive: true, force: true });
+    }
+  });
+
   it("should respect environment option", async () => {
     const projectFolder = await fs.mkdtemp(
       path.join(os.tmpdir(), "ajs-project-"),


### PR DESCRIPTION
## Summary

Self-contained interface packages (where all the real implementation lives in the `@antelopejs/interface-*` package itself) previously still required an **empty wrapper module** to be declared in `antelope.config.ts` — purely to satisfy interface resolution. The core errors on any imported interface that no loaded module declares in `antelopeJs.implements`, so apps had to list do-nothing modules like `@antelopejs/data-api` / `@antelopejs/database-decorators` just to pass that check.

This adds an opt-in `antelopeJs.standalone: true` flag on the **interface package**. When set:

- A required dependency with no implementer no longer throws `Unresolved interface dependencies`. It falls back to the existing stub/self-host path — the interface package is loaded **once** as a single shared copy via the resolver detour (so shared runtime state, e.g. a model registry, stays shared across consumers).
- A module **may** still implement it; an explicit provider always wins.
- **Neutralization stays on.** It only rewrites `AsyncProxy` exports (it skips `RegisteringProxy`/`EventProxy` and ignores plain functions/objects), so a standalone interface's real working surface is untouched, while any proxy method that genuinely needs an external provider rejects fast instead of hanging forever.

The runtime path is reused unchanged — the only behavioral change is **classification**: standalone-with-no-implementer routes to `stubbed` instead of `unresolved`.

## Changes

- `src/core/resolution/interface-resolution.ts` — read `antelopeJs.standalone`; route standalone required deps to `stubbed` rather than `unresolved`; carry a `standalone` flag on stubbed entries.
- `src/core/module-manager.ts` — thread the `standalone` flag into the stub logger.
- `src/core/resolution/stub-interface-runtime.ts` — log standalone self-hosting at `Trace` (expected) instead of the `Warn`-level "Optional interface" message.

## Tests

- 4 new unit tests in `interface-resolution.test.ts` (standalone required → stubbed; non-standalone required → unresolved; implementer wins; standalone optional flagged).
- 1 new end-to-end integration test in `launch.test.ts`: a standalone interface under regular `dependencies` with no implementer launches without error, shares a single copy, keeps its sync `RegisteringProxy` surface working, and rejects an unimplemented `AsyncProxy` call promptly.

All 522 unit tests pass; `tsc` and `biome` are clean.

## Follow-up (separate repos)

To realize the benefit, the `@antelopejs/interface-data-api` and `@antelopejs/interface-database-decorators` packages set `standalone: true` (done locally), after which consuming apps can drop the empty `data-api` / `database-decorators` module entries from their configs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `standalone: true` opt-in flag to interface package manifests so that self-contained interface packages no longer require an empty wrapper module listed in `antelope.config.ts`. When set, a required dependency with no implementer is routed to the existing stub/self-host path instead of throwing `Unresolved interface dependencies`.

- `interface-resolution.ts` refactors `isInterfacePackage` into `readInterfacePackageInfo` to also capture `standalone`, then routes standalone required deps to `stubbed` instead of `unresolved`.
- `stub-interface-runtime.ts` and `module-manager.ts` thread the `standalone` flag through to logging so standalone self-hosting is emitted at `Trace` (expected) rather than `Warn` (unexpected).
- 4 unit tests and 1 integration test cover the new routing, the implementer-wins case, and that `RegisteringProxy` surfaces remain functional while `AsyncProxy` calls reject promptly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a well-scoped opt-in flag; existing behaviour for non-standalone required and optional dependencies is completely unchanged.

The new routing from standalone required deps into the existing stub path is isolated behind a flag read from the package manifest. Deduplication in registerStubbedInterfaces is unchanged and handles multiple consumers correctly. The integration test verifies end-to-end that RegisteringProxy surfaces stay functional and AsyncProxy calls reject promptly, and all 522 unit tests continue to pass. No correctness issues were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/core/resolution/interface-resolution.ts | Refactors isInterfacePackage into readInterfacePackageInfo to read the standalone flag; routes standalone required deps to stubbed instead of unresolved. Logic is clean and deduplication in registerStubbedInterfaces handles multiple consumers of the same package correctly. |
| src/core/resolution/stub-interface-runtime.ts | Adds standalone=false default to logStubInterfaceWarningOnce, emitting Trace for expected standalone self-hosting and keeping Warn for optional misses. makeRejection message updated but guidance to 'Load a module that implements it' is still somewhat misleading for standalone interfaces (previously flagged P2). |
| src/core/module-manager.ts | Threads standalone flag from stubbed entries into logStubInterfaceWarningOnce; drops 'optional' from the failed-load error message making it accurate for both optional and standalone interfaces. |
| test/core/resolution/interface-resolution.test.ts | Adds 4 well-scoped unit tests using temp-dir fixtures: standalone required → stubbed, non-standalone required → unresolved, implementer-wins, and standalone optional. Existing test updated to assert standalone: false on existing behavior. |
| test/integration/launch.test.ts | Integration test verifies end-to-end: standalone interface in regular dependencies launches without error, RegisteringProxy surface is functional post-neutralization, and AsyncProxy rejects promptly rather than hanging. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[findUnresolvedInterfaces] --> B{dep in implementedInterfaces?}
    B -- yes --> SKIP[skip]
    B -- no --> C[readInterfacePackageInfo]
    C --> D{isInterface?}
    D -- no --> SKIP
    D -- yes --> E{from dependencies\nor optionalDependencies?}

    E -- dependencies --> F{standalone: true?}
    F -- yes --> G[stubbed ✓\nstandalone: true]
    F -- no --> H[unresolved ✗\nthrows at startup]

    E -- optionalDependencies --> I[stubbed ✓\nstandalone: info.standalone]

    G --> J[registerStubbedInterfaces]
    I --> J

    J --> K{already in\nstubbedInterfacePaths?}
    K -- yes --> L[skip / dedup]
    K -- no --> M[resolve pkgRoot\nregister in resolver]
    M --> N{standalone?}
    N -- yes --> O[Logger.Trace\n'running standalone']
    N -- no --> P[Logger.Warn\n'optional, no provider']

    J --> Q[applyInterfaceStubs]
    Q --> R[require interfaceName]
    R --> S[neutralizeInterfacePackage]
    S --> T{export type?}
    T -- AsyncProxy --> U[onCall → makeRejection\nrejects immediately]
    T -- RegisteringProxy\nor EventProxy --> V[untouched ✓\nworks normally]
    T -- plain object --> W[walk children]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/core/resolution/stub-interface-runtime.ts`, line 13-19 ([link](https://github.com/antelopejs/antelopejs/blob/3a30b18c10a6ce4a7a7c339038909d4c87ae0fa0/src/core/resolution/stub-interface-runtime.ts#L13-L19)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Misleading rejection message for standalone interfaces**

   `makeRejection` always formats the error as `"Optional interface '…' has no provider; … Load an implementing module to enable this interface."` When a standalone interface's `AsyncProxy` method rejects, users see this message and are told to load an implementing module — the exact opposite of what `standalone: true` means. The guidance is incorrect in this context and will confuse anyone debugging a rejection from a standalone interface.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/core/resolution/stub-interface-runtime.ts
   Line: 13-19

   Comment:
   **Misleading rejection message for standalone interfaces**

   `makeRejection` always formats the error as `"Optional interface '…' has no provider; … Load an implementing module to enable this interface."` When a standalone interface's `AsyncProxy` method rejects, users see this message and are told to load an implementing module — the exact opposite of what `standalone: true` means. The guidance is incorrect in this context and will confuse anyone debugging a rejection from a standalone interface.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/core/module-manager.ts`, line 226-231 ([link](https://github.com/antelopejs/antelopejs/blob/3a30b18c10a6ce4a7a7c339038909d4c87ae0fa0/src/core/module-manager.ts#L226-L231)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **"Optional interface" label is inaccurate for standalone interfaces**

   When `require(interfaceName)` fails inside `applyInterfaceStubs`, the error is logged as `Failed to load optional interface '${interfaceName}'`. For packages that reached this path because they are `standalone: true` (not optional), this label is incorrect and will make the error harder to trace.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/core/module-manager.ts
   Line: 226-231

   Comment:
   **"Optional interface" label is inaccurate for standalone interfaces**

   When `require(interfaceName)` fails inside `applyInterfaceStubs`, the error is logged as `Failed to load optional interface '${interfaceName}'`. For packages that reached this path because they are `standalone: true` (not optional), this label is incorrect and will make the error harder to trace.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/antelopejs/antelopejs/commit/2480ee7788dd7c9bfa37d8298ca24aad52444576) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36448407)</sub>

<!-- /greptile_comment -->