### PR TITLE
fix(test): validate module graph before constructing modules in test runner

### DIFF
--- a/src/core/test/test-module.ts
+++ b/src/core/test/test-module.ts
@@ -12,6 +12,7 @@ import { NodeFileSystem } from "../filesystem";
 import { ModuleManager } from "../module-manager";
 import {
   constructAndStartModules,
+  ensureGraphIsValid,
   loadModuleEntriesForManager,
 } from "../runtime/module-loading";
 import {
@@ -115,6 +116,7 @@ export async function setupTestEnvironment(
     const manager = new ModuleManager();
     manager.resolver.stubModulePath = STUB_INTERFACE_PATH;
     await loadModuleEntriesForManager(manager, normalizedConfig, true);
+    ensureGraphIsValid(manager);
     await constructAndStartModules(manager);
     internal.testStubMode = true;
     registerTestDir(path.resolve(moduleRoot), manager);

--- a/test/core/test/test-module.test.ts
+++ b/test/core/test/test-module.test.ts
@@ -473,6 +473,35 @@ describe("test-module", () => {
       internal.testStubMode = false;
     });
 
+    it("validates the module graph before constructing modules so standalone interfaces get canonicalized", async () => {
+      const { internal } = await import("@antelopejs/interface-core/internal");
+      const moduleLoading = require("../../../src/core/runtime/module-loading");
+
+      const loadEntriesStub = sinon
+        .stub(moduleLoading, "loadModuleEntriesForManager")
+        .resolves([]);
+      const ensureGraphStub = sinon.stub(moduleLoading, "ensureGraphIsValid");
+      const constructStartStub = sinon
+        .stub(moduleLoading, "constructAndStartModules")
+        .resolves();
+
+      const manager = await testModule.setupTestEnvironment("/module", {
+        name: "test",
+        cacheFolder: ".antelope/cache",
+        modules: {},
+        envOverrides: {},
+      } as any);
+
+      expect(ensureGraphStub.calledOnceWithExactly(manager)).to.equal(true);
+      sinon.assert.callOrder(
+        loadEntriesStub,
+        ensureGraphStub,
+        constructStartStub,
+      );
+
+      internal.testStubMode = false;
+    });
+
     it("registers moduleRoot in internal.moduleByFolder so test-file frames find a module", async () => {
       const { internal } = await import("@antelopejs/interface-core/internal");
       const moduleLoading = require("../../../src/core/runtime/module-loading");


### PR DESCRIPTION
## Problem

`ajs module test` crashes at module construction when the project relies on standalone interfaces (introduced in #79), e.g.:

```
[ERROR] Failed to load module local TypeError: Cannot read properties of undefined (reading 'prototype')
```

`setupTestEnvironment` calls `loadModuleEntriesForManager` and then `constructAndStartModules` directly, without `ensureGraphIsValid`. That step is where `registerStubbedInterfaces` canonicalizes standalone interface packages into the resolver's `interfacePackages` map. Without it, requires of an interface package are not redirected to a single canonical copy: the module under test resolves its own `node_modules` copy while cached modules resolve theirs.

Interface metadata classes use anonymous Symbols as keys (`static key = Symbol()`), so metadata written through one copy is invisible to the other. Concretely: an app registers a data controller through its copy of `@antelopejs/interface-data-api`, then a cached module's decorator reads `DataAPIMeta` through its own copy, gets a fresh empty instance, and crashes on `dataMeta.tableClass.prototype`.

The run path is not affected: `initializeCore` already calls `ensureGraphIsValid` between loading and construction.

## Fix

Call `ensureGraphIsValid(manager)` in `setupTestEnvironment`, mirroring `initializeCore`. This also gives the test runner the same early "Unresolved interface dependencies" error instead of an opaque construction crash.

## Testing

- New unit test asserting the graph is validated between module loading and construction.
- `pnpm lint`, `pnpm build`, `pnpm test:unit` pass.
- Verified end-to-end on a real project (omnitec-backend, cms 0.0.17 + standalone `interface-data-api`/`interface-database-decorators` 0.1.2): `ajs module test .` went from the crash above to 1643 passing tests with this patch applied to `dist`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash in `ajs module test` when standalone interfaces are present by calling `ensureGraphIsValid(manager)` inside `setupTestEnvironment`, between module loading and construction — matching what `initializeCore` already does in the production run path.

- **Bug fix in `src/core/test/test-module.ts`**: inserts the missing `ensureGraphIsValid` call so standalone interface packages are canonicalized before module construction, preventing the `Cannot read properties of undefined (reading 'prototype')` crash when interface metadata is resolved through mismatched `node_modules` copies.
- **New unit test in `test/core/test/test-module.test.ts`**: asserts that `ensureGraphIsValid` is called exactly once with the manager and in the correct order (load → validate → construct) using `sinon.assert.callOrder`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-line fix in the test runner path with a matching unit test, no production code paths or data flow affected.

The change is a single-line addition that aligns the test runner with an already-proven production code path. The fix is backed by a well-structured test that verifies both the call itself and the call order. Existing tests that don't stub ensureGraphIsValid still pass because an empty ModuleManager causes the function to be a no-op.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/test/test-module.ts | Adds a single call to `ensureGraphIsValid(manager)` between `loadModuleEntriesForManager` and `constructAndStartModules`, mirroring the production `initializeCore` path. Change is minimal and well-targeted. |
| test/core/test/test-module.test.ts | New unit test validates that `ensureGraphIsValid` is called between `loadModuleEntriesForManager` and `constructAndStartModules` using `sinon.assert.callOrder`. Existing tests that don't stub `ensureGraphIsValid` are safe because an empty `ModuleManager` produces no-op behavior in `ensureGraphIsValid`. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as ajs module test
    participant STE as setupTestEnvironment
    participant LM as loadModuleEntriesForManager
    participant EGV as ensureGraphIsValid
    participant CAM as constructAndStartModules

    Caller->>STE: setupTestEnvironment(moduleRoot, config)
    STE->>LM: loadModuleEntriesForManager(manager, config, true)
    LM-->>STE: module entries loaded
    Note over STE,EGV: NEW: canonicalize standalone interface packages
    STE->>EGV: ensureGraphIsValid(manager)
    EGV-->>STE: (throws if unresolved deps, otherwise registers stubbed interfaces)
    STE->>CAM: constructAndStartModules(manager)
    CAM-->>STE: modules constructed and started
    STE-->>Caller: ModuleManager
```

<sub>Reviews (1): Last reviewed commit: ["fix(test): validate module graph before ..."](https://github.com/antelopejs/antelopejs/commit/e40e0704afa8598407d5ffeafb3b926ee982348a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37220625)</sub>

<!-- /greptile_comment -->