### PR TITLE
feat(cli): add reloadCommand and watchDir to generated local modules

### DIFF
--- a/src/core/cli/commands/project/modules/add.ts
+++ b/src/core/cli/commands/project/modules/add.ts
@@ -18,6 +18,9 @@ import { ExecuteCMD } from "../../../command";
 import { Options, readConfig, writeConfig } from "../../../common";
 import { parsePackageInfoOutput } from "../../../package-manager";
 
+const LOCAL_MODULE_WATCH_DIRS = ["src"];
+const LOCAL_MODULE_BUILD_COMMAND = ["npx tsc"];
+
 interface AddOptions {
   mode: string;
   project: string;
@@ -314,7 +317,9 @@ handlers.set("local", async (module, options) => {
       source: {
         type: "local",
         path: path.relative(options.project, resolvedModulePath) || ".",
-        installCommand: ["npx tsc"],
+        watchDir: LOCAL_MODULE_WATCH_DIRS,
+        installCommand: LOCAL_MODULE_BUILD_COMMAND,
+        reloadCommand: LOCAL_MODULE_BUILD_COMMAND,
       },
     },
   ];
@@ -334,7 +339,9 @@ handlers.set("dir", async (module, options) => {
       source: {
         type: "local-folder",
         path: path.relative(options.project, resolvedFolderPath) || ".",
-        installCommand: ["npx tsc"],
+        watchDir: LOCAL_MODULE_WATCH_DIRS,
+        installCommand: LOCAL_MODULE_BUILD_COMMAND,
+        reloadCommand: LOCAL_MODULE_BUILD_COMMAND,
       },
     },
   ];

--- a/test/core/cli/commands/project/modules.behavior.test.ts
+++ b/test/core/cli/commands/project/modules.behavior.test.ts
@@ -483,6 +483,10 @@ describe("project modules behavior", () => {
       } as any);
       expect(localName).to.equal("moduleA");
       expect((localConfig as any).source.type).to.equal("local");
+      expect((localConfig as any).source.watchDir).to.deep.equal(["src"]);
+      expect((localConfig as any).source.reloadCommand).to.deep.equal([
+        "npx tsc",
+      ]);
 
       const dirHandler = handlers.get("dir")!;
       const [dirName, dirConfig] = await dirHandler(pkgDir, {
@@ -490,6 +494,10 @@ describe("project modules behavior", () => {
       } as any);
       expect(dirName.startsWith(":")).to.equal(true);
       expect((dirConfig as any).source.type).to.equal("local-folder");
+      expect((dirConfig as any).source.watchDir).to.deep.equal(["src"]);
+      expect((dirConfig as any).source.reloadCommand).to.deep.equal([
+        "npx tsc",
+      ]);
     } finally {
       cleanupTempDir(tempDir);
     }


### PR DESCRIPTION
## What

Local (`type: "local"`) and local-folder (`type: "local-folder"`) module sources generated by `ajs project init` and `ajs project modules add --mode local/dir` now include:

- `watchDir: ["src"]`
- `reloadCommand: ["npx tsc"]`

## Why

Blank and Todo templates intentionally ship **without** an `antelope.config.ts` — the CLI generates it on init (see `template-todo-typescript` commit `chore: remove antelope.config.ts so the CLI generates it on init`). So the reload config for those templates has to come from the generator here, not from the template repos.

- **`reloadCommand`** runs a fast `tsc` on hot-reload. Paired with `incremental: true` in the templates' `tsconfig.json`, reloads only recompile what changed.
- **`watchDir: ["src"]`** scopes the file watcher to sources. The watcher excludes `.git`/`node_modules` but **not** `dist`; without this scope, `tsc` rewriting `dist` would re-trigger the watcher in a loop.

Shared values are extracted to named constants (`LOCAL_MODULE_WATCH_DIRS`, `LOCAL_MODULE_BUILD_COMMAND`) per repo conventions. Behavior test updated to assert the new fields.

## Related

Companion PRs add `incremental` (and, for module-typescript, `reloadCommand`) to the template repos:
- AntelopeJS/template-blank-typescript#6
- AntelopeJS/template-todo-typescript#4
- template-module-typescript (incremental + reloadCommand in committed playground config)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `watchDir: ["src"]` and `reloadCommand: ["npx tsc"]` to the generated config for `local` and `local-folder` module sources, extracted into named constants. The motivation is that templates no longer ship their own `antelope.config.ts`, so the generator must supply the hot-reload configuration.

- Both the `local` and `dir` handlers in `add.ts` are updated consistently, and since `init.ts` delegates to the same `local` handler, project init also benefits automatically.
- The behavior test is updated to assert both new fields for both handler types.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive, touches only two handlers, and is covered by the updated behavior test.

The diff is small and self-contained: two new fields added to both local source handlers, extracted into constants that are easy to audit, and the test suite asserts the correct values for both. The init command already delegates to the same local handler, so it inherits the new config without any extra work.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/cli/commands/project/modules/add.ts | Adds watchDir and reloadCommand fields to local/local-folder source config, extracted into named constants; logic is minimal and consistent across both handlers. |
| test/core/cli/commands/project/modules.behavior.test.ts | Adds assertions for the new watchDir and reloadCommand fields in both the local and dir handler test cases; coverage is adequate. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ajs project init or modules add] --> B{mode}
    B -->|local| C[local handler]
    B -->|dir| D[dir handler]
    C --> E["source config: type=local, watchDir=src, installCommand=npx tsc, reloadCommand=npx tsc"]
    D --> F["source config: type=local-folder, watchDir=src, installCommand=npx tsc, reloadCommand=npx tsc"]
    E --> G[writeConfig to antelope.config.ts]
    F --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ajs project init or modules add] --> B{mode}
    B -->|local| C[local handler]
    B -->|dir| D[dir handler]
    C --> E["source config: type=local, watchDir=src, installCommand=npx tsc, reloadCommand=npx tsc"]
    D --> F["source config: type=local-folder, watchDir=src, installCommand=npx tsc, reloadCommand=npx tsc"]
    E --> G[writeConfig to antelope.config.ts]
    F --> G
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): add reloadCommand and watchDi..."](https://github.com/antelopejs/antelopejs/commit/ac8e4460d64a20f6da392d77ab1a714cb98236b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40470504)</sub>

<!-- /greptile_comment -->