### PR TITLE
chore(deps): bump interface-core to ^0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test:coverage": "c8 --check-coverage --lines 90 --functions 90 --branches 90 --statements 90 mocha --require ts-node/register --require test/setup.ts 'test/**/*.test.ts' --exit"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.5",
+    "@antelopejs/interface-core": "^0.0.6",
     "@types/proper-lockfile": "^4.1.4",
     "boxen": "^8.0.1",
     "chalk": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.5
-        version: 0.0.5
+        specifier: ^0.0.6
+        version: 0.0.6
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
@@ -105,8 +105,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.5':
-    resolution: {integrity: sha512-4H6hpFfiK2+DE8vL2mEtPbq1WNch9lt40QNr9KjBrOAtnuq/zMfIlzhbEsda39m+FVkMWXfUYoVolRogVKCLIQ==}
+  '@antelopejs/interface-core@0.0.6':
+    resolution: {integrity: sha512-OMna86iT/ylL6wJl6FCPw9ieddULXGs4jTmeiDBNEXYQ9acnVXjS/+SaN0UR0h7oY7WTD9VwKXVwG95qjNIA1w==}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -1762,7 +1762,7 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.5':
+  '@antelopejs/interface-core@0.0.6':
     dependencies:
       reflect-metadata: 0.2.2
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Bumps `@antelopejs/interface-core` from `^0.0.5` to `^0.0.6`.

The 0.0.6 release fixes a bug in `AsyncProxy.call()`: when an implementation callback threw **synchronously** (e.g. a guard like `if (!config) throw ...`), the exception propagated synchronously instead of being wrapped in a rejected promise — violating the method's `Promise<R>` signature.

The internal inconsistency proving it was a bug: the queue-replay path (`onCall`) already wrapped sync throws in a `try/catch` and converted them to rejections, while the direct-call path (callback already attached) did not. Behaviour therefore depended on callback-attachment timing. 0.0.6 aligns the direct-call path with the replay path.

Note: with `^0.0.5` the caret is locked to `0.0.x` exact (semver treats every patch of `0.0.z` as breaking), so an explicit bump to `^0.0.6` is required to resolve the fix.

### ✅ Verification

- `pnpm install` resolves `interface-core@0.0.6`; the `try/catch` fix is present in the shipped `dist/proxies.js`.
- `pnpm build` — OK
- `pnpm test:unit` — **537 passing**

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [ ] I have run `ajs module exports generate` and committed any updated interface files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `@antelopejs/interface-core` from `^0.0.5` to `^0.0.6` to pick up a bug fix in `AsyncProxy.call()` where synchronous throws from implementation callbacks propagated synchronously instead of being wrapped in a rejected `Promise`, violating the method's `Promise<R>` return type contract.

- **`package.json`**: Version specifier updated from `^0.0.5` to `^0.0.6`.
- **`pnpm-lock.yaml`**: Resolved version, integrity hash, and snapshot updated to `0.0.6`; transitive dependency (`reflect-metadata: 0.2.2`) is unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal, well-described dependency bump with no logic changes in this repository.

Only two files change: the version specifier in package.json and the corresponding lock file entry in pnpm-lock.yaml. The upstream fix is narrowly scoped to AsyncProxy.call() error-handling alignment, the transitive dependency tree is unchanged (reflect-metadata: 0.2.2), and the PR author confirms 537 unit tests pass.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Single-line dependency bump from ^0.0.5 to ^0.0.6; no other changes. |
| pnpm-lock.yaml | Lock file regenerated correctly: resolved version, integrity SHA-512, and snapshot updated; transitive deps unchanged. |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant AsyncProxy
    participant Callback as Implementation Callback

    Note over AsyncProxy: Before 0.0.6 (direct-call path)
    Caller->>AsyncProxy: call()
    AsyncProxy->>Callback: invoke directly
    Callback-->>Caller: throws synchronously (unhandled sync throw)

    Note over AsyncProxy: After 0.0.6 (aligned paths)
    Caller->>AsyncProxy: call()
    AsyncProxy->>Callback: invoke inside try/catch
    Callback-->>AsyncProxy: throws synchronously
    AsyncProxy-->>Caller: Promise.reject(error)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant AsyncProxy
    participant Callback as Implementation Callback

    Note over AsyncProxy: Before 0.0.6 (direct-call path)
    Caller->>AsyncProxy: call()
    AsyncProxy->>Callback: invoke directly
    Callback-->>Caller: throws synchronously (unhandled sync throw)

    Note over AsyncProxy: After 0.0.6 (aligned paths)
    Caller->>AsyncProxy: call()
    AsyncProxy->>Callback: invoke inside try/catch
    Callback-->>AsyncProxy: throws synchronously
    AsyncProxy-->>Caller: Promise.reject(error)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump interface-core to ^0.0..."](https://github.com/antelopejs/antelopejs/commit/36dd273c0ee5d40cec314e5dd42a17387b3761e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37933271)</sub>

<!-- /greptile_comment -->