### PR TITLE
feat(runtime): implement runtime info and dev server registry interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test:coverage": "c8 --check-coverage --lines 90 --functions 90 --branches 90 --statements 90 mocha --require ts-node/register --require test/setup.ts 'test/**/*.test.ts' --exit"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.4",
+    "@antelopejs/interface-core": "^0.0.5",
     "@types/proper-lockfile": "^4.1.4",
     "boxen": "^8.0.1",
     "chalk": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.4
-        version: 0.0.4
+        specifier: ^0.0.5
+        version: 0.0.5
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
@@ -105,8 +105,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.4':
-    resolution: {integrity: sha512-RNptIsG3Luwy5XR4dIOvWPbVntWrpuCAOOK+49wmd0sOxMJ8lqtTaOarFCRvxN61uPEt8f8tzx7059mTtnjoig==}
+  '@antelopejs/interface-core@0.0.5':
+    resolution: {integrity: sha512-4H6hpFfiK2+DE8vL2mEtPbq1WNch9lt40QNr9KjBrOAtnuq/zMfIlzhbEsda39m+FVkMWXfUYoVolRogVKCLIQ==}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -582,6 +582,14 @@ packages:
       magicast:
         optional: true
 
+  c12@3.3.4:
+    resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
+    peerDependencies:
+      magicast: '*'
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
   c8@10.1.3:
     resolution: {integrity: sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==}
     engines: {node: '>=18'}
@@ -747,6 +755,9 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
@@ -772,6 +783,10 @@ packages:
 
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   duplexify@3.7.1:
@@ -889,6 +904,10 @@ packages:
 
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
+  giget@3.3.0:
+    resolution: {integrity: sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==}
     hasBin: true
 
   git-up@8.1.1:
@@ -1060,6 +1079,10 @@ packages:
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
   js-yaml@4.1.1:
@@ -1331,6 +1354,9 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -1361,6 +1387,9 @@ packages:
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
+  rc9@3.0.1:
+    resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -1444,6 +1473,11 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1611,8 +1645,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ufo@1.6.3:
-    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   unbzip2-stream@1.4.3:
     resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
@@ -1728,7 +1762,7 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.4':
+  '@antelopejs/interface-core@0.0.5':
     dependencies:
       reflect-metadata: 0.2.2
 
@@ -2193,6 +2227,21 @@ snapshots:
       pkg-types: 2.3.0
       rc9: 2.1.2
 
+  c12@3.3.4:
+    dependencies:
+      chokidar: 5.0.0
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 17.4.2
+      exsolve: 1.0.8
+      giget: 3.3.0
+      jiti: 2.7.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+
   c8@10.1.3:
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -2230,7 +2279,7 @@ snapshots:
 
   changelogen@0.6.2:
     dependencies:
-      c12: 3.3.3
+      c12: 3.3.4
       confbox: 0.2.4
       consola: 3.4.2
       convert-gitmoji: 0.1.5
@@ -2239,9 +2288,9 @@ snapshots:
       ofetch: 1.5.1
       open: 10.2.0
       pathe: 2.0.3
-      pkg-types: 2.3.0
+      pkg-types: 2.3.1
       scule: 1.3.0
-      semver: 7.7.4
+      semver: 7.8.4
       std-env: 3.10.0
     transitivePeerDependencies:
       - magicast
@@ -2347,6 +2396,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  defu@6.1.7: {}
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
@@ -2364,6 +2415,8 @@ snapshots:
   dotenv@16.6.1: {}
 
   dotenv@17.3.1: {}
+
+  dotenv@17.4.2: {}
 
   duplexify@3.7.1:
     dependencies:
@@ -2470,6 +2523,8 @@ snapshots:
       node-fetch-native: 1.6.7
       nypm: 0.6.5
       pathe: 2.0.3
+
+  giget@3.3.0: {}
 
   git-up@8.1.1:
     dependencies:
@@ -2654,6 +2709,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jiti@2.7.0: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -2798,7 +2855,7 @@ snapshots:
     dependencies:
       destr: 2.0.5
       node-fetch-native: 1.6.7
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   ohash@2.0.11: {}
 
@@ -2936,6 +2993,12 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
+      pathe: 2.0.3
+
   process-nextick-args@2.0.1: {}
 
   proper-lockfile@4.1.2:
@@ -2984,6 +3047,11 @@ snapshots:
   rc9@2.1.2:
     dependencies:
       defu: 6.1.4
+      destr: 2.0.5
+
+  rc9@3.0.1:
+    dependencies:
+      defu: 6.1.7
       destr: 2.0.5
 
   readable-stream@2.3.8:
@@ -3085,6 +3153,8 @@ snapshots:
   semver@7.7.3: {}
 
   semver@7.7.4: {}
+
+  semver@7.8.4: {}
 
   serialize-javascript@6.0.2:
     dependencies:
@@ -3255,7 +3325,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  ufo@1.6.3: {}
+  ufo@1.6.4: {}
 
   unbzip2-stream@1.4.3:
     dependencies:

--- a/src/core/runtime/dev-server-registry.ts
+++ b/src/core/runtime/dev-server-registry.ts
@@ -72,6 +72,7 @@ export class DevRegistryStore {
       return;
     }
 
+    await this.pendingWrite;
     await this.options.fs.rm(this.registryFilePath, { force: true });
   }
 

--- a/src/core/runtime/dev-server-registry.ts
+++ b/src/core/runtime/dev-server-registry.ts
@@ -1,0 +1,162 @@
+import path from "node:path";
+import * as coreInterfaceBeta from "@antelopejs/interface-core";
+import type {
+  DevServerEndpoint,
+  DevServerEntry,
+  DevServerRegistry,
+  RuntimeInfo,
+} from "@antelopejs/interface-core/runtime";
+import * as runtimeInterfaceBeta from "@antelopejs/interface-core/runtime";
+import type { IFileSystem } from "../../types";
+import type { ShutdownManager } from "../shutdown";
+
+const TEMP_FILE_SUFFIX = ".tmp";
+const JSON_INDENT = 2;
+const SHUTDOWN_PRIORITY_DEV_REGISTRY = 10;
+const PERMISSION_DENIED_CODE = "EPERM";
+
+export type PidProbe = (pid: number) => boolean;
+
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === PERMISSION_DENIED_CODE;
+  }
+}
+
+export interface DevRegistryStoreOptions {
+  projectPath: string;
+  fs: IFileSystem;
+  pid: number;
+  startedAt: Date;
+  isPidAlive?: PidProbe;
+}
+
+export class DevRegistryStore {
+  private servers: Record<string, DevServerEntry> = {};
+  private hasRegisteredServers = false;
+
+  constructor(private options: DevRegistryStoreOptions) {}
+
+  get registryFilePath(): string {
+    return path.join(
+      this.options.projectPath,
+      runtimeInterfaceBeta.DEV_REGISTRY_PATH,
+    );
+  }
+
+  async removeOrphanRegistry(): Promise<void> {
+    if (!(await this.options.fs.exists(this.registryFilePath))) {
+      return;
+    }
+
+    const existing = await this.readRegistry();
+    if (existing && this.isOwnerAlive(existing)) {
+      return;
+    }
+
+    await this.options.fs.rm(this.registryFilePath, { force: true });
+  }
+
+  async register(name: string, endpoints: DevServerEndpoint[]): Promise<void> {
+    this.servers[name] = { endpoints };
+    this.hasRegisteredServers = true;
+    await this.writeRegistry();
+  }
+
+  async cleanup(): Promise<void> {
+    if (!this.hasRegisteredServers) {
+      return;
+    }
+
+    await this.options.fs.rm(this.registryFilePath, { force: true });
+  }
+
+  private isOwnerAlive(registry: DevServerRegistry): boolean {
+    const probe = this.options.isPidAlive ?? isProcessAlive;
+    return typeof registry.pid === "number" && probe(registry.pid);
+  }
+
+  private async readRegistry(): Promise<DevServerRegistry | undefined> {
+    try {
+      const content = await this.options.fs.readFileString(
+        this.registryFilePath,
+      );
+      return JSON.parse(content) as DevServerRegistry;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private buildRegistry(): DevServerRegistry {
+    return {
+      pid: this.options.pid,
+      startedAt: this.options.startedAt.toISOString(),
+      servers: this.servers,
+    };
+  }
+
+  private async writeRegistry(): Promise<void> {
+    const filePath = this.registryFilePath;
+    const tempPath = `${filePath}${TEMP_FILE_SUFFIX}`;
+    await this.options.fs.mkdir(path.dirname(filePath), { recursive: true });
+    await this.options.fs.writeFile(
+      tempPath,
+      `${JSON.stringify(this.buildRegistry(), null, JSON_INDENT)}\n`,
+    );
+    await this.options.fs.rename(tempPath, filePath);
+  }
+}
+
+export interface RuntimeInterfaceOptions {
+  dev: boolean;
+  projectPath: string;
+  env: string;
+  fs: IFileSystem;
+  shutdownManager?: ShutdownManager;
+  isPidAlive?: PidProbe;
+}
+
+async function setupDevRegistryStore(
+  options: RuntimeInterfaceOptions,
+  projectPath: string,
+): Promise<DevRegistryStore | undefined> {
+  if (!options.dev) {
+    return undefined;
+  }
+
+  const store = new DevRegistryStore({
+    projectPath,
+    fs: options.fs,
+    pid: process.pid,
+    startedAt: new Date(),
+    isPidAlive: options.isPidAlive,
+  });
+  await store.removeOrphanRegistry();
+  options.shutdownManager?.register(
+    () => store.cleanup(),
+    SHUTDOWN_PRIORITY_DEV_REGISTRY,
+  );
+  return store;
+}
+
+export async function registerCoreRuntimeInterface(
+  options: RuntimeInterfaceOptions,
+): Promise<void> {
+  const projectPath = path.resolve(options.projectPath);
+  const runtimeInfo: RuntimeInfo = {
+    dev: options.dev,
+    projectPath,
+    env: options.env,
+  };
+  const store = await setupDevRegistryStore(options, projectPath);
+
+  void coreInterfaceBeta.ImplementInterface(runtimeInterfaceBeta, {
+    GetRuntimeInfo: async () => runtimeInfo,
+    RegisterDevServer: async (name: string, endpoints: DevServerEndpoint[]) => {
+      await store?.register(name, endpoints);
+    },
+  });
+}

--- a/src/core/runtime/dev-server-registry.ts
+++ b/src/core/runtime/dev-server-registry.ts
@@ -37,6 +37,7 @@ export interface DevRegistryStoreOptions {
 export class DevRegistryStore {
   private servers: Record<string, DevServerEntry> = {};
   private hasRegisteredServers = false;
+  private pendingWrite: Promise<void> = Promise.resolve();
 
   constructor(private options: DevRegistryStoreOptions) {}
 
@@ -98,7 +99,13 @@ export class DevRegistryStore {
     };
   }
 
-  private async writeRegistry(): Promise<void> {
+  private writeRegistry(): Promise<void> {
+    const write = this.pendingWrite.then(() => this.performWrite());
+    this.pendingWrite = write.catch(() => undefined);
+    return write;
+  }
+
+  private async performWrite(): Promise<void> {
     const filePath = this.registryFilePath;
     const tempPath = `${filePath}${TEMP_FILE_SUFFIX}`;
     await this.options.fs.mkdir(path.dirname(filePath), { recursive: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   warnIfBuildIsStale,
   writeProjectBuildArtifact,
 } from "./core/runtime/build-runtime";
+import { registerCoreRuntimeInterface } from "./core/runtime/dev-server-registry";
 import {
   constructAndStartModules,
   createLoaderContext,
@@ -185,6 +186,13 @@ async function initializeCore(
   const loaderContext = await createLoaderContext(
     runtimeConfig.normalizedConfig,
   );
+  await registerCoreRuntimeInterface({
+    dev: true,
+    projectPath: projectFolder,
+    env,
+    fs: runtimeConfig.fs,
+    shutdownManager,
+  });
 
   const manager = await withRaisedMaxListeners(async () => {
     const moduleManager = new ModuleManager();
@@ -325,6 +333,13 @@ export async function launchFromBuild(
 
   await warnIfBuildIsStale(projectFolder, artifact, fs);
   await ensureBuildModulesExist(artifact, fs);
+  await registerCoreRuntimeInterface({
+    dev: false,
+    projectPath: projectFolder,
+    env: startEnv,
+    fs,
+    shutdownManager,
+  });
 
   const manager = await withRaisedMaxListeners(async () => {
     const moduleManager = new ModuleManager();

--- a/test/core/dev-server-registry.test.ts
+++ b/test/core/dev-server-registry.test.ts
@@ -120,6 +120,18 @@ describe("core/runtime dev server registry", () => {
       expect(await fs.exists(REGISTRY_PATH)).to.equal(false);
     });
 
+    it("cleanup drains an in-flight registration before removing the file", async () => {
+      const fs = new InMemoryFileSystem();
+      const store = createStore(fs);
+
+      const registration = store.register("api", API_ENDPOINTS);
+      await store.cleanup();
+      await registration;
+
+      expect(await fs.exists(REGISTRY_PATH)).to.equal(false);
+      expect(await fs.exists(TEMP_REGISTRY_PATH)).to.equal(false);
+    });
+
     it("removes an orphan registry when the owning pid is dead", async () => {
       const fs = new InMemoryFileSystem();
       await fs.writeFile(

--- a/test/core/dev-server-registry.test.ts
+++ b/test/core/dev-server-registry.test.ts
@@ -1,0 +1,219 @@
+import {
+  DEV_REGISTRY_PATH,
+  type DevServerEndpoint,
+  GetRuntimeInfo,
+  RegisterDevServer,
+} from "@antelopejs/interface-core/runtime";
+import { expect } from "chai";
+import {
+  DevRegistryStore,
+  registerCoreRuntimeInterface,
+} from "../../src/core/runtime/dev-server-registry";
+import { ShutdownManager } from "../../src/core/shutdown";
+import { InMemoryFileSystem } from "../helpers/in-memory-filesystem";
+
+interface ResettableProxy {
+  onCall(callback: () => undefined, manualDetach?: boolean): void;
+  detach(): void;
+}
+
+interface ProxiedInterfaceFunction {
+  proxy: ResettableProxy;
+}
+
+function resetProxy(interfaceFunction: unknown): void {
+  const { proxy } = interfaceFunction as ProxiedInterfaceFunction;
+  proxy.onCall(() => undefined, true);
+  proxy.detach();
+}
+
+const PROJECT_PATH = "/project";
+const REGISTRY_PATH = `${PROJECT_PATH}/${DEV_REGISTRY_PATH}`;
+const TEMP_REGISTRY_PATH = `${REGISTRY_PATH}.tmp`;
+const OWNER_PID = 4242;
+const STARTED_AT = new Date("2026-06-12T10:00:00.000Z");
+const API_ENDPOINTS: DevServerEndpoint[] = [
+  { protocol: "http", host: "localhost", port: 5011 },
+];
+const WS_ENDPOINTS: DevServerEndpoint[] = [
+  { protocol: "ws", host: "localhost", port: 5012 },
+];
+
+function createStore(
+  fs: InMemoryFileSystem,
+  isPidAlive?: (pid: number) => boolean,
+): DevRegistryStore {
+  return new DevRegistryStore({
+    projectPath: PROJECT_PATH,
+    fs,
+    pid: OWNER_PID,
+    startedAt: STARTED_AT,
+    isPidAlive,
+  });
+}
+
+async function readRegistry(fs: InMemoryFileSystem): Promise<unknown> {
+  return JSON.parse(await fs.readFileString(REGISTRY_PATH));
+}
+
+describe("core/runtime dev server registry", () => {
+  describe("DevRegistryStore", () => {
+    it("writes the registry atomically with pid and startedAt", async () => {
+      const fs = new InMemoryFileSystem();
+      const store = createStore(fs);
+
+      await store.register("api", API_ENDPOINTS);
+
+      expect(await readRegistry(fs)).to.deep.equal({
+        pid: OWNER_PID,
+        startedAt: STARTED_AT.toISOString(),
+        servers: { api: { endpoints: API_ENDPOINTS } },
+      });
+      expect(await fs.exists(TEMP_REGISTRY_PATH)).to.equal(false);
+    });
+
+    it("merges servers across registrations", async () => {
+      const fs = new InMemoryFileSystem();
+      const store = createStore(fs);
+
+      await store.register("api", API_ENDPOINTS);
+      await store.register("ws", WS_ENDPOINTS);
+
+      const registry = (await readRegistry(fs)) as {
+        servers: Record<string, unknown>;
+      };
+      expect(registry.servers).to.deep.equal({
+        api: { endpoints: API_ENDPOINTS },
+        ws: { endpoints: WS_ENDPOINTS },
+      });
+    });
+
+    it("cleanup removes the registry only after a registration", async () => {
+      const fs = new InMemoryFileSystem();
+      await fs.writeFile(REGISTRY_PATH, "{}");
+      const store = createStore(fs);
+
+      await store.cleanup();
+      expect(await fs.exists(REGISTRY_PATH)).to.equal(true);
+
+      await store.register("api", API_ENDPOINTS);
+      await store.cleanup();
+      expect(await fs.exists(REGISTRY_PATH)).to.equal(false);
+    });
+
+    it("removes an orphan registry when the owning pid is dead", async () => {
+      const fs = new InMemoryFileSystem();
+      await fs.writeFile(
+        REGISTRY_PATH,
+        JSON.stringify({ pid: 999, startedAt: "", servers: {} }),
+      );
+      const store = createStore(fs, () => false);
+
+      await store.removeOrphanRegistry();
+
+      expect(await fs.exists(REGISTRY_PATH)).to.equal(false);
+    });
+
+    it("keeps the registry when the owning pid is alive", async () => {
+      const fs = new InMemoryFileSystem();
+      await fs.writeFile(
+        REGISTRY_PATH,
+        JSON.stringify({ pid: 999, startedAt: "", servers: {} }),
+      );
+      const store = createStore(fs, () => true);
+
+      await store.removeOrphanRegistry();
+
+      expect(await fs.exists(REGISTRY_PATH)).to.equal(true);
+    });
+
+    it("removes a corrupt registry file", async () => {
+      const fs = new InMemoryFileSystem();
+      await fs.writeFile(REGISTRY_PATH, "not-json");
+      const store = createStore(fs, () => true);
+
+      await store.removeOrphanRegistry();
+
+      expect(await fs.exists(REGISTRY_PATH)).to.equal(false);
+    });
+  });
+
+  describe("registerCoreRuntimeInterface", () => {
+    afterEach(() => {
+      resetProxy(GetRuntimeInfo);
+      resetProxy(RegisterDevServer);
+    });
+
+    it("exposes runtime info and writes the dev registry in dev mode", async () => {
+      const fs = new InMemoryFileSystem();
+      const shutdownManager = new ShutdownManager();
+
+      await registerCoreRuntimeInterface({
+        dev: true,
+        projectPath: PROJECT_PATH,
+        env: "default",
+        fs,
+        shutdownManager,
+      });
+
+      expect(await GetRuntimeInfo()).to.deep.equal({
+        dev: true,
+        projectPath: PROJECT_PATH,
+        env: "default",
+      });
+
+      await RegisterDevServer("api", API_ENDPOINTS);
+      const registry = (await readRegistry(fs)) as {
+        pid: number;
+        servers: Record<string, unknown>;
+      };
+      expect(registry.pid).to.equal(process.pid);
+      expect(registry.servers).to.deep.equal({
+        api: { endpoints: API_ENDPOINTS },
+      });
+
+      await shutdownManager.shutdown();
+      expect(await fs.exists(REGISTRY_PATH)).to.equal(false);
+    });
+
+    it("removes an orphan registry left by a dead process at startup", async () => {
+      const fs = new InMemoryFileSystem();
+      await fs.writeFile(
+        REGISTRY_PATH,
+        JSON.stringify({ pid: 999, startedAt: "", servers: {} }),
+      );
+
+      await registerCoreRuntimeInterface({
+        dev: true,
+        projectPath: PROJECT_PATH,
+        env: "default",
+        fs,
+        isPidAlive: () => false,
+      });
+
+      expect(await fs.exists(REGISTRY_PATH)).to.equal(false);
+    });
+
+    it("keeps GetRuntimeInfo available but skips the registry outside dev mode", async () => {
+      const fs = new InMemoryFileSystem();
+      const shutdownManager = new ShutdownManager();
+
+      await registerCoreRuntimeInterface({
+        dev: false,
+        projectPath: PROJECT_PATH,
+        env: "production",
+        fs,
+        shutdownManager,
+      });
+
+      expect(await GetRuntimeInfo()).to.deep.equal({
+        dev: false,
+        projectPath: PROJECT_PATH,
+        env: "production",
+      });
+
+      await RegisterDevServer("api", API_ENDPOINTS);
+      expect(await fs.exists(REGISTRY_PATH)).to.equal(false);
+    });
+  });
+});

--- a/test/core/dev-server-registry.test.ts
+++ b/test/core/dev-server-registry.test.ts
@@ -88,6 +88,25 @@ describe("core/runtime dev server registry", () => {
       });
     });
 
+    it("serializes concurrent registrations", async () => {
+      const fs = new InMemoryFileSystem();
+      const store = createStore(fs);
+
+      await Promise.all([
+        store.register("api", API_ENDPOINTS),
+        store.register("ws", WS_ENDPOINTS),
+      ]);
+
+      const registry = (await readRegistry(fs)) as {
+        servers: Record<string, unknown>;
+      };
+      expect(registry.servers).to.deep.equal({
+        api: { endpoints: API_ENDPOINTS },
+        ws: { endpoints: WS_ENDPOINTS },
+      });
+      expect(await fs.exists(TEMP_REGISTRY_PATH)).to.equal(false);
+    });
+
     it("cleanup removes the registry only after a registration", async () => {
       const fs = new InMemoryFileSystem();
       await fs.writeFile(REGISTRY_PATH, "{}");


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Implements the core side of the runtime interface introduced in `@antelopejs/interface-core` 0.0.5 (`@antelopejs/interface-core/runtime`):

- **`GetRuntimeInfo()`** resolves `{ dev, projectPath, env }`: `dev: true` for `ajs project dev`/`run` (`launch()`), `dev: false` for `ajs project start` (`launchFromBuild()`).
- **`RegisterDevServer(name, endpoints)`** in dev mode merges registered servers into `.antelope/dev.json` at the project root (`{ pid, startedAt, servers }` contract), written atomically via temp file + rename. Outside dev mode it is a no-op.
- The registry file is removed on shutdown through the existing `ShutdownManager`, and an orphaned file left by a dead process (or a corrupt one) is overwritten at startup.

This lets server modules (e.g. the api module) declare their actually-bound ports so external tooling can discover the running dev backend without hardcoded ports.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [ ] I have run `ajs module exports generate` and committed any updated interface files.

### Test plan

- `pnpm test:unit` — 534 passing, including 9 new tests in `test/core/dev-server-registry.test.ts` covering atomic write with pid/startedAt, server merge, shutdown cleanup, orphan/corrupt file handling, and dev vs non-dev behavior through the interface proxies.
- `pnpm test:playground` — full integration (dev launch + build + launch from build) passes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements `GetRuntimeInfo()` and `RegisterDevServer()` from `@antelopejs/interface-core` 0.0.5, writing a `.antelope/dev.json` registry (pid, startedAt, servers) in dev mode via atomic temp-file rename with serialized writes, orphan cleanup on startup, and `ShutdownManager`-backed removal on exit. Non-dev mode is a no-op for `RegisterDevServer`.

- `DevRegistryStore` serializes concurrent writes through a `pendingWrite` promise chain, using `write.catch(() => undefined)` to keep the chain progressing even on I/O failure, while still propagating the error to the awaiting caller.
- `cleanup()` correctly drains any in-flight write via `await this.pendingWrite` before removing the file, and `{ force: true }` handles the case where no file was ever written.
- Two call sites in `src/index.ts`: `dev: true` in `initializeCore` (dev/hot-reload path) and `dev: false` in `launchFromBuild`; shutdown priority 10 ensures modules (priority 30) fully stop before the registry file is removed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new runtime interface and registry implementation are well-contained, the write path is serialized, cleanup correctly drains in-flight writes, and the shutdown priority ordering ensures modules stop before the registry file is removed.

The core write path serialises concurrent calls through a promise chain, the atomic temp-rename prevents partial reads, and the orphan cleanup handles dead-process and corrupt-file scenarios. Nine new unit tests exercise all of these paths, including the concurrent-write and shutdown-drain cases. No logic errors were found in the changed files.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/runtime/dev-server-registry.ts | New file implementing DevRegistryStore and registerCoreRuntimeInterface; atomic writes via temp+rename with serialized promise chain, orphan cleanup on startup, and shutdown handler for registry removal — logic is sound and well-tested. |
| src/index.ts | Adds two call sites for registerCoreRuntimeInterface — dev:true in initializeCore (launch/hot-reload path) and dev:false in launchFromBuild; placement and options are correct. |
| test/core/dev-server-registry.test.ts | Nine new unit tests covering atomic write format, server merge, concurrent serialization, shutdown drain, orphan detection (dead/alive/corrupt), and dev vs. non-dev interface behavior — good coverage of the critical paths. |
| package.json | Bumps @antelopejs/interface-core from ^0.0.4 to ^0.0.5 to pick up the new runtime interface types (RuntimeInfo, DevServerRegistry, etc.). |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant L as launch or launchFromBuild
    participant RCI as registerCoreRuntimeInterface
    participant DRS as DevRegistryStore
    participant FS as FileSystem
    participant SM as ShutdownManager
    participant MOD as Module via RegisterDevServer

    L->>RCI: options dev projectPath env fs shutdownManager
    RCI->>RCI: path.resolve projectPath
    alt dev is true
        RCI->>DRS: new DevRegistryStore
        DRS->>FS: exists registryFilePath
        alt file exists
            DRS->>FS: readFileString registryFilePath
            alt owner dead or corrupt
                DRS->>FS: rm registryFilePath force
            end
        end
        RCI->>SM: register cleanup handler at priority 10
    end
    RCI->>RCI: ImplementInterface GetRuntimeInfo and RegisterDevServer

    Note over L,SM: Runtime running modules loaded

    MOD->>DRS: RegisterDevServer name endpoints
    DRS->>DRS: update servers map and set hasRegisteredServers
    DRS->>DRS: chain onto pendingWrite promise
    DRS->>FS: mkdir dir recursive
    DRS->>FS: writeFile registryFilePath.tmp
    DRS->>FS: rename tmp to registryFilePath

    Note over L,SM: Shutdown triggered

    SM->>SM: priority 30 stopAll and destroyAll
    SM->>SM: priority 20 stop watchers and REPL
    SM->>DRS: priority 10 cleanup
    DRS->>DRS: await pendingWrite drain in-flight write
    DRS->>FS: rm registryFilePath force
```

<sub>Reviews (3): Last reviewed commit: ["fix(runtime): drain in-flight registry w..."](https://github.com/antelopejs/antelopejs/commit/a7494b04dd0152df7b18128ad1794b6eb7364ba1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37276189)</sub>

<!-- /greptile_comment -->