### PR TITLE
fix(test): register core runtime interface in module test runner

### DIFF
--- a/src/core/test/test-module.ts
+++ b/src/core/test/test-module.ts
@@ -8,8 +8,10 @@ import { setupAntelopeProjectLogging } from "../../logging";
 import type { IFileSystem } from "../../types";
 import { mergeDeep } from "../../utils/object";
 import { ConfigLoader, type LoadedConfig } from "../config/config-loader";
+import { DEFAULT_ENV } from "../config/config-paths";
 import { NodeFileSystem } from "../filesystem";
 import { ModuleManager } from "../module-manager";
+import { registerCoreRuntimeInterface } from "../runtime/dev-server-registry";
 import {
   constructAndStartModules,
   ensureGraphIsValid,
@@ -108,6 +110,7 @@ export async function loadTestConfig(
 export async function setupTestEnvironment(
   moduleRoot: string,
   config: LoadedConfig,
+  fs: IFileSystem = new NodeFileSystem(),
 ): Promise<ModuleManager> {
   setupAntelopeProjectLogging(config.logging);
   const normalizedConfig = normalizeLoadedConfig(config, moduleRoot);
@@ -117,6 +120,12 @@ export async function setupTestEnvironment(
     manager.resolver.stubModulePath = STUB_INTERFACE_PATH;
     await loadModuleEntriesForManager(manager, normalizedConfig, true);
     ensureGraphIsValid(manager);
+    await registerCoreRuntimeInterface({
+      dev: false,
+      projectPath: moduleRoot,
+      env: DEFAULT_ENV,
+      fs,
+    });
     await constructAndStartModules(manager);
     internal.testStubMode = true;
     registerTestDir(path.resolve(moduleRoot), manager);
@@ -264,7 +273,11 @@ export async function TestModule(
       }
     }
 
-    manager = await self.setupTestEnvironment(moduleRoot, loadedConfig.config);
+    manager = await self.setupTestEnvironment(
+      moduleRoot,
+      loadedConfig.config,
+      fs,
+    );
     managerActive = true;
 
     const failures = await self.executeTests(

--- a/test/core/test/test-module.test.ts
+++ b/test/core/test/test-module.test.ts
@@ -571,6 +571,7 @@ describe("test-module", () => {
       resetProxy(GetRuntimeInfo);
 
       const moduleRoot = "/runtime/module";
+      const lengthBefore = internal.moduleByFolder.length;
       await testModule.setupTestEnvironment(moduleRoot, {
         name: "test",
         cacheFolder: ".antelope/cache",
@@ -586,6 +587,7 @@ describe("test-module", () => {
       });
 
       internal.testStubMode = false;
+      internal.moduleByFolder.length = lengthBefore;
       resetProxy(GetRuntimeInfo);
     });
   });

--- a/test/core/test/test-module.test.ts
+++ b/test/core/test/test-module.test.ts
@@ -5,6 +5,37 @@ import { ConfigLoader } from "../../../src/core/config/config-loader";
 import * as testModule from "../../../src/core/test/test-module";
 import { InMemoryFileSystem } from "../../helpers/in-memory-filesystem";
 
+const RUNTIME_INFO_TIMEOUT_MS = 1000;
+
+interface ResettableProxy {
+  onCall(callback: () => undefined, manualDetach?: boolean): void;
+  detach(): void;
+}
+
+interface ProxiedInterfaceFunction {
+  proxy: ResettableProxy;
+}
+
+function resetProxy(interfaceFunction: unknown): void {
+  const { proxy } = interfaceFunction as ProxiedInterfaceFunction;
+  proxy.onCall(() => undefined, true);
+  proxy.detach();
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const guard = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
+  });
+  try {
+    return await Promise.race([promise, guard]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 describe("test-module", () => {
   afterEach(() => {
     sinon.restore();
@@ -526,6 +557,36 @@ describe("test-module", () => {
 
       internal.testStubMode = false;
       internal.moduleByFolder.length = lengthBefore;
+    });
+
+    it("registers the core runtime interface so GetRuntimeInfo resolves instead of hanging", async () => {
+      const { internal } = await import("@antelopejs/interface-core/internal");
+      const { GetRuntimeInfo } = await import(
+        "@antelopejs/interface-core/runtime"
+      );
+      const moduleLoading = require("../../../src/core/runtime/module-loading");
+
+      sinon.stub(moduleLoading, "loadModuleEntriesForManager").resolves([]);
+      sinon.stub(moduleLoading, "constructAndStartModules").resolves();
+      resetProxy(GetRuntimeInfo);
+
+      const moduleRoot = "/runtime/module";
+      await testModule.setupTestEnvironment(moduleRoot, {
+        name: "test",
+        cacheFolder: ".antelope/cache",
+        modules: {},
+        envOverrides: {},
+      } as any);
+
+      const info = await withTimeout(GetRuntimeInfo(), RUNTIME_INFO_TIMEOUT_MS);
+      expect(info).to.deep.equal({
+        dev: false,
+        projectPath: path.resolve(moduleRoot),
+        env: "default",
+      });
+
+      internal.testStubMode = false;
+      resetProxy(GetRuntimeInfo);
     });
   });
 });


### PR DESCRIPTION
## Problème

Le core (depuis 1.4.0) n'enregistre l'implémentation de l'interface runtime que pour les chemins *projet* — `ajs project dev`/`run` (`initializeCore`) et `start` (`launchFromBuild`). Le chemin `ajs module test` (`setupTestEnvironment`) ne l'enregistrait **jamais**.

Conséquence : sous le runner de test, un module testé qui appelle `GetRuntimeInfo()` tombe sur un proxy d'interface-core sans implémentation, qui **reste suspendu indéfiniment**. Le module ne peut alors pas binder ses ports → tous les tests HTTP échouent en `ECONNREFUSED`.

Cas particulièrement pernicieux : l'interface runtime étant une interface *core*, elle n'est ni stubée (échec rapide via `stub-interface`) ni implémentée — elle obtient le vrai proxy bloquant.

## Correctif

- `setupTestEnvironment` appelle désormais `registerCoreRuntimeInterface({ dev: false, ... })` **avant** `constructAndStartModules` (les modules appellent `GetRuntimeInfo()` au binding de leurs ports). `dev: false` évite d'écrire un registre dev-server dans le module pendant les tests, tout en exposant `GetRuntimeInfo`/`RegisterDevServer`.
- `setupTestEnvironment` accepte un `fs` optionnel ; `TestModule` lui passe son `fs` existant.

## Pourquoi ce n'était pas détecté

Les deux moitiés étaient testées isolément (le registre dans `dev-server-registry.test.ts`, le setup test avec `module-loading` mocké dans `test-module.test.ts`), mais rien ne vérifiait que le runner de test *fournit effectivement* l'interface runtime attendue par les modules.

## Test de non-régression

Nouveau cas dans `test-module.test.ts` : après `setupTestEnvironment`, `GetRuntimeInfo()` (sous `withTimeout`) doit résoudre `{ dev: false, projectPath, env: "default" }` au lieu de pendre. Vérifié : échoue (timeout) sans le fix, passe avec.

## Validation

- `pnpm test:unit` : 537 passing, 0 failing
- `tsc --noEmit` : OK
- lint propre sur les fichiers modifiés

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug introduced in 1.4.0 where the `ajs module test` path never registered the core runtime interface, causing any module that calls `GetRuntimeInfo()` during port binding to hang indefinitely — blocking all HTTP tests with `ECONNREFUSED`. The fix calls `registerCoreRuntimeInterface({ dev: false, … })` inside `setupTestEnvironment` before `constructAndStartModules`, and threads the existing `fs` instance through to avoid a redundant `NodeFileSystem` allocation.

- `setupTestEnvironment` now registers the runtime interface (with `dev: false` to suppress dev-server registry writes) before constructing modules, matching the behavior already present in the `initializeCore` and `launchFromBuild` paths.
- A new regression test verifies that `GetRuntimeInfo()` resolves to the expected `{ dev: false, projectPath, env: \"default\" }` value instead of hanging, using a 1-second timeout as a failure sentinel.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive and well-tested, and the only non-test-path modification is a single new call inserted at a well-understood point in the setup sequence.

The production change is a focused one-liner insertion of `registerCoreRuntimeInterface` before `constructAndStartModules`, mirroring the identical call already present in `initializeCore` and `launchFromBuild`. The `dev: false` flag deliberately bypasses file-system side-effects, and `path.resolve` inside the function ensures `projectPath` is normalised correctly. The new test exercises the exact failure mode and passes. No existing behavior is altered for the project or build paths.

No files require special attention beyond the standard review.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/test/test-module.ts | Adds `registerCoreRuntimeInterface` call with `dev: false` before `constructAndStartModules` to fix hanging `GetRuntimeInfo()` in the test runner; also threads the optional `fs` parameter through to avoid creating a redundant `NodeFileSystem` instance. |
| test/core/test/test-module.test.ts | Adds regression test verifying `GetRuntimeInfo()` resolves (instead of hanging) after `setupTestEnvironment`; cleanup at lines 589-591 is not guarded by a `try/finally`, so a failing assertion would leave `internal.testStubMode` set and the `GetRuntimeInfo` proxy registered. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as ajs module test
    participant STE as setupTestEnvironment
    participant RCRI as registerCoreRuntimeInterface
    participant CSM as constructAndStartModules
    participant MOD as Module (GetRuntimeInfo caller)

    CLI->>STE: invoke
    STE->>STE: loadModuleEntriesForManager
    STE->>STE: ensureGraphIsValid
    STE->>RCRI: "registerCoreRuntimeInterface({ dev: false, projectPath, env })"
    note over RCRI: Registers GetRuntimeInfo impl on proxy
    RCRI-->>STE: done
    STE->>CSM: constructAndStartModules
    CSM->>MOD: construct + bind ports
    MOD->>RCRI: GetRuntimeInfo()
    RCRI-->>MOD: "{ dev: false, projectPath, env }"
    note over MOD: resolves (was hanging before fix)
    CSM-->>STE: done
    STE->>STE: "testStubMode = true, registerTestDir"
```

<sub>Reviews (2): Last reviewed commit: ["test: restore internal.moduleByFolder le..."](https://github.com/antelopejs/antelopejs/commit/d7563c296982435fd736a866340c56b0c765e99f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37481287)</sub>

<!-- /greptile_comment -->