### PR TITLE
feat(logging): default log level to info instead of warn

### DIFF
--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -72,11 +72,11 @@ function resolveLevelValue(level: number | string): number {
 
 function getChannelFilter(channel: string): number {
   if (!loggingConfig.channelFilter) {
-    return levelMap.warn;
+    return levelMap.info;
   }
 
   let match = -1;
-  let matchValue: number | string = levelMap.warn;
+  let matchValue: number | string = levelMap.info;
   for (const key of Object.keys(loggingConfig.channelFilter)) {
     if (key.endsWith("*")) {
       const prefix = key.substring(0, key.length - 1);
@@ -186,7 +186,7 @@ function registerLogHandler(): void {
 
 function initializeLogger(): void {
   globalLogger = new Logger();
-  globalLogger.setMinLevel(LogLevel.WARN);
+  globalLogger.setMinLevel(LogLevel.INFO);
   if (loggingConfig.channelFilter) {
     for (const [channel, level] of Object.entries(
       loggingConfig.channelFilter,


### PR DESCRIPTION
## Résumé

Passe le niveau de log par défaut de `WARN` à `INFO` afin que les logs `INFO` soient affichés dès le départ, sans configuration explicite. Auparavant, un projet sans config logging n'affichait aucun log d'activité normale (démarrage, modules chargés, etc.), ce qui pouvait laisser croire que rien ne se passait.

## Changements

Dans `src/logging/index.ts` :
- `getChannelFilter` : filtre par défaut `levelMap.warn` → `levelMap.info` (valeur retournée et `matchValue` initial)
- `initializeLogger` : `globalLogger.setMinLevel(LogLevel.WARN)` → `LogLevel.INFO`

Le fallback de `resolveLevelValue` (chaîne illisible) reste sur `warn` — c'est un garde-fou, pas le défaut d'affichage.

## Logs affichés par défaut

| Niveau | Avant | Après |
|--------|-------|-------|
| `TRACE` | ❌ | ❌ |
| `DEBUG` | ❌ | ❌ |
| `INFO`  | ❌ | ✅ |
| `WARN`  | ✅ | ✅ |
| `ERROR` | ✅ | ✅ |

## Tests

- `pnpm build` : OK
- `pnpm lint` : seulement warnings préexistants (sans rapport)
- `pnpm test:unit` : 537 passing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the default log level from `WARN` to `INFO` so that startup activity, loaded modules, and other informational messages are visible out-of-the-box without any explicit logging configuration. The change touches three points consistently: the channel-filter default return value, the `matchValue` initializer used when a `channelFilter` config exists but no key matches a given channel, and the `globalLogger.setMinLevel` call in `initializeLogger`.

- `getChannelFilter` now returns `levelMap.info` (20) when no `channelFilter` config is present, and initializes `matchValue` to `levelMap.info` for unmatched channels when a partial config is present — both previously returned `levelMap.warn` (30).
- `initializeLogger` now calls `globalLogger.setMinLevel(LogLevel.INFO)`, aligning the logger's internal gate with the channel-filter default.
- The fallback in `resolveLevelValue` for unrecognized string config values intentionally remains at `levelMap.warn`, which is a safe guard for misconfigured entries.

<h3>Confidence Score: 5/5</h3>

This is a straightforward, intentional default behavior change with no logic errors — safe to merge.

All three changed sites are consistent with each other and with the stated intent. The error-fallback in `resolveLevelValue` is deliberately left at `warn`, which is a sensible guard for invalid config. The only real-world impact is that projects without explicit logging config will now emit INFO-level messages by default, which is the goal of the PR.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/logging/index.ts | Three-line default level change from WARN to INFO; all three sites are internally consistent and the `resolveLevelValue` error-fallback is intentionally left at WARN. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Log event emitted] --> B{shouldIgnoreChannel?}
    B -- channel in cache --> C[Use cached filter value]
    B -- not in cache --> D{loggingConfig.channelFilter set?}
    D -- No --> E["return levelMap.info (default, was: warn)"]
    D -- Yes --> F[Iterate channelFilter keys]
    F -- match found --> G[matchValue = config entry]
    F -- no match --> H["matchValue stays at levelMap.info (was: warn)"]
    G --> I[resolveLevelValue]
    H --> I
    E --> J{filter > log.levelId?}
    I --> J
    C --> J
    J -- Yes / filtered out --> K[Drop log]
    J -- No / passes --> L[globalLogger.write]
    L --> M{level >= globalLogger.minLevel?}
    M -- "minLevel = INFO (was: WARN)" --> N[Output to transport]
    M -- below minLevel --> K
```

<sub>Reviews (1): Last reviewed commit: ["feat(logging): default log level to info..."](https://github.com/antelopejs/antelopejs/commit/af41945b2699f2879167d4f64da3bff25e61c750) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37497429)</sub>

<!-- /greptile_comment -->