### PR TITLE
docs: add framework documentation

### DIFF
--- a/docs/1.get-started/.navigation.yml
+++ b/docs/1.get-started/.navigation.yml
@@ -1,0 +1,2 @@
+title: Get Started
+icon: i-ph-rocket-launch

--- a/docs/1.get-started/1.introduction.md
+++ b/docs/1.get-started/1.introduction.md
@@ -1,0 +1,46 @@
+---
+title: Introduction
+description: An overview of the Antelopejs framework — a TypeScript framework for building modular, scalable applications using interface-based architecture.
+navigation:
+  icon: i-ph-info
+---
+
+## What is Antelopejs
+
+Antelopejs is a TypeScript framework for building modular, scalable applications using interface-based architecture. Modules communicate through interfaces — well-defined contracts that describe what a module provides — rather than importing each other directly. This design enables loose coupling between components and makes it possible to hot-swap module implementations at runtime.
+
+## Key Features
+
+::card-group
+::card{icon="i-ph-brackets-curly" title="Interface-Based Architecture"}
+Modules communicate through contracts, not direct dependencies. A module never needs to know which other module fulfills its requirements.
+::
+
+::card{icon="i-ph-rocket-launch" title="Hot Module Reloading"}
+Swap modules at runtime during development. Changes take effect immediately without restarting the entire application.
+::
+
+::card{icon="i-ph-code" title="Full TypeScript Support"}
+End-to-end type safety across module boundaries. Interfaces are fully typed, so your editor catches errors before you run anything.
+::
+
+::card{icon="i-ph-puzzle-piece" title="Modular Design"}
+Build applications as composable modules. Each module is an independent package that you can develop, test, and deploy on its own.
+::
+
+::card{icon="i-ph-arrows-split" title="Swap Without Rewriting"}
+Change your database, payment provider, or notification service by swapping one module for another. Dependent code stays the same because the interface contract holds.
+::
+::
+
+::warning
+HMR is currently available only for development environments. Production-ready HMR is planned for a future release.
+::
+
+## Philosophy
+
+Traditional frameworks pack too many features into their core, making them hard to customize and painful to upgrade. Antelopejs takes a different approach: instead of a monolithic framework, you compose applications from independent modules.
+
+Each module exports interfaces that describe what it provides and imports interfaces that describe what it needs. The core manages module lifecycle and routes interface calls between producers and consumers. You never wire modules together manually.
+
+This architecture means you can swap any module implementation without changing the code that depends on it. Switching from one database provider to another, or replacing a payment gateway, requires only a configuration change — the consuming modules keep working because the interface contract stays the same.

--- a/docs/1.get-started/2.installation.md
+++ b/docs/1.get-started/2.installation.md
@@ -1,0 +1,50 @@
+---
+title: Installation
+description: Install the Antelopejs CLI and verify your development environment is ready.
+navigation:
+  icon: i-ph-download
+---
+
+## Prerequisites
+
+Antelopejs requires **Node.js v18 or higher**. You can check your current version by running:
+
+```bash
+node --version
+```
+
+## Install the CLI
+
+Install the Antelopejs CLI globally using your preferred package manager:
+
+:::code-group
+
+```bash [npm]
+npm install -g @antelopejs/core
+```
+
+```bash [yarn]
+yarn global add @antelopejs/core
+```
+
+```bash [pnpm]
+pnpm add -g @antelopejs/core
+```
+
+:::
+
+After installation, the `ajs` command is available globally in your terminal.
+
+## Verify Installation
+
+Confirm that the CLI installed correctly by checking its version:
+
+```bash
+ajs --version
+```
+
+The command should print the installed version number. If you see a "command not found" error, make sure your global package manager bin directory is in your system's `PATH`.
+
+::tip
+The `ajs` command is the single entry point for all Antelopejs operations — creating projects, managing modules, running builds, and more. Every command in this documentation starts with `ajs`.
+::

--- a/docs/1.get-started/3.quick-start.md
+++ b/docs/1.get-started/3.quick-start.md
@@ -1,0 +1,59 @@
+---
+title: Quick Start
+description: Create and run your first Antelopejs project in under five minutes.
+navigation:
+  icon: i-ph-play
+---
+
+## Your First Project
+
+Create a project with a local module and run the application in development mode.
+
+::steps{level="4"}
+
+#### Create a new project
+
+Scaffold a new project with the `project init` command:
+
+```bash
+ajs project init my-project
+```
+
+The interactive wizard asks you to name your project and offers to create a new local module. Select the option to create a module — the wizard generates the module files and registers it automatically in your `antelope.config.ts` configuration.
+
+#### Run the project
+
+Start the project in development mode:
+
+```bash
+ajs project dev
+```
+
+The development server starts and loads all configured modules. Once every module completes its lifecycle, the application is ready to handle requests.
+
+::note
+`ajs project run` is an alias for `ajs project dev`. Both commands start the project in development mode.
+::
+
+#### Enable watch mode
+
+For automatic reloading when source files change, add the `--watch` flag:
+
+```bash
+ajs project dev --watch
+```
+
+The `--watch` flag enables Hot Module Reloading (HMR). When you modify a module's source code, the core unloads the old version and loads the updated one without restarting the entire application.
+
+::
+
+## What Happens at Startup
+
+When you run `ajs project dev`, the following sequence takes place:
+
+1. The core loads and resolves module configurations from `antelope.config.ts`
+2. The core downloads and caches required modules
+3. The core validates the interface dependency graph (ensures all required interfaces have providers)
+4. Each module executes `construct()` — internal state is initialized and interface implementations are registered
+5. Each module executes `start()` — all interfaces are now resolved and operational
+6. The application is ready to serve requests

--- a/docs/1.get-started/4.architecture.md
+++ b/docs/1.get-started/4.architecture.md
@@ -1,0 +1,105 @@
+---
+title: Architecture
+description: Understand the core architecture of Antelopejs — interfaces, modules, and the core — and how they create a flexible, modular system.
+navigation:
+  icon: i-ph-blueprint
+---
+
+## Overview
+
+Antelopejs follows an interface-based architecture built on three core concepts: **Interfaces**, **Modules**, and **the Core**. Together, they create a system where components are loosely coupled, independently replaceable, and easy to reason about.
+
+## Interfaces — Contracts Between Modules
+
+An interface defines a contract: a set of functions, events, or registrations that a module provides to the rest of the application. Other modules import and call these interfaces without knowing which module implements them.
+
+This separation is the foundation of loose coupling in Antelopejs. A module that needs database access imports the database interface — it never imports the database module directly. The core resolves which module fulfills the contract at runtime.
+
+<Mermaid>
+graph LR
+    A["Module A (Producer)"] -->|exports| I((Interface X))
+    I -->|imports| B["Module B (Consumer)"]
+    style I fill:#f0ad4e,stroke:#333,color:#333
+    style A fill:#5cb85c,stroke:#333,color:#fff
+    style B fill:#337ab7,stroke:#333,color:#fff
+</Mermaid>
+
+Module A exports Interface X, defining the contract. Module B imports Interface X and calls its methods. Module B has no dependency on Module A — only on the interface.
+
+## Modules — Building Blocks
+
+Each module is an independent package that exports and/or imports interfaces. Modules are self-contained: they have their own dependencies, configuration, and lifecycle.
+
+Every module follows the same lifecycle:
+
+1. **Construct** — The module initializes its internal state
+2. **Start** — The module begins serving its interfaces
+3. **Stop** — The module stops serving and cleans up active work
+4. **Destroy** — The module releases all resources
+
+Each lifecycle function maps to a specific state transition:
+
+| Function | Transition |
+|----------|-----------|
+| `construct()` | loaded → constructed |
+| `start()` | constructed → active |
+| `stop()` | active → constructed |
+| `destroy()` | constructed → loaded |
+
+<Mermaid>
+stateDiagram-v2
+    [*] --> Loaded: Module resolved
+    Loaded --> Constructed: construct()
+    Constructed --> Active: start()
+    Active --> Constructed: stop()
+    Constructed --> Loaded: destroy()
+</Mermaid>
+
+Because modules only depend on interfaces, you can replace any module with another that implements the same interfaces. The consuming modules keep working without any code changes.
+
+<Mermaid>
+graph TD
+    S[Stripe Module] -->|implements| P((Payment Interface))
+    O[Ogone Module] -->|implements| P
+    P -->|used by| C[Checkout Module]
+    style P fill:#f0ad4e,stroke:#333,color:#333
+    style S fill:#5cb85c,stroke:#333,color:#fff
+    style O fill:#5cb85c,stroke:#333,color:#fff
+    style C fill:#337ab7,stroke:#333,color:#fff
+</Mermaid>
+
+Both the Stripe module and the Ogone module implement the Payment interface. The Checkout module consumes the Payment interface. Swapping Stripe for Ogone requires only a configuration change — the Checkout module remains untouched.
+
+## The Core — The Conductor
+
+The core is minimal by design. It handles three responsibilities:
+
+- **Module lifecycle** — Loading, starting, stopping, and destroying modules in the correct order
+- **Interface routing** — Connecting interface producers to consumers automatically
+- **Runtime management** — Graceful shutdown, Hot Module Reloading (HMR) orchestration, and error propagation
+
+The core does not contain business logic. Instead, the core acts as the conductor: it makes sure modules start in the right order, interfaces find their implementations, and failures propagate cleanly.
+
+## Benefits
+
+This architecture delivers practical advantages across the entire development lifecycle:
+
+- **Consistent patterns** — Every module follows the same structure and lifecycle, so onboarding is fast and code reviews are predictable
+- **Swap without rewriting** — Change your database, payment provider, or notification service by swapping one module for another. Dependent code stays the same because the interface contract holds
+- **Predictable contracts** — Interfaces define stable boundaries between modules. Changes to an interface are explicit and intentional, keeping dependent modules safe
+- **Live development updates** — HMR gives you immediate feedback during development. Change a module, save the file, and the updated code loads automatically
+
+## Error Handling
+
+Each lifecycle phase propagates errors differently.
+
+**construct()** — Errors propagate to the module manager. The resolver detour detaches on failure. Modules construct in parallel via `Promise.all`, so other modules may continue constructing, but the first rejection causes the overall boot to fail.
+
+**start()** — This function is synchronous with no internal try/catch. An exception propagates immediately and prevents remaining modules from starting. The system may end up in a mixed state where some modules have started and others have not.
+
+**stop() / destroy()** — Errors propagate similarly. These functions can be async or sync. A failure during teardown does not automatically roll back other modules that have already stopped or been destroyed.
+
+## See also
+
+- [Modules](/docs/concepts/modules) — Module states and lifecycle details
+- [Creating a Module](/docs/module-development/creating-a-module) — Practical guide to implementing lifecycle functions

--- a/docs/1.get-started/index.md
+++ b/docs/1.get-started/index.md
@@ -1,0 +1,22 @@
+---
+title: Get Started
+navigation: false
+---
+
+::card-group
+::card{icon="i-ph-info" title="Introduction" to="/docs/get-started/introduction"}
+Learn about Antelopejs, its philosophy, key features, and how interface-based architecture helps you build better applications.
+::
+
+::card{icon="i-ph-download" title="Installation" to="/docs/get-started/installation"}
+Install the Antelopejs CLI and set up your development environment.
+::
+
+::card{icon="i-ph-play" title="Quick Start" to="/docs/get-started/quick-start"}
+Create and run your first Antelopejs project in under five minutes.
+::
+
+::card{icon="i-ph-blueprint" title="Architecture" to="/docs/get-started/architecture"}
+Understand the core architecture of Antelopejs: interfaces, modules, and the core.
+::
+::

--- a/docs/2.concepts/.navigation.yml
+++ b/docs/2.concepts/.navigation.yml
@@ -1,0 +1,2 @@
+title: Concepts
+icon: i-ph-lightbulb

--- a/docs/2.concepts/1.interfaces.md
+++ b/docs/2.concepts/1.interfaces.md
@@ -1,0 +1,246 @@
+---
+title: Interfaces
+description: Interfaces define the contracts that modules use to communicate — declaring functions, events, and registrations without tying them to any specific implementation.
+navigation:
+  icon: i-ph-brackets-curly
+---
+
+## What Is an Interface
+
+An interface is a contract that defines how modules communicate. The contract declares functions, events, or registrations without implementing them. Producers fulfill the contract, and consumers call the contract — neither side knows about the other directly.
+
+The AntelopeJS core resolves which module fulfills each interface at runtime. A module that needs email delivery imports the email interface, not the email module. Modules depend on contracts rather than on each other, which keeps them independent and interchangeable.
+
+## What an Interface Contains
+
+An interface file is more than type definitions and proxy declarations. The file serves as the complete public surface that both producers and consumers rely on.
+
+An interface can contain:
+
+- **Type definitions** — TypeScript types and interfaces shared between producer and consumer
+- **Proxy instances** — `InterfaceFunction`, `EventProxy`, and `RegisteringProxy` declarations that define the contract points
+- **Wrapper functions** — Public API functions that call the underlying proxies, providing a cleaner API surface
+- **Decorator factories** — Decorators used by consumers (e.g., `@Controller`, `@Authentication`)
+- **Utility code** — Helper classes, query builders, metadata management — any generic code that stays the same regardless of the implementation
+
+The following example shows an interface file with shared types, internal proxies, and public wrapper functions:
+
+```typescript [src/interface/index.ts]
+import { InterfaceFunction } from "@antelopejs/interface-core";
+
+// Types shared between producer and consumer
+export interface EmailParams {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+export interface EmailResult {
+  messageId: string;
+  status: string;
+}
+
+// Internal proxies — the actual contract points
+export namespace internal {
+  export const sendEmailProxy = InterfaceFunction<(params: EmailParams) => Promise<EmailResult>>();
+  export const getStatusProxy = InterfaceFunction<(messageId: string) => Promise<string>>();
+}
+
+// Public API — clean wrapper functions for consumers
+export function SendEmail(params: EmailParams): Promise<EmailResult> {
+  return internal.sendEmailProxy(params);
+}
+
+export function GetEmailStatus(messageId: string): Promise<string> {
+  return internal.getStatusProxy(messageId);
+}
+```
+
+Consumers call `SendEmail(params)` instead of reaching for the proxy directly. The wrapper functions provide a stable, readable API while the proxies handle the runtime resolution behind the scenes.
+
+::note
+Interface files can contain generic code that does not change between implementations. Decorator factories, utility functions, and helper classes belong in the interface when all implementations share the same behavior.
+::
+
+## Embedded vs Standalone Interfaces
+
+Interfaces take one of two forms depending on how many modules need to implement them.
+
+### Embedded Interface
+
+An embedded interface lives inside the module that implements the contract, in a `src/interface/` directory. The module contains both the contract and its implementation. Embedded interfaces are the natural starting point when you create a new module with a new interface.
+
+```
+my-module/
+├── src/
+│   ├── index.ts
+│   ├── interface/
+│   │   └── index.ts          # Interface contract
+│   └── implementations/
+│       └── index.ts          # Implementation
+```
+
+The module entry point connects the contract to its implementation:
+
+```typescript [src/index.ts]
+import { ImplementInterface } from "@antelopejs/interface-core";
+
+export async function construct() {
+  ImplementInterface(
+    await import("./interface"),
+    await import("./implementations")
+  );
+}
+```
+
+### Standalone Interface Package
+
+When an interface needs multiple implementations, extract the contract into its own npm package. The standalone interface package contains only the contract — types, proxies, wrappers, and utilities. Each implementing module lives in a separate package and declares the interface in its `implements` field.
+
+```
+@antelopejs/interface-email/     # Standalone interface package
+├── src/
+│   └── index.ts                 # Types, proxies, wrappers
+
+@antelopejs/email-brevo/         # Implementation module A
+├── src/
+│   ├── index.ts
+│   └── implementations/
+│       └── email/
+│           └── index.ts
+
+@antelopejs/email-sendgrid/      # Implementation module B
+├── src/
+│   ├── index.ts
+│   └── implementations/
+│       └── email/
+│           └── index.ts
+```
+
+Each implementing module references the external interface package in its configuration:
+
+```json [package.json]
+{
+  "antelopeJs": {
+    "implements": ["@antelopejs/interface-email"]
+  }
+}
+```
+
+The module entry point imports the interface from the standalone package instead of a local path:
+
+```typescript [src/index.ts]
+import { ImplementInterface } from "@antelopejs/interface-core";
+
+export async function construct() {
+  ImplementInterface(
+    await import("@antelopejs/interface-email"),
+    await import("./implementations/email")
+  );
+}
+```
+
+### When to Extract
+
+Start with an embedded interface and extract to a standalone package when the situation calls for it. Three signals indicate that extraction makes sense:
+
+- A second module needs to implement the same interface
+- Consumers should depend on the contract without depending on a specific implementation
+- The interface becomes part of the public ecosystem and needs its own release cycle
+
+::tip
+Start with an embedded interface. Extract to a standalone package only when a second implementation appears. Premature extraction adds complexity without benefit.
+::
+
+## Complete Example
+
+The following example walks through a storage interface from declaration to consumption. It covers three files: the interface contract, the producer module that implements it, and a consumer module that uses it.
+
+### Step 1 — Declare the interface
+
+The interface defines a key-value storage contract with `get` and `set` operations. `InterfaceFunction` creates typed proxies, and wrapper functions provide the public API.
+
+```typescript [src/interface/index.ts]
+import { InterfaceFunction } from "@antelopejs/interface-core";
+
+// Shared types
+export interface StorageEntry {
+  key: string;
+  value: string;
+  updatedAt: number;
+}
+
+// Internal proxies — the contract points
+export namespace internal {
+  export const getProxy = InterfaceFunction<(key: string) => Promise<StorageEntry | null>>();
+  export const setProxy = InterfaceFunction<(key: string, value: string) => Promise<StorageEntry>>();
+}
+
+// Public API — consumers call these functions
+export function Get(key: string): Promise<StorageEntry | null> {
+  return internal.getProxy(key);
+}
+
+export function Set(key: string, value: string): Promise<StorageEntry> {
+  return internal.setProxy(key, value);
+}
+```
+
+### Step 2 — Implement in the producer module
+
+The producer module exports a namespace that matches the interface's `internal` namespace. The core binds each proxy to the corresponding function by matching names.
+
+```typescript [src/implementations/index.ts]
+import type { StorageEntry } from "../interface";
+
+const store = new Map<string, StorageEntry>();
+
+export namespace internal {
+  export async function getProxy(key: string): Promise<StorageEntry | null> {
+    return store.get(key) ?? null;
+  }
+
+  export async function setProxy(key: string, value: string): Promise<StorageEntry> {
+    const entry: StorageEntry = { key, value, updatedAt: Date.now() };
+    store.set(key, entry);
+    return entry;
+  }
+}
+```
+
+The module entry point connects the interface to its implementation during the `construct` phase.
+
+```typescript [src/index.ts]
+import { ImplementInterface } from "@antelopejs/interface-core";
+
+export async function construct() {
+  ImplementInterface(
+    await import("./interface"),
+    await import("./implementations")
+  );
+}
+```
+
+### Step 3 — Consume from another module
+
+A consumer module imports the wrapper functions from the interface and calls them directly. The consumer has no dependency on the producer module — only on the contract.
+
+```typescript [src/index.ts]
+import { Get, Set } from "@your-org/storage-module/interface";
+
+export async function start() {
+  await Set("greeting", "hello world");
+
+  const entry = await Get("greeting");
+  if (entry) {
+    console.log(entry.value); // "hello world"
+  }
+}
+```
+
+If the proxy has no implementation attached yet when the consumer calls `Get` or `Set`, the call queues automatically and resolves once a producer module attaches its implementation. This queuing behavior means module load order does not matter.
+
+## See also
+
+- [Proxies](/docs/concepts/proxies) — How proxy types handle inter-module communication
+- [Exporting Interfaces](/docs/module-development/exporting-interfaces) — How to export interfaces from your module

--- a/docs/2.concepts/2.modules.md
+++ b/docs/2.concepts/2.modules.md
@@ -1,0 +1,142 @@
+---
+title: Modules
+description: Modules are the building blocks of an Antelopejs application — self-contained packages with a defined lifecycle, configuration, and interface bindings.
+navigation:
+  icon: i-ph-cube
+---
+
+## Module Structure
+
+A module is a standard npm package with an `antelopeJs` field in its `package.json`. This field tells the core what the module implements, where to find its compiled output, and how to resolve its internal imports.
+
+```json [package.json]
+{
+  "name": "my-module",
+  "antelopeJs": {
+    "implements": ["@antelopejs/interface-example"],
+    "baseUrl": "dist",
+    "paths": { "@/*": ["*"] },
+    "moduleAliases": {},
+    "defaultConfig": {}
+  }
+}
+```
+
+The `implements` array lists the interface packages this module provides. The `baseUrl` points to the compiled output directory. The `paths` field configures TypeScript-style path aliases, and `defaultConfig` provides fallback configuration values.
+
+## Entry Point
+
+The module entry point (`src/index.ts`, compiled to `dist/index.js`) exports lifecycle functions. The core calls these functions in order as the module transitions through its lifecycle states.
+
+```typescript [src/index.ts]
+import { ImplementInterface } from "@antelopejs/interface-core";
+
+export async function construct(config: unknown): Promise<void> {
+  // Initialize resources, connect to databases
+  // Register interface implementations
+}
+
+export function start(): void {
+  // Module is fully active, all interfaces available
+}
+
+export async function stop(): Promise<void> {
+  // Gracefully stop operations
+}
+
+export async function destroy(): Promise<void> {
+  // Clean up resources
+}
+```
+
+The `construct` function receives the module's configuration object. Use it to set up database connections, register interface implementations, and prepare internal state. The `start` function runs after all modules have been constructed and interfaces are resolved.
+
+## Lifecycle States
+
+Every module passes through a defined sequence of states. The core manages these transitions and ensures they happen in the correct order.
+
+| State | Description |
+|-------|-------------|
+| `loaded` | Module files have been resolved and loaded into memory. |
+| `constructed` | The `construct()` function has completed successfully. |
+| `active` | The `start()` function has completed and the module is serving its interfaces. |
+
+The full lifecycle flows in one direction: **loaded** &rarr; **constructed** &rarr; **active** &rarr; (stop) &rarr; (destroy). The `stop` and `destroy` phases reverse the startup sequence, giving each module a chance to release resources gracefully.
+
+## Module Events
+
+Other modules can listen for lifecycle transitions. The core emits events whenever a module changes state, enabling coordination between modules that need to react to each other's availability.
+
+```typescript
+import { Events } from "@antelopejs/interface-core/modules";
+
+Events.ModuleConstructed.register((moduleId: string) => {
+  // Fires after a module completes construct()
+});
+
+Events.ModuleStarted.register((moduleId: string) => {
+  // Fires after a module completes start()
+});
+
+Events.ModuleStopped.register((moduleId: string) => {
+  // Fires after a module completes stop()
+});
+
+Events.ModuleDestroyed.register((moduleId: string) => {
+  // Fires after a module completes destroy()
+});
+```
+
+::note
+Module events are broadcast to all registered listeners. Use them to trigger initialization that depends on another module being ready, or to clean up references when a dependency goes away.
+::
+
+## Module Management Functions
+
+The core provides functions to inspect and control modules at runtime. These functions are available from `@antelopejs/interface-core/modules` and operate on module IDs as defined in your project configuration.
+
+### Listing and Inspecting Modules
+
+Retrieve the list of loaded modules or query detailed information about a specific module. Both functions return promises and accept module IDs as defined in your project configuration.
+
+```typescript
+import { ListModules, GetModuleInfo } from "@antelopejs/interface-core/modules";
+
+// List all loaded module IDs
+const modules = await ListModules();
+
+// Get detailed info about a module
+const info = await GetModuleInfo("my-module");
+// info.status: "loaded" | "constructed" | "active" | "unknown"
+// info.source, info.config, info.importOverrides, info.disabledExports, info.localPath
+```
+
+### Loading Modules Dynamically
+
+Add new modules to a running application without restarting. The third argument controls whether the module starts immediately after loading.
+
+```typescript
+import { LoadModule } from "@antelopejs/interface-core/modules";
+
+await LoadModule("new-module", {
+  source: { type: "package", package: "@scope/module", version: "1.0.0" },
+  config: { /* module config */ }
+}, true); // true = autostart
+```
+
+### Lifecycle Control
+
+Start, stop, destroy, or perform Hot Module Reloading (HMR) on individual modules. These functions give you fine-grained control over the module lifecycle at runtime.
+
+```typescript
+import { StartModule, StopModule, DestroyModule, ReloadModule } from "@antelopejs/interface-core/modules";
+
+await StartModule("my-module");
+await StopModule("my-module");
+await DestroyModule("my-module");
+await ReloadModule("my-module"); // HMR
+```
+
+::tip
+`ReloadModule` performs a stop-destroy-load-start cycle in a single call. During development, the `--watch` flag on `ajs project dev` triggers this automatically when source files change.
+::

--- a/docs/2.concepts/3.proxies.md
+++ b/docs/2.concepts/3.proxies.md
@@ -1,0 +1,355 @@
+---
+title: Proxies
+description: Proxies are the communication backbone of Antelopejs — AsyncProxy for function calls, EventProxy for broadcasting, and RegisteringProxy for registration systems.
+navigation:
+  icon: i-ph-arrows-left-right
+---
+
+## Overview
+
+Proxies are the communication backbone of Antelopejs. They provide module-aware function calls, event broadcasting, and registration systems with automatic cleanup when modules unload. Every interface function, event, and registration in the framework is backed by a proxy.
+
+The core tracks which module creates or attaches to each proxy. When a module is destroyed, all of its proxy bindings are automatically cleaned up. Automatic cleanup prevents memory leaks and stale references without requiring manual teardown code.
+
+## AsyncProxy
+
+AsyncProxy manages async function calls between modules. A provider attaches an implementation with `onCall`, and consumers invoke it with `call`. If `call` is invoked before any implementation is attached, the request queues until one becomes available.
+
+```typescript
+import { AsyncProxy } from "@antelopejs/interface-core";
+
+const myProxy = new AsyncProxy<(id: string) => Promise<User>>();
+
+// Provider: attach the implementation
+myProxy.onCall(async (id: string) => {
+  return await fetchUser(id);
+});
+
+// Consumer: call the proxy
+const user = await myProxy.call("user-123");
+```
+
+### AsyncProxy Methods
+
+| Method | Description |
+|--------|-------------|
+| `onCall(callback, manualDetach?)` | Attach a callback function. Queued calls execute once attached. |
+| `call(...args)` | Invoke the proxied function. Returns a Promise with the result. |
+| `detach()` | Manually detach the current callback. |
+
+::note
+An AsyncProxy accepts only one callback at a time. Calling `onCall` a second time replaces the previous callback.
+::
+
+## EventProxy
+
+EventProxy provides module-aware event broadcasting. Multiple handlers can register for the same event, and `emit` broadcasts to all of them. The core tracks which module registered each handler.
+
+```typescript
+import { EventProxy } from "@antelopejs/interface-core";
+
+const userCreated = new EventProxy<(user: User) => void>();
+
+// Register a handler
+const handler = (user: User) => {
+  console.log("User created:", user.name);
+};
+userCreated.register(handler);
+
+// Emit to all handlers
+userCreated.emit({ name: "Alice", id: "123" });
+
+// Unregister a specific handler
+userCreated.unregister(handler);
+```
+
+### EventProxy Methods
+
+| Method | Description |
+|--------|-------------|
+| `register(callback)` | Add an event handler. |
+| `emit(...args)` | Broadcast the event to all registered handlers. |
+| `unregister(callback)` | Remove a specific handler by reference. |
+
+## RegisteringProxy
+
+RegisteringProxy manages registration-based systems where items are added and removed by ID. A provider sets up `onRegister` and `onUnregister` callbacks to react when consumers register or unregister items.
+
+```typescript
+import { RegisteringProxy } from "@antelopejs/interface-core";
+
+const routes = new RegisteringProxy<(id: string, path: string, handler: Function) => void>();
+
+// Provider: set up registration/unregistration callbacks
+routes.onRegister((id, path, handler) => {
+  // Add route to router
+});
+routes.onUnregister((id) => {
+  // Remove route from router
+});
+
+// Consumer: register items
+routes.register("route-1", "/api/users", handleUsers);
+routes.unregister("route-1");
+```
+
+### RegisteringProxy Methods
+
+| Method | Description |
+|--------|-------------|
+| `onRegister(callback, manualDetach?)` | Set the function called when an item is registered. |
+| `onUnregister(callback)` | Set the function called when an item is unregistered. |
+| `register(id, ...args)` | Register an item with a unique ID. |
+| `unregister(id)` | Unregister an item by its ID. |
+| `detach()` | Manually detach both the register and unregister callbacks. |
+
+::tip
+RegisteringProxy is ideal for plugin-style systems — route registration, middleware stacks, template engines, and similar patterns where items come and go over the application lifetime.
+::
+
+## Automatic Cleanup
+
+When a module is destroyed, the core automatically performs cleanup across all proxies:
+
+- **AsyncProxy** — Detaches all callbacks attached by that module
+- **EventProxy** — Unregisters all event handlers from that module
+- **RegisteringProxy** — Removes all entries created by that module
+
+This automatic cleanup is one of the key benefits of the proxy system. Modules do not need to write teardown logic for their proxy bindings — the core handles it based on ownership tracking.
+
+## Manual Detachment
+
+In some cases, you need a proxy binding to survive module destruction. Pass `true` as the second argument to `onCall()` or `onRegister()` to opt out of automatic cleanup.
+
+```typescript
+// This callback won't be auto-detached when the module is destroyed
+myProxy.onCall(callback, true);
+
+// This registration handler won't be auto-detached either
+routes.onRegister(callback, true);
+```
+
+::warning
+Use manual detachment sparingly. Bindings that outlive their module can cause unexpected behavior if the callback references resources that no longer exist.
+::
+
+## AsyncProxy Example
+
+This example shows two modules communicating through an authentication interface. The auth module (producer) provides a `login` function, and a CLI module (consumer) calls it.
+
+The interface file declares the proxy and exposes a wrapper function. `InterfaceFunction` creates an `AsyncProxy` internally and returns a callable function.
+
+```typescript [auth-module/src/interface/index.ts]
+import { InterfaceFunction } from "@antelopejs/interface-core";
+
+export interface Token {
+  accessToken: string;
+  expiresIn: number;
+}
+
+export namespace internal {
+  export const loginProxy = InterfaceFunction<
+    (username: string, password: string) => Promise<Token>
+  >();
+}
+
+export function Login(username: string, password: string): Promise<Token> {
+  return internal.loginProxy(username, password);
+}
+```
+
+The producer module implements the login logic and wires it through `ImplementInterface`.
+
+```typescript [auth-module/src/implementations/index.ts]
+import type { Token } from "../interface";
+
+export namespace internal {
+  export async function loginProxy(username: string, password: string): Promise<Token> {
+    // Validate credentials against your data store
+    if (username === "admin" && password === "secret") {
+      return { accessToken: "jwt-token-here", expiresIn: 3600 };
+    }
+    throw new Error("Invalid credentials");
+  }
+}
+```
+
+```typescript [auth-module/src/index.ts]
+import { ImplementInterface } from "@antelopejs/interface-core";
+
+export async function construct() {
+  ImplementInterface(
+    await import("./interface"),
+    await import("./implementations")
+  );
+}
+```
+
+The consumer module imports the wrapper function and calls it. The call queues until the auth module attaches its implementation, then resolves with the result.
+
+```typescript [cli-module/src/index.ts]
+import { Login } from "@your-org/auth-module/interface";
+
+export async function start() {
+  const token = await Login("admin", "secret");
+  console.log("Authenticated, token expires in", token.expiresIn, "seconds");
+}
+```
+
+## EventProxy Example
+
+This example shows a notification system where a user-management module emits an event whenever a user is created, and other modules listen for it.
+
+The interface file declares the `EventProxy` and exposes helper functions for emitting and subscribing.
+
+```typescript [user-module/src/interface/index.ts]
+import { InterfaceFunction, EventProxy } from "@antelopejs/interface-core";
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export namespace internal {
+  export const createUserProxy = InterfaceFunction<
+    (name: string, email: string) => Promise<User>
+  >();
+  export const onUserCreated = new EventProxy<(user: User) => void>();
+}
+
+export function CreateUser(name: string, email: string): Promise<User> {
+  return internal.createUserProxy(name, email);
+}
+
+export function OnUserCreated(handler: (user: User) => void): void {
+  internal.onUserCreated.register(handler);
+}
+```
+
+The producer implementation creates the user and emits the event. The `EventProxy` is not wired through `ImplementInterface` — the producer imports it directly from the interface and calls `emit`.
+
+```typescript [user-module/src/implementations/index.ts]
+import type { User } from "../interface";
+import { internal as iface } from "../interface";
+
+export namespace internal {
+  export async function createUserProxy(name: string, email: string): Promise<User> {
+    const user: User = { id: crypto.randomUUID(), name, email };
+    // Persist the user, then broadcast the event
+    iface.onUserCreated.emit(user);
+    return user;
+  }
+}
+```
+
+A consumer module registers a handler that runs each time a user is created. Multiple modules can register handlers on the same `EventProxy`.
+
+```typescript [email-module/src/index.ts]
+import { OnUserCreated } from "@your-org/user-module/interface";
+
+export function start() {
+  OnUserCreated((user) => {
+    console.log("Sending welcome email to", user.email);
+  });
+}
+```
+
+When the email module is destroyed, the core automatically unregisters its handler from the `EventProxy`. No manual cleanup is needed.
+
+## RegisteringProxy Example
+
+This example shows an HTTP module that allows other modules to register API routes dynamically. The HTTP module (producer) manages the route table, and feature modules (consumers) contribute routes.
+
+The interface file declares a `RegisteringProxy` typed with an ID and the route metadata.
+
+```typescript [http-module/src/interface/index.ts]
+import { RegisteringProxy } from "@antelopejs/interface-core";
+
+export interface RouteHandler {
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  path: string;
+  handler: (req: any, res: any) => void | Promise<void>;
+}
+
+export namespace internal {
+  export const routesProxy = new RegisteringProxy<
+    (id: string, route: RouteHandler) => void
+  >();
+}
+
+export function RegisterRoute(id: string, route: RouteHandler): void {
+  internal.routesProxy.register(id, route);
+}
+
+export function UnregisterRoute(id: string): void {
+  internal.routesProxy.unregister(id);
+}
+```
+
+The producer module sets up `onRegister` and `onUnregister` callbacks to react when routes are added or removed. For a `RegisteringProxy`, the implementation exports an object with `register` and `unregister` functions.
+
+```typescript [http-module/src/implementations/index.ts]
+import type { RouteHandler } from "../interface";
+
+const routeTable = new Map<string, RouteHandler>();
+
+export namespace internal {
+  export const routesProxy = {
+    register(id: string, route: RouteHandler) {
+      routeTable.set(id, route);
+      console.log(`Route registered: ${route.method} ${route.path}`);
+    },
+    unregister(id: string) {
+      const route = routeTable.get(id);
+      if (route) {
+        routeTable.delete(id);
+        console.log(`Route removed: ${route.method} ${route.path}`);
+      }
+    },
+  };
+}
+```
+
+```typescript [http-module/src/index.ts]
+import { ImplementInterface } from "@antelopejs/interface-core";
+
+export async function construct() {
+  ImplementInterface(
+    await import("./interface"),
+    await import("./implementations")
+  );
+}
+```
+
+Consumer modules register routes by calling the wrapper function. Each route gets a unique ID that can be used to remove it later.
+
+```typescript [users-module/src/index.ts]
+import { RegisterRoute } from "@your-org/http-module/interface";
+
+export function start() {
+  RegisterRoute("users-list", {
+    method: "GET",
+    path: "/api/users",
+    handler: (req, res) => {
+      res.end(JSON.stringify([{ id: "1", name: "Alice" }]));
+    },
+  });
+
+  RegisterRoute("users-create", {
+    method: "POST",
+    path: "/api/users",
+    handler: (req, res) => {
+      // Create user logic
+      res.end(JSON.stringify({ id: "2", name: "Bob" }));
+    },
+  });
+}
+```
+
+When the users module is destroyed, the core automatically calls the `unregister` callback for each route that module registered. The HTTP module's route table stays clean without any manual teardown in the consumer.
+
+## See also
+
+- [Interfaces](/docs/concepts/interfaces) — Interface contracts and implementation
+- [Exporting Interfaces](/docs/module-development/exporting-interfaces) — How to publish interfaces from your module

--- a/docs/2.concepts/4.configuration.md
+++ b/docs/2.concepts/4.configuration.md
@@ -1,0 +1,406 @@
+---
+title: Configuration
+description: Configure your Antelopejs project with antelope.config.ts — define modules, sources, environment overrides, logging, and per-environment settings.
+navigation:
+  icon: i-ph-gear
+---
+
+## Configuration File
+
+Antelopejs uses `antelope.config.ts` as its configuration file. The framework expects a TypeScript config file at the root of your project, providing full type safety and autocompletion through the `defineConfig` helper.
+
+```typescript [antelope.config.ts]
+import { defineConfig } from "@antelopejs/interface-core/config";
+
+export default defineConfig({
+  name: "my-project",
+  modules: {
+    // Module definitions
+  }
+});
+```
+
+The `defineConfig` helper provides full type checking for your configuration. Place the configuration file in the root of your project directory.
+
+## Dynamic Configuration
+
+The config file can export a function instead of a static object. The function receives a context object with the current environment, allowing you to vary settings based on deployment target.
+
+```typescript [antelope.config.ts]
+import { defineConfig } from "@antelopejs/interface-core/config";
+
+export default defineConfig((ctx) => ({
+  name: "my-project",
+  modules: {
+    "my-module": {
+      source: { type: "local", path: "./modules/my-module" },
+      config: {
+        apiUrl: ctx.env === "production" ? "https://api.prod.com" : "http://localhost:3000"
+      }
+    }
+  }
+}));
+```
+
+## Full Configuration Reference
+
+The top-level configuration object accepts the following fields. All fields except `name` are optional.
+
+```typescript
+interface AntelopeConfig {
+  name: string;                                            // Project name
+  cacheFolder?: string;                                    // Default: ".antelope/cache"
+  modules?: Record<string, string | AntelopeModuleConfig>; // Module definitions
+  logging?: AntelopeLogging;                               // Logging configuration
+  envOverrides?: Record<string, string | string[]>;        // Environment variable mappings
+  environments?: Record<string, Partial<AntelopeConfig>>;  // Per-environment overrides
+  test?: AntelopeTestConfig;                               // Test configuration
+}
+```
+
+## Module Definitions
+
+Define modules as a simple version string (shorthand for an npm package) or as a full configuration object with source, config, and overrides.
+
+```typescript [antelope.config.ts]
+import { defineConfig } from "@antelopejs/interface-core/config";
+
+export default defineConfig({
+  name: "my-project",
+  modules: {
+    // Shorthand: npm package with version
+    "my-module": "1.0.0",
+
+    // Full configuration
+    "my-other-module": {
+      source: { type: "local", path: "./modules/my-module" },
+      config: { port: 3000 },
+      importOverrides: { "@antelopejs/interface-db": "postgres-module" },
+      disabledExports: ["@antelopejs/interface-legacy"]
+    }
+  }
+});
+```
+
+The shorthand format `"my-module": "1.0.0"` is equivalent to specifying a package source with that version. Use the full object form when you need local sources, custom config, import overrides, or disabled exports.
+
+## Module Source Types
+
+Each module source type tells the core where to find the module code and how to load it. The following table summarizes the available types.
+
+| Type | Description |
+|------|-------------|
+| `local` | Local filesystem path to a TypeScript/JavaScript project. |
+| `local-folder` | Local folder loaded directly without compilation. |
+| `package` | npm package fetched from a registry. |
+| `git` | Git repository cloned and built. |
+
+### Local Source
+
+Point to a module on your local filesystem. The core watches the specified directories for changes during development.
+
+```typescript
+{
+  type: "local",
+  path: "./modules/my-module",      // Relative path to the module
+  main: "custom-entry.js",          // Custom entry point (optional)
+  watchDir: ["src", "lib"],         // Directories to watch (optional, string or string[])
+  installCommand: "npm run build",  // Command to run after install (optional, string or string[])
+  reloadCommand: "npm run build"    // Command to run on hot reload instead of installCommand (optional, string or string[])
+}
+```
+
+When set, `reloadCommand` runs in place of `installCommand` during a hot reload, letting you configure a faster command (for example, a build that skips dependency installation).
+
+### Package Source
+
+Fetch a module from an npm registry. The core downloads and caches the package automatically.
+
+```typescript
+{
+  type: "package",
+  package: "@scope/my-module",
+  version: "1.0.0"
+}
+```
+
+### Git Source
+
+Clone a module from a Git repository. You can pin to a specific branch or commit.
+
+```typescript
+{
+  type: "git",
+  remote: "https://github.com/user/repo.git",
+  branch: "main",                                        // optional
+  commit: "abc123",                                      // optional
+  installCommand: "npm install && npm run build"          // optional
+}
+```
+
+### Local Folder Source
+
+Load a module directly from a folder without any compilation step. This source type is useful for pre-built modules or JavaScript-only projects.
+
+```typescript
+{
+  type: "local-folder",
+  path: "./modules/my-module",
+  watchDir: "src",                  // optional
+  installCommand: "npm install",    // optional
+  reloadCommand: "npm run build"    // runs instead of installCommand on hot reload (optional)
+}
+```
+
+## Import Overrides
+
+Import overrides route interface imports to specific modules. When a module imports an interface, the core checks the override map to determine which provider module should fulfill the request.
+
+```typescript [antelope.config.ts]
+{
+  importOverrides: {
+    "@antelopejs/interface-database": "postgres-module"
+  }
+}
+```
+
+Override mapping is useful when multiple modules implement the same interface and you need to control which implementation a specific consumer receives.
+
+## Disabled Exports
+
+Prevent a module from providing specific interfaces. The module still loads and runs, but the core does not register the listed interfaces from it.
+
+```typescript [antelope.config.ts]
+{
+  disabledExports: ["@antelopejs/interface-legacy"]
+}
+```
+
+## Environment Variable Overrides
+
+The `envOverrides` field maps environment variables to configuration paths. When an environment variable is set, its value overrides the corresponding configuration value at runtime. The path uses dot notation to target nested fields.
+
+```typescript [antelope.config.ts]
+import { defineConfig } from "@antelopejs/interface-core/config";
+
+export default defineConfig({
+  name: "my-project",
+  modules: {
+    "db-module": {
+      config: { host: "localhost", port: 5432 }
+    }
+  },
+  envOverrides: {
+    "DB_HOST": "modules.db-module.config.host",
+    "DB_PORT": "modules.db-module.config.port"
+  }
+});
+```
+
+With this configuration, setting `DB_HOST=db.prod.com` in your environment overrides the `host` value in the `db-module` config. Environment variable overrides keep sensitive or deployment-specific values out of your configuration file.
+
+## Template Substitution
+
+Use `${path}` syntax in string configuration values to reference other values within the same config block. The core resolves these references before passing the config to the module.
+
+```typescript [antelope.config.ts]
+{
+  config: {
+    host: "localhost",
+    port: 5432,
+    url: "${host}:${port}/mydb"  // Resolves to "localhost:5432/mydb"
+  }
+}
+```
+
+## Environment-Specific Configuration
+
+The `environments` field defines per-environment overrides. Each key is an environment name, and its value is a partial configuration that merges on top of the base config when that environment is active.
+
+```typescript [antelope.config.ts]
+import { defineConfig } from "@antelopejs/interface-core/config";
+
+export default defineConfig({
+  name: "my-project",
+  modules: {
+    "api-module": {
+      config: { port: 3000 }
+    }
+  },
+  environments: {
+    production: {
+      modules: {
+        "api-module": {
+          config: { port: 8080 }
+        }
+      }
+    }
+  }
+});
+```
+
+Run your project with a specific environment using the `-e` flag. The flag accepts any environment name defined in your configuration.
+
+```bash
+ajs project dev -e production
+```
+
+The base configuration applies first, then the environment-specific overrides merge on top. The environment block overrides only the fields you specify — everything else keeps its base value.
+
+## Logging Configuration
+
+Configure log output directly in the config file. The logging section controls which channels appear, their minimum severity level, and the output format.
+
+```typescript [antelope.config.ts]
+{
+  logging: {
+    enabled: true,
+    moduleTracking: {
+      enabled: true,
+      includes: ["my-module"],    // Only show logs from these modules
+      excludes: ["noisy-module"]  // Hide logs from these modules
+    },
+    channelFilter: {
+      "main": "info",             // Level name or number
+      "http": 10,                 // DEBUG level
+      "db:*": "warn"              // Prefix wildcard
+    },
+    dateFormat: "yyyy-MM-dd HH:mm:ss"
+  }
+}
+```
+
+::tip
+See the [Logging](/docs/concepts/logging) page for a full explanation of severity levels, channels, and filtering options.
+::
+
+## Complete configuration example
+
+The following example combines all configuration features into a single realistic file. Each field includes an inline comment explaining its role.
+
+```typescript [antelope.config.ts]
+import { defineConfig } from "@antelopejs/interface-core/config";
+
+export default defineConfig({
+  // Project name — identifies this project in logs and CLI output
+  name: "my-fullstack-app",
+
+  // Directory for build artifacts and cached modules (default: ".antelope/cache")
+  cacheFolder: ".antelope/cache",
+
+  modules: {
+    // Shorthand: npm package source — version string resolves to { type: "package", version }
+    "@antelopejs/module-auth": "2.1.0",
+
+    // Local source: point to a module on disk, with a watch directory for live reload
+    "api-module": {
+      source: {
+        type: "local",
+        path: "./modules/api",
+        watchDir: ["src"],
+        installCommand: "npm install"
+      },
+      config: {
+        port: 3000,
+        host: "localhost",
+        url: "${host}:${port}"         // template substitution — resolves to "localhost:3000"
+      },
+      importOverrides: {
+        "@antelopejs/interface-database": "postgres-module"
+      },
+      disabledExports: ["@antelopejs/interface-legacy-api"]
+    },
+
+    // Git source: clone a module from a remote repository
+    "analytics-module": {
+      source: {
+        type: "git",
+        remote: "https://github.com/your-org/analytics-module.git",
+        branch: "main",
+        installCommand: "npm install && npm run build"
+      },
+      config: {
+        trackingId: "UA-000000-1"
+      }
+    },
+
+    // Package source (explicit form): fetch from an npm registry
+    "postgres-module": {
+      source: {
+        type: "package",
+        package: "@antelopejs/module-postgres",
+        version: "1.3.0"
+      },
+      config: {
+        host: "localhost",
+        port: 5432,
+        database: "app_dev"
+      }
+    }
+  },
+
+  // Map environment variables to configuration paths using dot notation
+  envOverrides: {
+    "DB_HOST": "modules.postgres-module.config.host",
+    "DB_PORT": "modules.postgres-module.config.port",
+    "DB_NAME": "modules.postgres-module.config.database",
+    // A single env var can override multiple paths
+    "API_HOST": [
+      "modules.api-module.config.host",
+      "modules.analytics-module.config.endpoint"
+    ]
+  },
+
+  // Per-environment overrides — merged on top of the base config
+  environments: {
+    production: {
+      modules: {
+        "api-module": {
+          config: { port: 8080, host: "0.0.0.0" }
+        },
+        "postgres-module": {
+          config: { host: "db.prod.internal", database: "app_prod" }
+        }
+      },
+      logging: {
+        enabled: true,
+        channelFilter: { "default": "warn" }
+      }
+    },
+    staging: {
+      modules: {
+        "postgres-module": {
+          config: { host: "db.staging.internal", database: "app_staging" }
+        }
+      }
+    }
+  },
+
+  // Logging configuration — controls console output for all modules
+  logging: {
+    enabled: true,
+    moduleTracking: {
+      enabled: true,
+      includes: ["api-module", "postgres-module"],
+      excludes: []
+    },
+    channelFilter: {
+      "main": "info",
+      "http": 10
+    },
+    dateFormat: "yyyy-MM-dd HH:mm:ss"
+  }
+});
+```
+
+### Key takeaways
+
+- **Shorthand modules** accept a version string and resolve to the `package` source type automatically.
+- **`envOverrides`** keep secrets and deployment-specific values out of the config file. Set `DB_HOST` in your shell or CI environment and the value flows into the correct module config.
+- **`environments`** let you maintain a single config file for development, staging, and production. Only the fields you specify in an environment block are overridden.
+- **Template substitution** (`${host}:${port}`) references other values in the same config block, so you can build derived strings without duplication.
+
+## See also
+
+- [CLI Config Commands](/docs/cli/config) — Manage configuration from the command line
+- [Quick Start](/docs/get-started/quick-start) — Getting started with your first project

--- a/docs/2.concepts/5.logging.md
+++ b/docs/2.concepts/5.logging.md
@@ -1,0 +1,103 @@
+---
+title: Logging
+description: The Antelopejs logging system provides severity levels, named channels, and configurable output formatting for structured application logs.
+navigation:
+  icon: i-ph-list-bullets
+---
+
+## Severity Levels
+
+Antelopejs defines five severity levels, each with a numeric value. Higher values indicate more critical messages. You can filter logs by setting a minimum level per channel in your project configuration.
+
+| Level | Value | Description |
+|-------|-------|-------------|
+| ERROR | 40 | Errors that need immediate attention. |
+| WARN | 30 | Potential issues that may require investigation. |
+| INFO | 20 | General operational information. |
+| DEBUG | 10 | Detailed information useful during development. |
+| TRACE | 0 | Fine-grained tracing for deep debugging. |
+
+## Global Logging Functions
+
+The `Logging` namespace provides functions for each severity level. These functions write to the `main` channel and are the quickest way to emit log messages from any module.
+
+```typescript
+import { Logging } from "@antelopejs/interface-core/logging";
+
+Logging.Error("Something failed:", error);
+Logging.Warn("Deprecated feature used");
+Logging.Info("Server started on port", 3000);
+Logging.Debug("Request payload:", data);
+Logging.Trace("Entering function processUser");
+```
+
+Each function accepts any number of arguments, similar to `console.log`. The core automatically attributes each log entry to the module that produced it.
+
+## Custom Channels
+
+Named channels organize logs by category. Create a channel with `Logging.Channel` and use it the same way as the global functions. Channels let you filter and format logs independently in the project configuration.
+
+```typescript
+import { Logging } from "@antelopejs/interface-core/logging";
+
+const httpLog = new Logging.Channel("http");
+
+httpLog.Info("GET /api/users - 200");
+httpLog.Error("POST /api/users - 500:", error);
+httpLog.Debug("Request headers:", headers);
+```
+
+A channel name can be any string. Choose names that reflect the subsystem producing the logs — `http`, `database`, `auth`, `scheduler`, and so on. Each channel can have its own minimum severity level in the configuration.
+
+## Writing to Custom Levels
+
+Use `Logging.Write()` to log at an arbitrary numeric level. Custom levels are useful when the five built-in levels are not granular enough for your use case.
+
+```typescript
+import { Logging } from "@antelopejs/interface-core/logging";
+
+Logging.Write(25, "custom-channel", "Custom level message");
+```
+
+The first argument is the numeric level, the second is the channel name, and the remaining arguments form the log message. The message appears only if the channel's minimum level is at or below the specified value.
+
+## Log Configuration
+
+Configure logging behavior in your `antelope.config.ts` under the `logging` key. The configuration controls which modules and channels produce visible output, the minimum severity threshold, and the date format.
+
+```typescript [antelope.config.ts]
+{
+  logging: {
+    enabled: true,
+    moduleTracking: {
+      enabled: true,
+      includes: ["my-module"],
+      excludes: ["noisy-module"]
+    },
+    channelFilter: {
+      "main": "info",
+      "http": 10,
+      "db:*": "warn"
+    },
+    dateFormat: "yyyy-MM-dd HH:mm:ss"
+  }
+}
+```
+
+### Module Tracking
+
+Module tracking controls which modules produce visible log output. When `enabled` is `true`, the core tags each log entry with its originating module. Use `includes` to show logs only from specific modules, or `excludes` to hide logs from noisy modules.
+
+### Channel Filtering
+
+The `channelFilter` field sets the minimum severity level per channel. Specify the level as a string name (`"info"`, `"debug"`) or a numeric value. The core silently drops messages below the threshold.
+
+Keys are matched against channel names exactly. A key ending in `*` acts as a prefix wildcard — `"db:*"` matches every channel whose name starts with `db:`. Logs emitted from the top-level `Logging.Error/Warn/Info/Debug/Trace` helpers land on the channel named `"main"`; use that name (or a `"*"` wildcard) to tune their threshold.
+
+### Date Format
+
+The `dateFormat` field accepts a date format string (default: `"yyyy-MM-dd HH:mm:ss"`). Supported tokens: `yyyy`, `MM`, `dd`, `HH`, `mm`, `ss` (all values are formatted in UTC).
+
+::tip
+Start with `"main": "info"` and lower individual channels to `"debug"` only when you need to troubleshoot a specific subsystem. Selective filtering keeps your log output clean during normal operation.
+::

--- a/docs/2.concepts/6.core-utilities.md
+++ b/docs/2.concepts/6.core-utilities.md
@@ -1,0 +1,177 @@
+---
+title: Core Utilities
+description: Core utility functions for interface declarations, implementations, module introspection, and decorator factories in Antelopejs.
+navigation:
+  icon: i-ph-wrench
+---
+
+## GetResponsibleModule
+
+`GetResponsibleModule` determines which module is currently executing by inspecting the call stack. The core uses this function internally for automatic proxy cleanup and logging attribution. You can also call it directly when you need to know the caller's identity.
+
+```typescript
+import { GetResponsibleModule } from "@antelopejs/interface-core";
+
+const moduleId = GetResponsibleModule();
+```
+
+The function returns the module ID string, or `undefined` if the call originates outside any module context (for example, from the core itself). Use the return value to make decisions based on which module triggered a particular code path.
+
+## InterfaceFunction
+
+`InterfaceFunction` creates a callable function backed by an AsyncProxy. `InterfaceFunction` is the primary way to declare functions in an interface definition. Consumers call the returned function like any regular async function — the proxy handles routing to the correct implementation.
+
+```typescript [src/interface/index.ts]
+import { InterfaceFunction } from "@antelopejs/interface-core";
+
+export const GetUser = InterfaceFunction<(id: string) => Promise<User>>();
+export const CreateUser = InterfaceFunction<(data: UserInput) => Promise<User>>();
+```
+
+Consumers import and call these functions directly. The proxy routes each call to the correct provider at runtime.
+
+```typescript
+import { GetUser } from "@antelopejs/interface-example";
+
+const user = await GetUser("user-123");
+```
+
+The type parameter defines the function signature. The returned function is fully typed, so consumers get autocompletion and type checking at the call site.
+
+## ImplementInterface
+
+`ImplementInterface` connects an interface declaration with its implementation. Call it during the module's `construct` phase to bind your implementation functions to the corresponding interface proxies.
+
+```typescript [src/index.ts]
+import { ImplementInterface } from "@antelopejs/interface-core";
+
+export async function construct() {
+  ImplementInterface(
+    await import("./interface"),
+    await import("./implementations")
+  );
+}
+```
+
+The first argument is the interface module (containing `InterfaceFunction` declarations). The second argument is the implementation module, which must export functions with the same names. The core matches each declaration to its implementation by name and attaches the implementation via the underlying proxy.
+
+For standalone interface packages, import from the package name instead of a local path:
+
+```typescript [src/index.ts]
+import { ImplementInterface } from "@antelopejs/interface-core";
+
+export async function construct() {
+  ImplementInterface(
+    await import("@antelopejs/interface-email"),
+    await import("./implementations")
+  );
+}
+```
+
+## GetMetadata
+
+`GetMetadata` retrieves metadata attached to a target object using a metadata class. Use it for reflection and introspection when building systems that need to read decorator-applied configuration at runtime.
+
+```typescript
+import { GetMetadata } from "@antelopejs/interface-core";
+
+class MyMeta {
+  static key = Symbol("MyMeta");
+  constructor(target: any) { /* initialize from target */ }
+}
+
+const metadata = GetMetadata(myInstance, MyMeta);
+```
+
+The function takes the target object as the first argument and a metadata class (with a static `key` symbol) as the second. An optional third argument controls prototype chain inheritance (defaults to `true`). The return value is an instance of the metadata class associated with the target.
+
+## GetInterfaceInstances and GetInterfaceInstance
+
+These functions retrieve interface connection information at runtime. They are useful when multiple modules implement the same interface and you need to query or iterate over the connections.
+
+```typescript
+import { GetInterfaceInstances, GetInterfaceInstance } from "@antelopejs/interface-core";
+
+// Get all connections for a specific interface
+const allConnections = GetInterfaceInstances("@antelopejs/interface-email");
+
+// Get a specific connection by interface ID and connection ID
+const connection = GetInterfaceInstance("@antelopejs/interface-email", "brevo-module");
+```
+
+`GetInterfaceInstances` takes an interface ID and returns all connections to implementations of that interface. `GetInterfaceInstance` takes an interface ID and a connection ID and returns the matching connection, or `undefined` if not found. These functions are primarily useful for advanced scenarios such as multi-provider routing or interface diagnostics.
+
+## Decorator Factories
+
+Antelopejs provides factory functions that create typed decorators for use in interface definitions. These factories take a handler function whose arguments are split in two: the first arguments are the decorator target arguments (class, property key, descriptor, or parameter index depending on the decorator type), and the remaining arguments become the factory parameters that users pass when applying the decorator.
+
+### Basic Factories
+
+Each factory creates a decorator for a specific target type. The type parameter `T` defines the factory parameter types as a tuple.
+
+```typescript
+import {
+  MakeClassDecorator,
+  MakePropertyDecorator,
+  MakeMethodDecorator,
+  MakeParameterDecorator
+} from "@antelopejs/interface-core/decorators";
+
+// Create a class decorator — handler receives (target, ...factoryArgs)
+const MyDecorator = MakeClassDecorator<[name: string]>((target, name) => {
+  // target is the class constructor, name is the factory parameter
+});
+
+// Create a property decorator — handler receives (target, key, ...factoryArgs)
+const MyPropDecorator = MakePropertyDecorator<[required: boolean]>((target, key, required) => {
+  // target is the prototype, key is the property name
+});
+
+// Create a method decorator — handler receives (target, key, descriptor, ...factoryArgs)
+const MyMethodDecorator = MakeMethodDecorator<[route: string]>((target, key, descriptor, route) => {
+  // target is the prototype, key is the method name, descriptor is the property descriptor
+});
+
+// Create a parameter decorator — handler receives (target, key, index, ...factoryArgs)
+const MyParamDecorator = MakeParameterDecorator<[validate: boolean]>((target, key, index, validate) => {
+  // target is the prototype, key is the method name, index is the parameter position
+});
+```
+
+The handler function receives the standard decorator arguments first, followed by any factory parameters. When applying the decorator, users pass only the factory parameters:
+
+```typescript
+@MyDecorator("MyClassName")
+class Example {
+  @MyPropDecorator(true)
+  name!: string;
+
+  @MyMethodDecorator("/api/users")
+  getUsers(@MyParamDecorator(true) id: string) {}
+}
+```
+
+### Combined Factories
+
+Combined factories create decorators that work on multiple target types. Use these when a single decorator should be applicable to more than one kind of declaration.
+
+```typescript
+import {
+  MakeMethodAndClassDecorator,
+  MakeParameterAndMethodDecorator
+} from "@antelopejs/interface-core/decorators";
+
+// Works on both methods and classes
+const Transactional = MakeMethodAndClassDecorator<[isolation?: string]>((target, key, descriptor, isolation) => {
+  // key and descriptor are undefined when applied to a class
+});
+
+// Works on both parameters and methods
+const Validate = MakeParameterAndMethodDecorator<[schema: string]>((target, key, indexOrDescriptor, schema) => {
+  // indexOrDescriptor is a number for parameters, a PropertyDescriptor for methods
+});
+```
+
+::tip
+Decorator factories are most commonly used when defining interfaces that need consumers to annotate their classes. For example, an HTTP interface can provide a `Route` method decorator and a `Controller` class decorator that consumers apply to their handler classes.
+::

--- a/docs/2.concepts/7.runtime.md
+++ b/docs/2.concepts/7.runtime.md
@@ -1,0 +1,68 @@
+---
+title: Runtime
+description: Inspect the runtime environment of a running project and register development servers for discovery by external tooling.
+navigation:
+  icon: i-ph-cpu
+---
+
+The `@antelopejs/interface-core/runtime` module exposes information about the environment a project runs in, along with a registry for development servers. The AntelopeJS core provides the implementation: `ajs project dev` reports development mode, while `ajs project start` and `ajs project run` report production mode.
+
+```typescript
+import {
+  GetRuntimeInfo,
+  RegisterDevServer,
+  DEV_REGISTRY_PATH,
+} from "@antelopejs/interface-core/runtime";
+```
+
+## GetRuntimeInfo
+
+`GetRuntimeInfo` retrieves information about the runtime environment of the running project. Use it when a module needs to behave differently in development — for example, enabling verbose diagnostics or relaxing security checks.
+
+```typescript
+const info = await GetRuntimeInfo();
+// { dev: true, projectPath: "/path/to/project", env: "default" }
+```
+
+| Field | Description |
+|-------|-------------|
+| `dev` | `true` when running under `ajs project dev`, `false` otherwise. |
+| `projectPath` | Absolute path to the root of the running project. |
+| `env` | Name of the active configuration environment. |
+
+## RegisterDevServer
+
+`RegisterDevServer` registers a development server and the endpoints it listens on. Modules that bind network ports (such as an HTTP API) call it after a successful `listen()`, so external tooling can discover the actual endpoints.
+
+```typescript
+await RegisterDevServer("api", [
+  { protocol: "http", host: "localhost", port: 5011 },
+]);
+```
+
+In development mode, the core merges the registration into the dev registry file and removes the file on shutdown. Outside development mode, the call is a no-op, so modules can call it unconditionally.
+
+## Dev Registry File
+
+The dev registry file lives at `DEV_REGISTRY_PATH` (`.antelope/dev.json`) relative to the project root. The `DevServerRegistry` type describes its shape, and `DevServerEndpoint` describes each endpoint entry.
+
+```json [.antelope/dev.json]
+{
+  "pid": 12345,
+  "startedAt": "2026-06-12T10:00:00Z",
+  "servers": {
+    "api": {
+      "endpoints": [{ "protocol": "http", "host": "localhost", "port": 5011 }]
+    }
+  }
+}
+```
+
+::warning
+The file is only valid while the process identified by `pid` exists. If that process is gone, the file is orphaned and must be ignored or overwritten.
+::
+
+## See also
+
+- [Configuration](/docs/concepts/configuration) — Environments and module sources referenced by the runtime info
+- [Core Utilities](/docs/concepts/core-utilities) — Other functions exported by the core interface

--- a/docs/2.concepts/8.glossary.md
+++ b/docs/2.concepts/8.glossary.md
@@ -1,0 +1,56 @@
+---
+title: Glossary
+description: Key terms and definitions used throughout the AntelopeJS documentation.
+navigation:
+  icon: i-ph-book-open-text
+---
+
+## Key Terms
+
+This glossary defines the core terms used throughout the AntelopeJS documentation. Each entry includes a short definition and links to the relevant page for further detail.
+
+### Interface
+
+A TypeScript contract that defines methods, events, or registrations a module can implement (produce) or consume. Interfaces enable modules to communicate without direct dependencies — a consumer imports the interface, not the module behind it. The core resolves which module fulfills each interface at runtime.
+
+See [Interfaces](/docs/concepts/interfaces)
+
+### Module
+
+A self-contained functional unit packaged as a standard npm package with a managed lifecycle. Modules provide or consume interfaces and transition through defined states (loaded, constructed, active) under the control of the core.
+
+See [Modules](/docs/concepts/modules)
+
+### Proxy
+
+An abstraction layer that handles communication between modules through interfaces. AntelopeJS provides three proxy types: `InterfaceFunction` for async function calls, `EventProxy` for event-based messaging, and `RegisteringProxy` for registration patterns.
+
+See [Proxies](/docs/concepts/proxies)
+
+### Binding
+
+The resolved association between an interface producer (the module that implements it) and a consumer (the module that uses it). The core resolves all bindings before modules enter the `start` phase, ensuring every interface call has a concrete target.
+
+### Implementation
+
+The concrete code in a module that fulfills an interface contract. An implementation maps each proxy declared in the interface to a real function, event handler, or registration handler inside the module.
+
+### Contract
+
+A synonym for interface, commonly used in the context of contract tests that validate whether an implementation correctly fulfills the interface it claims to provide. Contract tests run the same assertions against any module that implements a given interface.
+
+### Lifecycle
+
+The sequence of phases a module goes through: **construct** → **start** → **stop** → **destroy**, corresponding to states **loaded** → **constructed** → **active**. The core orchestrates these transitions and ensures they happen in the correct order across all modules.
+
+See [Architecture](/docs/get-started/architecture)
+
+### Core
+
+The AntelopeJS runtime that orchestrates module loading, lifecycle management, and interface routing. The core resolves the dependency graph between modules, manages bindings, and provides the infrastructure that makes interface-based communication possible.
+
+### Hot Module Reloading (HMR)
+
+The ability to reload a module at runtime during development without restarting the entire application. HMR performs a stop-destroy-load-start cycle on a single module, preserving the state of all other modules. The `--watch` flag on `ajs project dev` triggers HMR automatically when source files change.
+
+See [Modules](/docs/concepts/modules)

--- a/docs/2.concepts/index.md
+++ b/docs/2.concepts/index.md
@@ -1,0 +1,38 @@
+---
+title: Concepts
+navigation: false
+---
+
+::card-group
+::card{icon="i-ph-brackets-curly" title="Interfaces" to="/docs/concepts/interfaces"}
+Understand interface contracts and how modules communicate through well-defined boundaries.
+::
+
+::card{icon="i-ph-cube" title="Modules" to="/docs/concepts/modules"}
+Explore module structure, lifecycle states, and runtime management functions.
+::
+
+::card{icon="i-ph-arrows-left-right" title="Proxies" to="/docs/concepts/proxies"}
+Learn about AsyncProxy, EventProxy, and RegisteringProxy — the communication backbone of Antelopejs.
+::
+
+::card{icon="i-ph-gear" title="Configuration" to="/docs/concepts/configuration"}
+Configure your project with antelope.config.ts, module sources, environment overrides, and more.
+::
+
+::card{icon="i-ph-list-bullets" title="Logging" to="/docs/concepts/logging"}
+Use the built-in logging system with severity levels, custom channels, and configurable output.
+::
+
+::card{icon="i-ph-wrench" title="Core Utilities" to="/docs/concepts/core-utilities"}
+Discover utility functions for interface declarations, implementations, decorators, and module introspection.
+::
+
+::card{icon="i-ph-cpu" title="Runtime" to="/docs/concepts/runtime"}
+Inspect the runtime environment and register development servers for discovery by external tooling.
+::
+
+::card{icon="i-ph-book-open-text" title="Glossary" to="/docs/concepts/glossary"}
+Key terms and definitions used throughout the AntelopeJS documentation.
+::
+::

--- a/docs/3.module-development/.navigation.yml
+++ b/docs/3.module-development/.navigation.yml
@@ -1,0 +1,2 @@
+title: Module Development
+icon: i-ph-hammer

--- a/docs/3.module-development/1.creating-a-module.md
+++ b/docs/3.module-development/1.creating-a-module.md
@@ -1,0 +1,180 @@
+---
+title: Creating a Module
+description: Create an Antelopejs module from scratch — initialize the project, configure the entry point, and register it in your application.
+navigation:
+  icon: i-ph-hammer
+---
+
+## Initialize a Module
+
+The CLI provides a scaffolding command that generates a module with the standard directory structure and configuration files.
+
+```bash
+ajs module init ./my-module
+```
+
+The command creates a new directory with a ready-to-use module template. The generated project includes TypeScript configuration, a package.json with Antelopejs metadata, and placeholder files for interfaces and implementations.
+
+## Module Structure
+
+Every module follows a consistent directory layout that separates interface declarations from their implementations.
+
+```
+my-module/
+├── package.json              # Module metadata with antelopeJs config
+├── tsconfig.json             # TypeScript configuration
+├── src/
+│   ├── index.ts              # Entry point with lifecycle functions
+│   ├── interface/            # Interface contract
+│   │   └── index.ts
+│   └── implementations/     # Interface implementation
+│       └── index.ts
+└── dist/                     # Compiled output
+```
+
+The `interface/` directory holds the contract definition — types, proxy declarations, and wrapper functions that describe what the module offers. The `implementations/` directory holds the concrete logic that fulfills the contract.
+
+## Package Configuration
+
+The `antelopeJs` field in `package.json` defines how the core discovers and loads the module.
+
+```json [package.json]
+{
+  "name": "@your-org/my-module",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "antelopeJs": {
+    "implements": ["@your-org/my-module"],
+    "baseUrl": "dist",
+    "moduleAliases": {},
+    "defaultConfig": {}
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `implements` | Array of npm package names from which consumers import the interface |
+| `baseUrl` | Base directory for path resolution (typically `dist`) |
+| `moduleAliases` | Additional module import aliases |
+| `defaultConfig` | Default configuration values for this module |
+| `test` | Path to the test configuration file |
+
+The `implements` array lists the npm package names that expose the interface contract. When the interface is embedded, the module lists its own package name because consumers import the interface from it (e.g., `@your-org/my-module/interface`). When the interface lives in a standalone package, the module lists that package name instead (e.g., `@antelopejs/interface-api`).
+
+::tip
+Interfaces start embedded inside the module and can later be extracted into standalone packages. See the [Interfaces concept page](/docs/concepts/interfaces) and the [Exporting Interfaces guide](/docs/module-development/exporting-interfaces) for details on this lifecycle.
+::
+
+## Entry Point
+
+The module entry point exports lifecycle functions that the core calls in a specific order. These functions control initialization, startup, and teardown.
+
+```typescript [src/index.ts]
+import { ImplementInterface } from "@antelopejs/interface-core";
+
+export async function construct(config: any): Promise<void> {
+  // Called first — initialize resources
+  // Register interface implementations
+  ImplementInterface(
+    await import("./interface"),
+    await import("./implementations")
+  );
+}
+
+export function start(): void {
+  // Called after all modules are constructed
+  // All interfaces are now available
+}
+
+export async function stop(): Promise<void> {
+  // Gracefully stop operations
+}
+
+export async function destroy(): Promise<void> {
+  // Clean up resources (close connections, etc.)
+}
+```
+
+The lifecycle follows four phases:
+
+| Phase | When It Runs | Purpose |
+|-------|-------------|---------|
+| `construct` | First, for each module | Initialize resources and register interface implementations |
+| `start` | After all modules are constructed | Begin operations — all interfaces are now resolved |
+| `stop` | When shutting down | Gracefully stop ongoing operations |
+| `destroy` | After all modules are stopped | Release resources, close connections |
+
+::note
+The `construct` function receives the module's configuration object. Use it to set up database connections, initialize state, or configure behavior based on user-provided settings.
+::
+
+::warning
+If your module throws an error during `construct()` or `start()`, the application boot fails. The core does not catch these errors — they propagate and prevent other modules from starting. Handle errors internally when you want graceful degradation, or let them propagate intentionally to signal a critical failure that should stop the entire application.
+::
+
+## TypeScript Configuration
+
+A standard `tsconfig.json` for an Antelopejs module includes the compiler options needed for decorators and type declarations.
+
+```json [tsconfig.json]
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}
+```
+
+## Importing Interfaces
+
+To use interfaces provided by other modules, add the interface package as a dependency and import from it directly.
+
+```typescript
+import { GetUser } from "@antelopejs/interface-user-service";
+
+// Use the interface function
+const user = await GetUser("user-123");
+```
+
+The import resolves to the interface declaration, not the implementation. At runtime, the core connects the call to whichever module implements that interface. Your code never depends on a specific implementation — only on the contract.
+
+::tip
+You do not need to know which module implements an interface. The core resolves implementations based on your project configuration. Swapping implementations requires only a configuration change, not a code change.
+::
+
+## Adding the Module to a Project
+
+Register the module in your project's `antelope.config.ts` to make it available at runtime.
+
+```typescript [antelope.config.ts]
+import { defineConfig } from "@antelopejs/interface-core/config";
+
+export default defineConfig({
+  name: "my-project",
+  modules: {
+    "my-module": {
+      source: { type: "local", path: "./my-module" }
+    }
+  }
+});
+```
+
+The `source` field supports multiple types. Local paths point to a directory on disk, which is ideal during development. For production, modules can also come from npm packages or git repositories.
+
+::warning
+The module must be compiled before the core can load it. Run your TypeScript build step before starting the project, or use `ajs project dev --watch` to compile and reload automatically.
+::
+
+## See also
+
+- [Modules](/docs/concepts/modules) — Module states and lifecycle overview
+- [Testing](/docs/module-development/testing) — How to test your module
+- [Architecture](/docs/get-started/architecture) — How the core orchestrates modules

--- a/docs/3.module-development/2.exporting-interfaces.md
+++ b/docs/3.module-development/2.exporting-interfaces.md
@@ -1,0 +1,236 @@
+---
+title: Exporting Interfaces
+description: Create interface contracts with typed proxies, implement them with concrete logic, and extract standalone packages when multiple implementations appear.
+navigation:
+  icon: i-ph-plugs-connected
+---
+
+## Creating an Embedded Interface
+
+An embedded interface lives inside the module that implements it. The module contains both the contract definition and the concrete logic, organized into separate directories.
+
+```
+my-module/
+├── src/
+│   ├── index.ts
+│   ├── interface/
+│   │   └── index.ts
+│   └── implementations/
+│       └── index.ts
+```
+
+The `interface/` directory holds the contract — types, proxies, and public wrapper functions. The `implementations/` directory holds the concrete logic that fulfills that contract.
+
+### Step 1 — Define the Interface Contract
+
+The interface file declares types, internal proxy functions, and public wrapper functions that consumers call. Proxies live inside a `namespace internal` block, and wrapper functions provide the clean public API.
+
+```typescript [src/interface/index.ts]
+import { InterfaceFunction } from "@antelopejs/interface-core";
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+// Internal proxies — bound to an implementation at runtime
+export namespace internal {
+  export const getUserProxy = InterfaceFunction<(id: string) => Promise<User>>();
+  export const createUserProxy = InterfaceFunction<(name: string, email: string) => Promise<User>>();
+  export const deleteUserProxy = InterfaceFunction<(id: string) => Promise<void>>();
+}
+
+// Public API — consumers import and call these functions
+export function GetUser(id: string): Promise<User> {
+  return internal.getUserProxy(id);
+}
+
+export function CreateUser(name: string, email: string): Promise<User> {
+  return internal.createUserProxy(name, email);
+}
+
+export function DeleteUser(id: string): Promise<void> {
+  return internal.deleteUserProxy(id);
+}
+```
+
+`InterfaceFunction` creates a typed proxy that the core wires to an implementation at runtime. The wrapper functions forward calls to the proxies, giving consumers a straightforward function-based API without exposing the proxy mechanism.
+
+### Step 2 — Write the Implementation
+
+The implementation file exports a namespace that matches the interface's `internal` namespace. Each function in the namespace contains the concrete logic that fulfills the corresponding proxy.
+
+```typescript [src/implementations/index.ts]
+import type { User } from "../interface";
+
+const users = new Map<string, User>();
+
+export namespace internal {
+  export async function getUserProxy(id: string): Promise<User> {
+    const user = users.get(id);
+    if (!user) throw new Error("User not found");
+    return user;
+  }
+
+  export async function createUserProxy(name: string, email: string): Promise<User> {
+    const user: User = { id: crypto.randomUUID(), name, email };
+    users.set(user.id, user);
+    return user;
+  }
+
+  export async function deleteUserProxy(id: string): Promise<void> {
+    users.delete(id);
+  }
+}
+```
+
+The exported namespace and function names must match exactly. The core binds each proxy to its implementation by matching the namespace structure and function names between the interface and the implementation.
+
+### Step 3 — Declare the Interface in `package.json`
+
+The `implements` field in `package.json` lists the npm package names from which consumers import the interface. For an embedded interface, the module lists its own package name because consumers import the interface from it.
+
+```json [package.json]
+{
+  "name": "@your-org/my-module",
+  "antelopeJs": {
+    "implements": ["@your-org/my-module"]
+  }
+}
+```
+
+Consumers can then import the interface using the module's package name and the `interface` subpath:
+
+```typescript
+import { GetUser, CreateUser } from "@your-org/my-module/interface";
+```
+
+### Step 4 — Connect Interface and Implementation
+
+The module entry point calls `ImplementInterface` to bind the interface proxies to their implementations. Place the call inside the `construct` lifecycle function so all bindings are ready before the `start` phase runs.
+
+```typescript [src/index.ts]
+import { ImplementInterface } from "@antelopejs/interface-core";
+
+export async function construct() {
+  ImplementInterface(
+    await import("./interface"),
+    await import("./implementations")
+  );
+}
+```
+
+`ImplementInterface` takes two arguments: the interface module and the implementation module. The function matches the exported namespaces and wires each proxy to the corresponding concrete function.
+
+::note
+You can call `ImplementInterface` multiple times to register implementations for different interfaces. Each call binds one interface to one implementation.
+::
+
+## Adding Utility Code to Interfaces
+
+Interface files can contain more than proxies and wrapper functions. Any implementation-agnostic code that consumers need belongs in the interface file alongside the contract definition.
+
+Common additions include:
+
+- **Decorator factories** — Decorators that consumers use to annotate their classes or methods
+- **Helper classes** — Query builders, request formatters, metadata containers
+- **Utility functions** — Data transformation, validation helpers, constants
+
+The following example adds an `Authenticated` decorator alongside the interface proxies. Consumers apply the decorator to inject authentication checks without depending on a specific auth implementation.
+
+```typescript [src/interface/index.ts]
+import { InterfaceFunction } from "@antelopejs/interface-core";
+import { MakeParameterDecorator } from "@antelopejs/interface-core/decorators";
+
+export interface UserPayload {
+  id: string;
+  roles: string[];
+}
+
+// Internal proxy
+export namespace internal {
+  export const validateProxy = InterfaceFunction<(token: string) => Promise<UserPayload>>();
+}
+
+// Public API
+export function ValidateToken(token: string): Promise<UserPayload> {
+  return internal.validateProxy(token);
+}
+
+// Decorator for consumers — generic code that belongs in the interface
+export const Authenticated = MakeParameterDecorator<[]>((target, key, index) => {
+  // Mark this parameter for token extraction and validation
+});
+```
+
+::note
+Code in the interface file should be implementation-agnostic. If the logic depends on a specific implementation (database driver, HTTP library, etc.), the code belongs in the implementation file instead.
+::
+
+## Extracting to a Standalone Package
+
+An embedded interface works well when a single module owns both the contract and the implementation. When a second module needs to implement the same contract, extract the interface into its own npm package.
+
+### When to Extract
+
+- A second module needs to implement the same contract
+- Consumers should depend on the contract without depending on a specific implementation
+- The interface becomes part of a shared ecosystem
+
+### How to Extract
+
+**1. Create a new package for the interface** (e.g., `@your-org/interface-email`). Move the interface file content to the new package's `src/index.ts` and publish it to npm.
+
+**2. Update the implementing module.** Add the interface package as a dependency and set `"implements"` in the `antelopeJs` configuration:
+
+```json [package.json]
+{
+  "antelopeJs": {
+    "implements": ["@your-org/interface-email"]
+  }
+}
+```
+
+**3. Change the `ImplementInterface` call** to import from the package instead of a local path:
+
+```typescript [src/index.ts]
+import { ImplementInterface } from "@antelopejs/interface-core";
+
+export async function construct() {
+  ImplementInterface(
+    await import("@your-org/interface-email"),
+    await import("./implementations/email")
+  );
+}
+```
+
+**4. Update consumers** to import from the interface package instead of the module:
+
+```typescript
+import { SendEmail } from "@your-org/interface-email";
+
+await SendEmail({ to: "user@example.com", subject: "Hello", body: "World" });
+```
+
+Consumers now depend only on the interface package. Any module that implements `@your-org/interface-email` can fulfill the contract at runtime, and consumers remain unaffected by implementation swaps.
+
+::tip
+Start with an embedded interface inside your module. Extract to a standalone package only when a second implementation appears. Premature extraction adds complexity without benefit.
+::
+
+## Best Practices
+
+- Keep interface files focused on the contract — types, proxies, wrapper functions, and shared utilities.
+- Place implementation-specific logic in the implementation file, not the interface.
+- Use `InterfaceFunction` for request-response patterns where a caller needs a result.
+- Use `EventProxy` for broadcasting events to multiple listeners.
+- Use `RegisteringProxy` for systems where modules contribute items to a collection.
+- Name wrapper functions clearly — they are the public API that consumers call.
+- Export shared types from the interface file so both implementations and consumers access the same definitions.
+
+## See also
+
+- [Interfaces](/docs/concepts/interfaces) — Understanding interface contracts
+- [Proxies](/docs/concepts/proxies) — Proxy types for inter-module communication
+- [Interface Registry](/docs/module-development/interface-registry) — Publishing interfaces to the registry

--- a/docs/3.module-development/3.testing.md
+++ b/docs/3.module-development/3.testing.md
@@ -1,0 +1,208 @@
+---
+title: Testing
+description: Test Antelopejs modules with the built-in test runner — configure the test environment, write isolated tests, and validate interface implementations.
+navigation:
+  icon: i-ph-test-tube
+---
+
+## Running Tests
+
+The CLI includes a test runner that boots the module in an isolated environment, loads dependencies, and executes test files.
+
+```bash
+ajs module test
+```
+
+To run a specific test file instead of the entire suite:
+
+```bash
+ajs module test -f test/specific.test.ts
+```
+
+The test runner compiles TypeScript, initializes the module lifecycle, runs all matching test files, and reports results. The runner tears down the environment after tests complete.
+
+## Test Configuration
+
+Point your module to a test configuration file by adding the `test` field in the `antelopeJs` section of `package.json`.
+
+```json [package.json]
+{
+  "antelopeJs": {
+    "test": "antelope.test.ts"
+  }
+}
+```
+
+The test configuration file defines which modules to load, how to set them up, and how to clean up after tests finish.
+
+```typescript [antelope.test.ts]
+import { defineConfig } from "@antelopejs/interface-core/config";
+
+export default defineConfig({
+  name: "my-module-test",
+  modules: {
+    // Modules needed for testing
+    "db-module": {
+      source: { type: "local", path: "../db-module" },
+      config: { connectionString: "mongodb://localhost/test" }
+    }
+  },
+  test: {
+    folder: "test",
+    setup: async () => {
+      // Run before tests — return config overrides if needed
+      return {
+        modules: { /* additional overrides */ }
+      };
+    },
+    cleanup: async () => {
+      // Run after tests — clean up test resources
+    }
+  }
+});
+```
+
+| Field | Description |
+|-------|-------------|
+| `modules` | Modules to load alongside your module during tests |
+| `test.folder` | Directory containing test files (defaults to `test`) |
+| `test.setup` | Async function that runs before tests — can return config overrides |
+| `test.cleanup` | Async function that runs after all tests complete |
+
+The `setup` function runs after modules are loaded but before test files execute. Use it to seed test data, start mock services, or apply configuration overrides. The `cleanup` function runs after all tests finish, regardless of pass or fail status.
+
+## Test File Conventions
+
+Test files must match the pattern `*.test.ts` or `*.spec.ts`. Place them in the `test/` directory or the directory specified by `test.folder` in your test configuration.
+
+```
+my-module/
+├── test/
+│   ├── user-service.test.ts
+│   ├── auth.test.ts
+│   └── helpers/
+│       └── fixtures.ts
+└── antelope.test.ts
+```
+
+Helper files and fixtures that do not match the test pattern are not executed as tests. You can import them from your test files to share setup logic or test data.
+
+## Stub Mode
+
+During testing, the framework enables stub mode by default. Stub mode enforces strict interface resolution so that unimplemented interfaces fail loudly instead of silently returning undefined.
+
+- `InterfaceFunction` calls reject with "Interface function called without implementation in test environment" unless a loaded module provides the implementation
+- `RegisteringProxy.register()` throws the same error if no module handles the registration
+
+This behavior forces you to explicitly load all required modules in your test configuration. Tests become isolated and predictable because every dependency must be declared upfront.
+
+::warning
+If a test fails with "Interface function called without implementation in test environment", check that the module providing that interface is listed in your test configuration's `modules` section.
+::
+
+## Writing Tests
+
+Test files use standard Mocha syntax. Import interface functions directly and call them as you would in production code.
+
+```typescript [test/user-service.test.ts]
+import { expect } from "chai";
+import { GetUser, CreateUser } from "@antelopejs/interface-user-service";
+
+describe("User Service", () => {
+  it("should create and retrieve a user", async () => {
+    const user = await CreateUser("Alice", "alice@example.com");
+    expect(user.name).to.equal("Alice");
+
+    const retrieved = await GetUser(user.id);
+    expect(retrieved.id).to.equal(user.id);
+  });
+});
+```
+
+Tests call the same interface functions that consumers use in production. The test runner loads your module's implementation and wires it to the interface proxies, so tests exercise the real code path through the interface layer.
+
+::note
+The test runner uses Mocha under the hood. You can use any assertion library compatible with Mocha, including Chai, Node's built-in `assert`, or any other library that throws on failure.
+::
+
+## Interface Tests
+
+Standalone interface packages can include their own test files in a `tests/` directory. These tests define the expected behavior of the contract — any module that implements the interface must pass them.
+
+```
+@antelopejs/interface-email/
+├── src/
+│   ├── index.ts              # Interface contract
+│   └── tests/
+│       └── send.test.ts      # Contract tests
+└── dist/
+    └── tests/
+        └── send.test.js      # Compiled tests
+```
+
+When you run `ajs module test` on an implementing module, the test runner automatically discovers and runs these interface tests. The runner reads the `implements` array from the module's `package.json`, locates each interface package, and looks for compiled test files in `dist/tests/`. The runner then combines the interface tests with the module's own local tests and executes them all together.
+
+```
+Test execution order:
+1. Local tests from the module's test/ directory
+2. Interface tests from each package listed in implements
+```
+
+This mechanism ensures that every implementation satisfies the contract defined by the interface. The interface author writes the tests once, and every implementing module runs them automatically.
+
+::tip
+When creating a standalone interface package, include tests that verify the contract behavior. These tests act as a compliance suite — any module claiming to implement the interface must pass them.
+::
+
+## Implementation-Specific Tests
+
+A module can include its own tests alongside the interface tests. Local tests in the module's `test/` directory cover implementation-specific behavior that the interface contract does not define.
+
+```
+my-email-module/
+├── test/
+│   ├── retry-logic.test.ts     # Implementation-specific
+│   └── rate-limiting.test.ts   # Implementation-specific
+└── package.json                # implements: ["@antelopejs/interface-email"]
+```
+
+The test runner collects both sets of test files and runs them in a single Mocha session. Interface tests verify that the contract is fulfilled, and local tests verify that implementation details work correctly.
+
+## Testing with Dependencies
+
+When your module depends on interfaces from other modules, declare those modules in the test configuration. The test runner loads them and resolves all interface bindings before running tests.
+
+```typescript [antelope.test.ts]
+import { defineConfig } from "@antelopejs/interface-core/config";
+
+export default defineConfig({
+  name: "my-module-test",
+  modules: {
+    "auth-module": {
+      source: { type: "local", path: "../auth-module" },
+      config: { secretKey: "test-secret" }
+    },
+    "db-module": {
+      source: { type: "local", path: "../db-module" },
+      config: { connectionString: "mongodb://localhost/test" }
+    }
+  },
+  test: {
+    folder: "test",
+    cleanup: async () => {
+      // Drop test database after tests
+    }
+  }
+});
+```
+
+Each module in the `modules` section receives its own `config` object. Use test-specific values — test database URLs, mock API keys, or reduced timeouts — to keep tests fast and isolated from production data.
+
+::tip
+Keep test configurations minimal. Only load the modules your tests actually depend on. Fewer modules mean faster test startup and clearer failure messages when something breaks.
+::
+
+## See also
+
+- [Creating a Module](/docs/module-development/creating-a-module) — Module structure and lifecycle
+- [Interfaces](/docs/concepts/interfaces) — Interface contracts that tests validate

--- a/docs/3.module-development/4.interface-registry.md
+++ b/docs/3.module-development/4.interface-registry.md
@@ -1,0 +1,131 @@
+---
+title: Interface Registry
+description: Register interfaces and implementations in the official registry to make them discoverable through the AntelopeJS CLI.
+navigation:
+  icon: i-ph-archive
+---
+
+## What Is the Interface Registry
+
+The interface registry is a git repository that acts as a catalog of available interfaces and their implementations. The AntelopeJS CLI queries this registry to help developers discover and install modules.
+
+Registering an interface is **optional**. Modules and interfaces work without being listed in the registry. The registry provides two CLI conveniences:
+
+- **`ajs project modules install`** — The CLI scans your project for unresolved interface dependencies and suggests implementations from the registry
+- **`ajs module init`** — The CLI can propose registered interfaces when scaffolding a new module
+
+::note
+The registry does not host code. The registry only stores metadata (descriptions and source locations). The actual interface packages and implementation modules live on npm, git, or local paths.
+::
+
+## Registry Structure
+
+The registry is a git repository with one directory per interface. Each directory contains a `manifest.json` file that describes the interface and lists available implementations.
+
+```
+interfaces/
+├── auth/
+│   └── manifest.json
+├── database/
+│   └── manifest.json
+└── api/
+    └── manifest.json
+```
+
+Antelopejs maintains an official registry. Organizations can also host private registries for internal interfaces.
+
+## Manifest Format
+
+Each `manifest.json` describes the interface and lists the modules that implement it.
+
+```json [manifest.json]
+{
+  "description": "User management interface",
+  "modules": [
+    {
+      "name": "user-module-mongodb",
+      "source": {
+        "type": "package",
+        "package": "@antelopejs/user-mongodb",
+        "version": "1.0.0"
+      }
+    }
+  ]
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `description` | Short summary of what the interface provides |
+| `modules` | List of modules that implement this interface |
+| `modules[].name` | Display name of the implementing module |
+| `modules[].source` | Source definition (package, git, or local) |
+
+The `modules` array can contain multiple implementations. When a developer runs `ajs project modules install`, the CLI presents all listed modules and lets them choose the implementation that fits their needs.
+
+## Adding to the Registry
+
+Registering an interface or adding a new implementation follows a contribution workflow through the registry repository.
+
+::steps{level="4"}
+
+#### Create or update the manifest
+
+Write a `manifest.json` for your interface if the registry does not have one yet. If the interface already has a manifest, add your module to the `modules` array.
+
+```json [manifest.json]
+{
+  "description": "Payment processing interface",
+  "modules": [
+    {
+      "name": "payment-stripe",
+      "source": {
+        "type": "package",
+        "package": "@your-org/payment-stripe",
+        "version": "1.0.0"
+      }
+    }
+  ]
+}
+```
+
+#### Make your module available
+
+Publish the implementing module to npm or make it accessible through a git repository. The registry points to your module's source — developers download the module directly from there.
+
+#### Submit a pull request
+
+Open a pull request against the registry repository with your manifest changes. The repository maintainers review the manifest before merging.
+
+::
+
+## Custom Registry
+
+Organizations can host a private registry for internal interfaces that should not appear in the official catalog.
+
+```bash
+ajs config set git https://github.com/your-org/your-interfaces.git
+```
+
+The CLI uses your custom repository for interface discovery. The repository must follow the same directory structure — one directory per interface, each containing a `manifest.json`.
+
+::tip
+Private registries work with any git hosting service. Use SSH URLs or access tokens for repositories that require authentication.
+::
+
+## CLI Integration
+
+The registry powers the `ajs project modules install` command. The CLI automates interface discovery and module installation for projects with unresolved dependencies.
+
+```bash
+ajs project modules install
+```
+
+The installation process follows these steps:
+
+1. The CLI scans your modules for interface imports that have no corresponding implementation
+2. The CLI fetches the registry and looks up each unresolved interface
+3. Available implementations are presented for selection
+4. The selected module is added to your project's `antelope.config.ts`
+
+After installation, the new module is downloaded and ready to use the next time you start the project. The interface imports in your existing modules automatically resolve to the newly installed implementation.

--- a/docs/3.module-development/index.md
+++ b/docs/3.module-development/index.md
@@ -1,0 +1,22 @@
+---
+title: Module Development
+navigation: false
+---
+
+::card-group
+::card{icon="i-ph-hammer" title="Creating a Module" to="/docs/module-development/creating-a-module"}
+Initialize a new module, understand the directory structure, configure the entry point, and register it in your project.
+::
+
+::card{icon="i-ph-plugs-connected" title="Exporting Interfaces" to="/docs/module-development/exporting-interfaces"}
+Define interface contracts with InterfaceFunction, EventProxy, and RegisteringProxy, then connect them to implementations.
+::
+
+::card{icon="i-ph-test-tube" title="Testing" to="/docs/module-development/testing"}
+Run module tests, configure the test environment, and write isolated tests against interface contracts.
+::
+
+::card{icon="i-ph-archive" title="Interface Registry" to="/docs/module-development/interface-registry"}
+Register interfaces and implementations in the official registry to make them discoverable through the CLI.
+::
+::

--- a/docs/4.guides/.navigation.yml
+++ b/docs/4.guides/.navigation.yml
@@ -1,0 +1,2 @@
+title: Guides
+icon: i-ph-book-open

--- a/docs/4.guides/1.api-routing.md
+++ b/docs/4.guides/1.api-routing.md
@@ -1,0 +1,260 @@
+---
+title: API Routing
+description: Build HTTP APIs with controllers, route decorators, parameter extraction, and structured responses in AntelopeJS.
+navigation:
+  icon: i-ph-arrows-split
+---
+
+## Prerequisites
+
+API routing requires the `@antelopejs/interface-api` package. Install it in your module and import from `@antelopejs/interface-api`.
+
+:::code-group
+```bash [npm]
+npm install @antelopejs/interface-api
+```
+```bash [yarn]
+yarn add @antelopejs/interface-api
+```
+```bash [pnpm]
+pnpm add @antelopejs/interface-api
+```
+:::
+
+All decorators, classes, and functions referenced in this guide come from this single package. No additional dependencies are needed.
+
+## Creating Controllers
+
+Controllers group related routes under a shared base path. The `Controller` function creates a base class at a specific URL location. Extend it to define your controller. Each method inside the class becomes a route handler when decorated with an HTTP method decorator.
+
+```typescript [src/controllers/users.ts]
+import { Controller, Get, Post, Put, Delete, Parameter, JSONBody } from "@antelopejs/interface-api";
+
+class UserController extends Controller("/api/users") {
+  @Get("")
+  async listUsers() {
+    return { users: [] };
+  }
+
+  @Get(":id")
+  async getUser(@Parameter("id") id: string) {
+    return { id, name: "Alice" };
+  }
+
+  @Post("")
+  async createUser(@JSONBody() body: { name: string; email: string }) {
+    return { id: "new-id", ...body };
+  }
+
+  @Put(":id")
+  async updateUser(@Parameter("id") id: string, @JSONBody() body: any) {
+    return { id, ...body };
+  }
+
+  @Delete(":id")
+  async deleteUser(@Parameter("id") id: string) {
+    return { success: true };
+  }
+}
+```
+
+The framework automatically serializes return values from handler methods as JSON responses. The `Controller` function is not a decorator. It returns a class that you extend with `extends Controller("/path")`. Path segments prefixed with `:` (such as `:id`) declare route parameters and feed `@Parameter("id")` (the default source is `"param"`). Pass an empty string (`@Get("")`) to bind the route to the controller's base path; omit the argument and the method name becomes the final segment. The decorator on each parameter controls whether the value comes from the URL path, the query string, or a header.
+
+## HTTP Responses
+
+The `HTTPResult` class provides control over status codes and response headers. Without `HTTPResult`, all successful responses return status `200`. Use `HTTPResult` when you need a different status code or custom headers.
+
+```typescript [src/controllers/users.ts]
+import { Controller, Post, JSONBody, HTTPResult } from "@antelopejs/interface-api";
+
+class UserController extends Controller("/api/users") {
+  @Post("")
+  async createUser(@JSONBody() body: any) {
+    const user = await saveUser(body);
+    return new HTTPResult(201, user);
+  }
+}
+```
+
+The first argument is the HTTP status code and the second is the response body. This pattern works well for `201 Created`, `204 No Content`, and other non-200 responses.
+
+## Route Prefixes and Postfixes
+
+The `@Prefix` and `@Postfix` decorators are **method** decorators that run before or after the main handler for a specific route. They are useful for authentication checks, input validation, response modification, or logging.
+
+`@Prefix(method, location?, priority?)` runs before the main handler. `@Postfix(method, location?, priority?)` runs after the main handler.
+
+```typescript [src/controllers/api.ts]
+import { Controller, Get, Prefix, Postfix, Result, HTTPResult, HandlerPriority } from "@antelopejs/interface-api";
+
+class ApiController extends Controller("/api") {
+  @Prefix("get", "status")
+  checkAccess() {
+    // Runs before the main handler for GET /api/status
+    // Return an HTTPResult to short-circuit the request
+  }
+
+  @Get("status")
+  async handler() {
+    return { version: 1 };
+  }
+
+  @Postfix("get", "status")
+  addHeaders(@Result() response: HTTPResult) {
+    // Runs after the main handler for GET /api/status
+    response.addHeader("X-API-Version", "1.0");
+  }
+}
+```
+
+The `method` argument is the HTTP method to match (e.g., `"get"`, `"post"`, or `"*"` for all methods). The `location` argument specifies the route path relative to the controller. The optional `priority` argument controls execution order when multiple prefix or postfix handlers match the same route.
+
+## Handler Priority
+
+The `HandlerPriority` enum controls the order in which route handlers run when multiple handlers match the same path. The enum defines five levels and is not a decorator.
+
+```typescript [src/controllers/api.ts]
+import { HandlerPriority } from "@antelopejs/interface-api";
+
+// HandlerPriority.HIGHEST = 0
+// HandlerPriority.HIGH    = 1
+// HandlerPriority.NORMAL  = 2
+// HandlerPriority.LOW     = 3
+// HandlerPriority.LOWEST  = 4
+```
+
+Handlers with a lower numeric value run first. The default priority for all handlers is `NORMAL`. Set the priority through route configuration when registering routes manually.
+
+## Parameter Decorators
+
+Parameter decorators extract specific parts of the incoming HTTP request and inject them as method arguments. Each decorator targets a different part of the request.
+
+| Decorator | Description |
+|-----------|-------------|
+| `@Parameter(name, source?)` | Single value from route parameter, query string, or header |
+| `@MultiParameter(name, source?)` | Multiple values from query string or header |
+| `@JSONBody()` | Parsed JSON request body |
+| `@RawBody()` | Raw request body as Buffer |
+| `@Context()` | Full `RequestContext` object |
+| `@Result()` | Response `HTTPResult` object (typically used in postfix handlers) |
+| `@WriteStream(type?)` | Writable stream for long-running or chunked responses |
+| `@Connection()` | WebSocket connection object (for `@WebsocketHandler` routes) |
+| `@Transform(fn)` | Apply a transformation function to a parameter value |
+
+## Request Context
+
+The `@Context()` decorator provides access to the full request context, including the raw request object, response object, headers, and other low-level details.
+
+```typescript [src/controllers/debug.ts]
+import { Controller, Get, Context, type RequestContext } from "@antelopejs/interface-api";
+
+class DebugController extends Controller("/api/debug") {
+  @Get("info")
+  async handler(@Context() ctx: RequestContext) {
+    return {
+      method: ctx.rawRequest.method,
+      url: ctx.url.toString(),
+      headers: ctx.rawRequest.headers,
+    };
+  }
+}
+```
+
+The `RequestContext` interface provides `rawRequest` (the Node.js `IncomingMessage`), `rawResponse` (the `ServerResponse`), `url` (a parsed `URL` object), `routeParameters`, `body`, and `response` (the `HTTPResult` that will be sent). Use `@Context()` when the higher-level parameter decorators do not provide enough information. Most route handlers only need `@Parameter()` and `@JSONBody()`.
+
+## Streaming Responses
+
+The `@WriteStream()` decorator injects a writable stream for sending long-running or chunked responses. Streaming is useful for server-sent events, file downloads, or progress updates.
+
+```typescript [src/controllers/stream.ts]
+import { Controller, Get, WriteStream } from "@antelopejs/interface-api";
+import { PassThrough } from "node:stream";
+
+class StreamController extends Controller("/api/stream") {
+  @Get("data")
+  async streamData(@WriteStream() stream: PassThrough) {
+    for (let i = 0; i < 10; i++) {
+      stream.write(`data: chunk ${i}\n\n`);
+    }
+    stream.end();
+  }
+}
+```
+
+The stream remains open until you explicitly call `end()`. The client receives data as it is written.
+
+## WebSocket Handlers
+
+The `@WebsocketHandler` decorator marks a method as a WebSocket handler. Use the `@Connection()` decorator to receive the WebSocket connection object.
+
+```typescript [src/controllers/ws.ts]
+import { Controller, WebsocketHandler, Connection } from "@antelopejs/interface-api";
+
+class WebSocketController extends Controller("/ws") {
+  @WebsocketHandler("connect")
+  async handleConnection(@Connection() conn: any) {
+    conn.on("message", (msg: string) => {
+      conn.send(`Echo: ${msg}`);
+    });
+  }
+}
+```
+
+WebSocket handlers operate independently from HTTP route handlers. They manage persistent connections and bidirectional communication.
+
+## Manual Route Registration
+
+The `RegisterRoute()` function registers routes programmatically without decorators. This approach works well when routes need to be generated dynamically or configured at runtime.
+
+```typescript [src/routes/dynamic.ts]
+import { RegisterRoute } from "@antelopejs/interface-api";
+
+RegisterRoute({
+  mode: "handler",
+  method: "get",
+  location: "/api/health",
+  callback: async () => {
+    return { status: "ok" };
+  },
+  parameters: [],
+  properties: {},
+  proto: {},
+});
+```
+
+The `RegisterRoute` function takes a `RouteHandler` object with these required fields: `mode` (`"handler"`, `"prefix"`, `"postfix"`, `"monitor"`, or `"websocket"`), `method` (HTTP method), `location` (full route path), `callback` (handler function), `parameters` (computed parameter array), `properties` (computed properties), and `proto` (controller prototype). An optional `priority` field accepts a `HandlerPriority` value. Manual registration gives you full control over route configuration. Use this approach when you need to generate routes from external configuration or runtime data.
+
+::note
+There is no `@Patch` decorator. For PATCH requests, use `@Route` with custom configuration.
+::
+
+## Starting the Server
+
+The API module starts the HTTP server automatically by default. The server port and other settings are controlled through the module's configuration in `antelope.config.ts`.
+
+To take manual control over when the server starts, set `autoListen` to `false` in the API module's configuration and call `Listen()` yourself:
+
+```typescript [antelope.config.ts]
+import { defineConfig } from "@antelopejs/interface-core/config";
+
+export default defineConfig({
+  name: "my-app",
+  modules: {
+    api: {
+      config: { autoListen: false }
+    }
+  }
+});
+```
+
+```typescript [src/index.ts]
+import { Listen } from "@antelopejs/interface-api";
+
+export async function start() {
+  await Listen();
+}
+```
+
+::tip
+Most applications can rely on the default `autoListen` behavior. Disable it only when you need to delay server startup until other resources are ready.
+::

--- a/docs/4.guides/2.database.md
+++ b/docs/4.guides/2.database.md
@@ -1,0 +1,268 @@
+---
+title: Database
+description: Define database tables, apply modifiers for hashing and encryption, and perform CRUD operations with data models in AntelopeJS.
+navigation:
+  icon: i-ph-database
+---
+
+## Prerequisites
+
+Database operations require the `@antelopejs/interface-database-decorators` package. Install it in your module and import from `@antelopejs/interface-database-decorators`.
+
+:::code-group
+```bash [npm]
+npm install @antelopejs/interface-database-decorators
+```
+```bash [yarn]
+yarn add @antelopejs/interface-database-decorators
+```
+```bash [pnpm]
+pnpm add @antelopejs/interface-database-decorators
+```
+:::
+
+All table classes, decorators, modifiers, and model functions referenced in this guide come from this package. No additional dependencies are needed.
+
+## Defining Tables
+
+You define tables as classes that extend the `Table` base class. The `@RegisterTable` decorator registers the class with the database system under a specific table name and schema. Each property on the class represents a column.
+
+```typescript [src/db/tables/user.ts]
+import { Table, RegisterTable, Index } from "@antelopejs/interface-database-decorators";
+
+@RegisterTable("users", "main")
+class User extends Table {
+  @Index()
+  declare email: string;
+
+  declare name: string;
+  declare age: number;
+}
+
+export { User };
+```
+
+The first argument to `@RegisterTable` is the table name and the second is the schema name. Default values on properties define the column types and provide fallback values for new records. The `@Index` decorator marks a property as indexed for faster lookups.
+
+::note
+`Table` is a base class, not a decorator. Always extend it with `class MyTable extends Table`.
+::
+
+## Indexing
+
+The `@Index` decorator marks a property for database indexing. Indexes speed up queries that filter or sort by the indexed column. You can group multiple columns into a composite index by specifying a group name.
+
+```typescript [src/db/tables/product.ts]
+import { Table, RegisterTable, Index } from "@antelopejs/interface-database-decorators";
+
+@RegisterTable("products", "main")
+class Product extends Table {
+  @Index()
+  declare sku: string;
+
+  @Index({ group: "category_brand" })
+  declare category: string;
+
+  @Index({ group: "category_brand" })
+  declare brand: string;
+
+  declare name: string;
+  declare price: number;
+}
+
+export { Product };
+```
+
+Properties with the same `group` value form a composite index. Queries that filter by both `category` and `brand` benefit from the composite index.
+
+## Table Modifiers
+
+Modifiers add specialized behavior to table properties. Apply modifiers through `Table.with()`, which returns an extended base class with the modifier capabilities enabled. You can chain multiple modifiers together.
+
+### Hashing
+
+The `HashModifier` enables the `@Hashed` decorator for properties that store hashed values, such as passwords. Hashed values are one-way transformed before storage and cannot be reversed.
+
+```typescript [src/db/tables/user.ts]
+import { Table, RegisterTable, Index, Hashed } from "@antelopejs/interface-database-decorators";
+import { HashModifier } from "@antelopejs/interface-database-decorators";
+
+@RegisterTable("users", "main")
+class User extends Table.with(HashModifier) {
+  @Index()
+  declare email: string;
+
+  @Hashed()
+  declare password: string;
+
+  declare name: string;
+}
+
+export { User };
+```
+
+When a record is inserted or updated, the `password` field is automatically hashed before it reaches the database. The original plaintext value is never stored.
+
+### Encryption
+
+The `EncryptionModifier` enables the `@Encrypted` decorator for properties that must be stored encrypted. Unlike hashing, encrypted values can be decrypted when read back.
+
+```typescript [src/db/tables/user.ts]
+import { Table, RegisterTable, Index, Encrypted } from "@antelopejs/interface-database-decorators";
+import { EncryptionModifier } from "@antelopejs/interface-database-decorators";
+
+@RegisterTable("users", "main")
+class User extends Table.with(EncryptionModifier) {
+  @Index()
+  declare email: string;
+
+  @Encrypted({ secretKey: "change-me-to-a-32-char-key-12345" })
+  declare socialSecurityNumber: string;
+
+  declare name: string;
+}
+
+export { User };
+```
+
+Encrypted fields are transparently encrypted on write and decrypted on read. The `secretKey` option is required and specifies the encryption key. You can also configure the `algorithm` (defaults to `aes-256-gcm`) and `ivSize` (defaults to `16`).
+
+### Combining Modifiers
+
+You can apply multiple modifiers at once by passing them all to `Table.with()`. This combination enables both `@Hashed` and `@Encrypted` decorators on the same table class.
+
+```typescript [src/db/tables/user.ts]
+import { Table, RegisterTable, Index, Hashed, Encrypted } from "@antelopejs/interface-database-decorators";
+import { HashModifier, EncryptionModifier } from "@antelopejs/interface-database-decorators";
+
+@RegisterTable("users", "main")
+class User extends Table.with(HashModifier, EncryptionModifier) {
+  @Index()
+  declare email: string;
+
+  @Hashed()
+  declare password: string;
+
+  @Encrypted({ secretKey: "change-me-to-a-32-char-key-12345" })
+  declare socialSecurityNumber: string;
+
+  declare name: string;
+}
+
+export { User };
+```
+
+## Registering a Database Schema
+
+Before your models can interact with the database, you must register the schema. The `RegisterSchema` function builds the schema definition from all tables registered under the given schema id and provisions it through the database adapter.
+
+```typescript [src/db/schema.ts]
+import { RegisterSchema } from "@antelopejs/interface-database-decorators";
+
+await RegisterSchema("main");
+```
+
+The schema name passed here must match the schema name used in your `@RegisterTable` decorators. Call this function once during module initialization (for example, in the module's `construct` function). The function is async, so make sure to `await` it.
+
+## Data Models
+
+The `BasicDataModel` function generates a model class with built-in CRUD operations for a registered table. It accepts the table class and returns a new class that you can extend with custom methods.
+
+```typescript [src/db/models/user-model.ts]
+import { BasicDataModel, GetModel } from "@antelopejs/interface-database-decorators";
+import { User } from "../tables/user";
+
+class UserModel extends BasicDataModel(User) {
+  async getUserByEmail(email: string) {
+    const users = await this.getBy("email", email);
+    return users.length > 0 ? users[0] : null;
+  }
+}
+
+export function getUserModel() {
+  return GetModel(UserModel);
+}
+
+export { UserModel };
+```
+
+::note
+`BasicDataModel` is a function that returns a class, not a decorator. Use `extends BasicDataModel(TableClass)` to create your model. Model instances require a database connection, so use `GetModel(YourModel)` to obtain a properly initialized instance rather than calling `new` directly.
+::
+
+The returned model includes these built-in instance methods:
+
+| Method | Description |
+|--------|-------------|
+| `get(id)` | Retrieve a single record by its primary key |
+| `getBy(index, ...keys)` | Retrieve records matching a given index |
+| `getAll()` | Retrieve all records |
+| `insert(data)` | Create a new record |
+| `update(id, data)` | Update an existing record by ID |
+| `delete(id)` | Remove a record by ID |
+
+The model also provides static methods for data conversion:
+
+| Static Method | Description |
+|---------------|-------------|
+| `fromPlainData()` | Create a model instance from plain data |
+| `fromDatabase()` | Create a model instance from database format |
+| `toDatabase()` | Convert a model instance to database format |
+
+## CRUD Operations
+
+Once you have a model instance, all standard CRUD operations are available as async methods. Each method handles serialization, modifier processing (hashing, encryption), and database communication automatically.
+
+```typescript
+import { getUserModel } from "./models/user-model";
+
+const userModel = getUserModel();
+
+// Create
+await userModel.insert({
+  name: "Alice",
+  email: "alice@example.com",
+  password: "secret",
+});
+
+// Read all
+const allUsers = await userModel.getAll();
+
+// Read by index
+const users = await userModel.getBy("email", "alice@example.com");
+const user = users[0];
+
+// Read by primary key
+const found = await userModel.get(user._id);
+
+// Update
+await userModel.update(user._id, { name: "Alice Updated" });
+
+// Delete
+await userModel.delete(user._id);
+```
+
+When inserting a record with a `@Hashed` property, the value is hashed before storage. When reading a record with an `@Encrypted` property, the value is decrypted automatically.
+
+## Fixtures
+
+The `@Fixture` decorator provides seed data for development and testing. It takes a generator function that returns an array of records to insert when the table is first created.
+
+```typescript [src/db/tables/role.ts]
+import { Table, RegisterTable, Fixture } from "@antelopejs/interface-database-decorators";
+
+@Fixture(() => [
+  { name: "admin", permissions: ["read", "write", "delete"] },
+  { name: "editor", permissions: ["read", "write"] },
+  { name: "viewer", permissions: ["read"] },
+])
+@RegisterTable("roles", "main")
+class Role extends Table {
+  declare name: string;
+  permissions: string[] = [];
+}
+
+export { Role };
+```
+
+Fixtures run once during schema initialization. They are useful for populating lookup tables, default roles, or any data that must exist before the application starts serving requests.

--- a/docs/4.guides/3.authentication.md
+++ b/docs/4.guides/3.authentication.md
@@ -1,0 +1,198 @@
+---
+title: Authentication
+description: Sign and validate JWT tokens, protect routes with authentication decorators, and manage server-side cookie authentication in AntelopeJS.
+navigation:
+  icon: i-ph-lock-key
+---
+
+## Prerequisites
+
+Authentication requires the `@antelopejs/interface-auth` package. Install it in your module and import from `@antelopejs/interface-auth`.
+
+:::code-group
+```bash [npm]
+npm install @antelopejs/interface-auth @antelopejs/interface-api
+```
+```bash [yarn]
+yarn add @antelopejs/interface-auth @antelopejs/interface-api
+```
+```bash [pnpm]
+pnpm add @antelopejs/interface-auth @antelopejs/interface-api
+```
+:::
+
+The `@antelopejs/interface-auth` package provides token signing and validation. The `@antelopejs/interface-api` package provides controller and route decorators for protecting endpoints.
+
+## Signing Tokens
+
+The `SignRaw` function creates a signed JWT token from a data payload. The token encodes the payload and can be verified later with `ValidateRaw`. An optional second argument controls token expiration and activation timing.
+
+```typescript
+import { SignRaw } from "@antelopejs/interface-auth";
+
+const token = await SignRaw(
+  { userId: "123", role: "admin" },
+  { expiresIn: "24h" }
+);
+```
+
+The `options` object supports these fields:
+
+| Option | Description |
+|--------|-------------|
+| `expiresIn` | Duration until the token expires (e.g., `"1h"`, `"7d"`, `"30m"`) |
+| `notBefore` | Duration before the token becomes valid |
+
+::tip
+Always set `expiresIn` on tokens used for user sessions. Tokens without expiration remain valid indefinitely if the signing key is not rotated.
+::
+
+## Validating Tokens
+
+The `ValidateRaw` function verifies a token's signature and returns the decoded payload. It throws an error if the token is invalid, expired, or not yet active.
+
+```typescript
+import { ValidateRaw } from "@antelopejs/interface-auth";
+
+const payload = await ValidateRaw(token);
+// payload: { userId: "123", role: "admin", iat: ..., exp: ... }
+```
+
+The returned payload includes the original data plus standard JWT claims (`iat` for issued-at, `exp` for expiration). An optional second argument provides validation options.
+
+| Option | Description |
+|--------|-------------|
+| `ignoreExpiration` | Accept expired tokens |
+| `ignoreNotBefore` | Accept tokens before their `notBefore` time |
+| `maxAge` | Maximum allowed age of the token |
+
+Pass these options as the second argument to `ValidateRaw`:
+
+```typescript
+// Accept expired tokens (useful for refresh flows)
+const payload = await ValidateRaw(token, { ignoreExpiration: true });
+```
+
+::warning
+Only use `ignoreExpiration` in controlled scenarios such as token refresh endpoints. Accepting expired tokens in regular authentication weakens security.
+::
+
+## Protecting Routes with `@Authentication`
+
+The `@Authentication` parameter decorator extracts and validates a token from the incoming request automatically. It reads the token from the `x-antelopejs-auth` header or an `ANTELOPEJS_AUTH` cookie, validates it, and injects the decoded payload into the handler method.
+
+```typescript [src/controllers/profile.ts]
+import { Controller, Get } from "@antelopejs/interface-api";
+import { Authentication } from "@antelopejs/interface-auth";
+
+class ProfileController extends Controller("/api/profile") {
+  @Get("me")
+  async getProfile(@Authentication() auth: any) {
+    return { userId: auth.userId, role: auth.role };
+  }
+}
+```
+
+Requests without a valid token receive an authentication error response. The decorator handles token extraction and validation entirely, so the handler method only runs for authenticated requests.
+
+## Server-Side Cookie Authentication
+
+The `SignServerResponse` function creates a signed token and sets it as an HTTP cookie on the response. This approach stores the authentication token in a cookie rather than requiring the client to manage it manually.
+
+```typescript [src/controllers/auth.ts]
+import { Controller, Post, JSONBody, Context, type RequestContext } from "@antelopejs/interface-api";
+import { SignServerResponse } from "@antelopejs/interface-auth";
+
+class AuthController extends Controller("/api/auth") {
+  @Post("login")
+  async login(@JSONBody() body: { email: string; password: string }, @Context() ctx: RequestContext) {
+    const user = await validateCredentials(body.email, body.password);
+
+    await SignServerResponse(
+      ctx.rawResponse,
+      { userId: user.id, role: user.role },
+      { expiresIn: "7d" }
+    );
+
+    return { success: true };
+  }
+}
+```
+
+The function accepts four arguments:
+
+| Argument | Description |
+|----------|-------------|
+| `res` | The raw `ServerResponse` object (`ctx.rawResponse` from the request context) |
+| `data` | The payload to encode in the token |
+| `signOptions` | Token signing options (same as `SignRaw`) |
+| `cookieOptions` | Optional cookie configuration (path, domain, secure, etc.) |
+
+Subsequent requests from the client automatically include the cookie. The `@Authentication` decorator reads tokens from the `ANTELOPEJS_AUTH` cookie in addition to the `x-antelopejs-auth` header.
+
+## Custom Auth Decorators
+
+The `CreateAuthDecorator` function builds a specialized authentication decorator with custom extraction, verification, and validation logic. Custom decorators are useful when you need role-based access control or multi-tenant authentication.
+
+```typescript [src/auth/admin-auth.ts]
+import { CreateAuthDecorator, ValidateRaw } from "@antelopejs/interface-auth";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+const AdminAuth = CreateAuthDecorator({
+  source(req: IncomingMessage, _res: ServerResponse) {
+    const header = req.headers["authorization"];
+    return typeof header === "string" ? header.replace("Bearer ", "") : undefined;
+  },
+  async authenticator(token?: string) {
+    const payload = await ValidateRaw(token);
+    if ((payload as any).role !== "admin") {
+      throw new Error("Admin access required");
+    }
+    return payload;
+  },
+});
+
+export { AdminAuth };
+```
+
+The callbacks object accepts four optional fields: `source` extracts the token from the request, `authenticator` verifies the token, `authenticatorOptions` provides options for verification, and `validator` performs additional validation on the verified data. Use the custom decorator on any route handler just like `@Authentication`.
+
+```typescript [src/controllers/admin.ts]
+import { Controller, Get } from "@antelopejs/interface-api";
+import { AdminAuth } from "../auth/admin-auth";
+
+class AdminController extends Controller("/api/admin") {
+  @Get("dashboard")
+  async dashboard(@AdminAuth() auth: any) {
+    return { message: "Welcome, admin", userId: auth.userId };
+  }
+}
+```
+
+Only requests with a valid admin token can access this route. The custom decorator encapsulates the role check, keeping handler methods focused on business logic.
+
+## Authentication Flow
+
+A typical authentication flow combines token signing, cookie management, and route protection into a cohesive system.
+
+::steps{level="4"}
+
+#### User registers or logs in
+
+The server validates credentials and issues a signed token. The server returns the token in the response body or sets it as a cookie.
+
+#### Client sends the token with requests
+
+The client includes the token in the `x-antelopejs-auth` header, or the browser sends it automatically as the `ANTELOPEJS_AUTH` cookie.
+
+#### Route handlers validate the token
+
+The `@Authentication` decorator extracts and validates the token before the handler runs. Invalid or missing tokens result in an error response.
+
+#### Token expires and is refreshed
+
+When a token expires, the client requests a new one using a refresh endpoint. The refresh endpoint validates the expired token with `ignoreExpiration` and issues a fresh token.
+
+::
+
+This pattern keeps authentication logic separate from business logic. Controllers declare their authentication requirements through decorators, and the auth system handles the rest.

--- a/docs/4.guides/4.data-api.md
+++ b/docs/4.guides/4.data-api.md
@@ -1,0 +1,213 @@
+---
+title: Data API
+description: Generate automatic CRUD endpoints from database tables with customizable routes, authentication, and middleware in AntelopeJS.
+navigation:
+  icon: i-ph-plug
+---
+
+## Prerequisites
+
+The Data API builds on both the API and database systems. Install all three interface packages in your module.
+
+:::code-group
+```bash [npm]
+npm install @antelopejs/interface-data-api @antelopejs/interface-api @antelopejs/interface-database-decorators
+```
+```bash [yarn]
+yarn add @antelopejs/interface-data-api @antelopejs/interface-api @antelopejs/interface-database-decorators
+```
+```bash [pnpm]
+pnpm add @antelopejs/interface-data-api @antelopejs/interface-api @antelopejs/interface-database-decorators
+```
+:::
+
+Import from these packages as needed:
+
+- `@antelopejs/interface-data-api` -- `DataController`, `RegisterDataController`, `DefaultRoutes`
+- `@antelopejs/interface-api` -- `Controller`
+- `@antelopejs/interface-database-decorators` -- Table definitions and models
+
+Before using the Data API, you need a registered table. Refer to the [Database guide](/docs/guides/database) for table setup.
+
+## Creating a Data Controller
+
+The `DataController` function generates a controller class with CRUD endpoints mapped to a database table. It accepts three arguments: the table class, a route definition object, and a base controller. The `@RegisterDataController()` decorator registers the generated controller with the framework.
+
+```typescript [src/data-api/tasks.ts]
+import { DataController, RegisterDataController, DefaultRoutes } from "@antelopejs/interface-data-api";
+import { Controller } from "@antelopejs/interface-api";
+import { Task } from "../db/tables/task";
+
+@RegisterDataController()
+class TaskDataController extends DataController(
+  Task,
+  {
+    get: DefaultRoutes.Get,
+    list: DefaultRoutes.List,
+    new: DefaultRoutes.New,
+    edit: DefaultRoutes.Edit,
+    delete: DefaultRoutes.Delete,
+  },
+  Controller("/api/tasks")
+) {}
+```
+
+This single class definition creates five endpoints:
+
+| Route | Method | Description |
+|-------|--------|-------------|
+| `GET /api/tasks/get?id=<id>` | `DefaultRoutes.Get` | Retrieve a single task |
+| `GET /api/tasks/list` | `DefaultRoutes.List` | List all tasks |
+| `POST /api/tasks/new` | `DefaultRoutes.New` | Create a new task |
+| `PUT /api/tasks/edit?id=<id>` | `DefaultRoutes.Edit` | Update an existing task |
+| `DELETE /api/tasks/delete?id=<id>` | `DefaultRoutes.Delete` | Delete a task |
+
+The final path segment matches the key you used in the route definition (`get`, `list`, `new`, `edit`, `delete`). Identifiers for single-record routes are passed as the `id` query parameter, not as a path segment.
+
+::note
+`DataController` is a function that returns a class, not a decorator. Use `extends DataController(...)` to create your data controller.
+::
+
+## Using DefaultRoutes.All
+
+When you need all five CRUD routes, `DefaultRoutes.All` provides a shorthand that includes `Get`, `List`, `New`, `Edit`, and `Delete` in a single declaration.
+
+```typescript [src/data-api/tasks.ts]
+import { DataController, RegisterDataController, DefaultRoutes } from "@antelopejs/interface-data-api";
+import { Controller } from "@antelopejs/interface-api";
+import { Task } from "../db/tables/task";
+
+@RegisterDataController()
+class TaskDataController extends DataController(
+  Task,
+  DefaultRoutes.All,
+  Controller("/api/tasks")
+) {}
+```
+
+The shorthand produces the exact same set of endpoints as the explicit route definition. Use the explicit form when you need to include only specific routes or apply different options to each route.
+
+## Selective Routes
+
+You can include only the routes your API needs by listing a subset in the route definition. Omitted routes are not generated.
+
+```typescript [src/data-api/readonly-tasks.ts]
+import { DataController, RegisterDataController, DefaultRoutes } from "@antelopejs/interface-data-api";
+import { Controller } from "@antelopejs/interface-api";
+import { Task } from "../db/tables/task";
+
+@RegisterDataController()
+class ReadOnlyTaskController extends DataController(
+  Task,
+  {
+    get: DefaultRoutes.Get,
+    list: DefaultRoutes.List,
+  },
+  Controller("/api/public/tasks")
+) {}
+```
+
+This controller exposes only `GET` endpoints. No create, update, or delete operations are available, making it suitable for public or read-only APIs.
+
+## Adding Authentication
+
+`@Authentication` from `@antelopejs/interface-auth` works as a class decorator. Applied to the Data API controller, it registers an auth check as a computed property on the controller, which the framework evaluates for every incoming request before any handler runs.
+
+```typescript [src/data-api/tasks.ts]
+import { DataController, RegisterDataController, DefaultRoutes } from "@antelopejs/interface-data-api";
+import { Controller } from "@antelopejs/interface-api";
+import { Authentication } from "@antelopejs/interface-auth";
+import { Task } from "../db/tables/task";
+
+@RegisterDataController()
+@Authentication()
+class TaskDataController extends DataController(
+  Task,
+  DefaultRoutes.All,
+  Controller("/api/tasks")
+) {}
+```
+
+Every route now requires a valid authentication token. Requests without authentication are rejected before reaching the route handler.
+
+## Mixed Access Patterns
+
+Class-level `@Authentication()` is all-or-nothing. When you need a mix of public read endpoints and protected write endpoints on the same table, split the routes across two controllers mounted at the same base path — one protected, one public.
+
+```typescript [src/data-api/articles.ts]
+import { DataController, RegisterDataController, DefaultRoutes } from "@antelopejs/interface-data-api";
+import { Controller } from "@antelopejs/interface-api";
+import { Authentication } from "@antelopejs/interface-auth";
+import { Article } from "../db/tables/article";
+
+@RegisterDataController()
+class PublicArticleController extends DataController(
+  Article,
+  {
+    get: DefaultRoutes.Get,
+    list: DefaultRoutes.List,
+  },
+  Controller("/api/articles")
+) {}
+
+@RegisterDataController()
+@Authentication()
+class ProtectedArticleController extends DataController(
+  Article,
+  {
+    new: DefaultRoutes.New,
+    edit: DefaultRoutes.Edit,
+    delete: DefaultRoutes.Delete,
+  },
+  Controller("/api/articles")
+) {}
+```
+
+Anyone can read articles, but only authenticated users can create, edit, or delete them.
+
+## Custom Route Options
+
+The `DefaultRoutes.WithOptions` function accepts an optional third argument for the endpoint path. The third argument replaces the final path segment of a specific route.
+
+```typescript
+DefaultRoutes.WithOptions(DefaultRoutes.Get, {}, "by-id")
+```
+
+With this override the Get route becomes `GET /api/tasks/by-id?id=<id>` instead of the default `GET /api/tasks/get?id=<id>`. The options object forwards query-parameter defaults to the route handler (for example `{ noPluck: true }` or `{ noForeign: true }`); it is not a place to plug in authentication. Use custom endpoints when the default URL segment does not match your API design or when you need to avoid conflicts with other controllers.
+
+## Combining with the Database Guide
+
+The Data API works directly with tables defined using the database decorators. Here is a complete example that defines a table and exposes it as a CRUD API.
+
+```typescript [src/db/tables/task.ts]
+import { Table, RegisterTable, Index } from "@antelopejs/interface-database-decorators";
+
+@RegisterTable("tasks", "main")
+class Task extends Table {
+  @Index()
+  declare userId: string;
+
+  declare title: string;
+  declare description: string;
+  declare completed: boolean;
+}
+
+export { Task };
+```
+
+The data controller below exposes CRUD endpoints for the Task table using `DefaultRoutes.All`:
+
+```typescript [src/data-api/tasks.ts]
+import { DataController, RegisterDataController, DefaultRoutes } from "@antelopejs/interface-data-api";
+import { Controller } from "@antelopejs/interface-api";
+import { Task } from "../db/tables/task";
+
+@RegisterDataController()
+class TaskDataController extends DataController(
+  Task,
+  DefaultRoutes.All,
+  Controller("/api/tasks")
+) {}
+```
+
+The Data API reads the table's schema and generates endpoints that match the table's structure. Column names become the fields in request and response bodies. You can use indexed fields for filtering in list operations.

--- a/docs/4.guides/5.full-stack-tutorial.md
+++ b/docs/4.guides/5.full-stack-tutorial.md
@@ -1,0 +1,382 @@
+---
+title: Full-Stack Application
+description: Build a complete task management API from scratch using database tables, authentication, and automatic CRUD endpoints in AntelopeJS.
+navigation:
+  icon: i-ph-rocket
+---
+
+## Overview
+
+This tutorial builds a task management API with user registration, login, and authenticated CRUD operations. By the end, you will have a running application with these endpoints:
+
+- `POST /api/auth/register` -- Create a new user account
+- `POST /api/auth/login` -- Authenticate and receive a token
+- `GET /api/auth/profile` -- Retrieve the authenticated user's profile
+- `GET /api/tasks/list` -- List all tasks (authenticated)
+- `GET /api/tasks/get?id=<id>` -- Get a single task (authenticated)
+- `POST /api/tasks/new` -- Create a task (authenticated)
+- `PUT /api/tasks/edit?id=<id>` -- Update a task (authenticated)
+- `DELETE /api/tasks/delete?id=<id>` -- Delete a task (authenticated)
+
+## Prerequisites
+
+This tutorial uses four interface packages. Install them all in your module.
+
+:::code-group
+```bash [npm]
+npm install @antelopejs/interface-api @antelopejs/interface-database-decorators @antelopejs/interface-auth @antelopejs/interface-data-api
+```
+```bash [yarn]
+yarn add @antelopejs/interface-api @antelopejs/interface-database-decorators @antelopejs/interface-auth @antelopejs/interface-data-api
+```
+```bash [pnpm]
+pnpm add @antelopejs/interface-api @antelopejs/interface-database-decorators @antelopejs/interface-auth @antelopejs/interface-data-api
+```
+:::
+
+You also need the AntelopeJS CLI installed globally. Refer to the [Installation guide](/docs/get-started/installation) if you have not set it up yet.
+
+## Application Structure
+
+The completed project follows this layout:
+
+```
+my-app/
+├── antelope.config.ts
+├── src/
+│   ├── index.ts
+│   ├── db/
+│   │   ├── tables/
+│   │   │   ├── user.ts
+│   │   │   └── task.ts
+│   │   └── models/
+│   │       ├── user-model.ts
+│   │       └── task-model.ts
+│   ├── routes/
+│   │   └── auth.ts
+│   └── data-api/
+│       └── tasks.ts
+└── package.json
+```
+
+The `db/` directory holds table definitions and data models. The `routes/` directory contains custom controllers for authentication. The `data-api/` directory uses the Data API to generate CRUD endpoints automatically.
+
+## Building the Application
+
+::steps{level="4"}
+
+#### Set up the module
+
+Create the module directory and initialize it with the required package configuration. The `antelopeJs` field in `package.json` tells the core how to load and resolve the module.
+
+```json [package.json]
+{
+  "name": "my-app",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "antelopeJs": {
+    "implements": [],
+    "baseUrl": "dist",
+    "paths": {
+      "@/*": ["*"]
+    },
+    "moduleAliases": {},
+    "defaultConfig": {}
+  },
+  "dependencies": {
+    "@antelopejs/interface-api": "*",
+    "@antelopejs/interface-auth": "*",
+    "@antelopejs/interface-data-api": "*",
+    "@antelopejs/interface-database-decorators": "*"
+  }
+}
+```
+
+Set up TypeScript configuration with decorator support:
+
+```json [tsconfig.json]
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}
+```
+
+#### Define the User table
+
+The User table stores account credentials and profile information. The `@Hashed` modifier on the `password` property ensures passwords are hashed before storage. Extend `Table.with(HashModifier)` to enable hashing support.
+
+```typescript [src/db/tables/user.ts]
+import { Table, RegisterTable, Index, Hashed } from "@antelopejs/interface-database-decorators";
+import { HashModifier } from "@antelopejs/interface-database-decorators";
+
+@RegisterTable("users", "main")
+class User extends Table.with(HashModifier) {
+  @Index()
+  declare email: string;
+
+  @Hashed()
+  declare password: string;
+
+  declare name: string;
+}
+
+export { User };
+```
+
+The `@Index` decorator on `email` enables fast lookups when authenticating users. The `@Hashed` decorator ensures the plaintext password is never stored in the database.
+
+#### Define the Task table
+
+The Task table stores task records associated with users. The `userId` field links each task to its owner, and the `@Index` decorator enables efficient filtering by user.
+
+```typescript [src/db/tables/task.ts]
+import { Table, RegisterTable, Index } from "@antelopejs/interface-database-decorators";
+
+@RegisterTable("tasks", "main")
+class Task extends Table {
+  @Index()
+  declare userId: string;
+
+  declare title: string;
+  declare description: string;
+  declare completed: boolean;
+}
+
+export { Task };
+```
+
+#### Create the User model
+
+The User model extends `BasicDataModel` with custom methods for authentication workflows. The `getUserByEmail` method retrieves a user by email address, and `createUser` handles user registration.
+
+```typescript [src/db/models/user-model.ts]
+import { BasicDataModel, GetModel } from "@antelopejs/interface-database-decorators";
+import { User } from "../tables/user";
+
+class UserModel extends BasicDataModel(User) {
+  async getUserByEmail(email: string) {
+    const users = await this.getBy("email", email);
+    return users.length > 0 ? users[0] : null;
+  }
+
+  async createUser(data: { name: string; email: string; password: string }) {
+    const existing = await this.getUserByEmail(data.email);
+    if (existing) {
+      throw new Error("A user with this email already exists");
+    }
+    return this.insert(data);
+  }
+}
+
+export function getUserModel() {
+  return GetModel(UserModel);
+}
+
+export { UserModel };
+```
+
+The `BasicDataModel` function provides `get`, `getBy`, `getAll`, `insert`, `update`, and `delete` methods automatically. Model instances require a database connection, so use `GetModel(YourModel)` to obtain a properly initialized instance. The custom methods add application-specific logic on top.
+
+#### Create the Task model
+
+The Task model adds a method to retrieve all tasks belonging to a specific user. The task endpoints use this method to scope results to the authenticated user.
+
+```typescript [src/db/models/task-model.ts]
+import { BasicDataModel, GetModel } from "@antelopejs/interface-database-decorators";
+import { Task } from "../tables/task";
+
+class TaskModel extends BasicDataModel(Task) {
+  async getTasksByUserId(userId: string) {
+    return this.getBy("userId", userId);
+  }
+}
+
+export function getTaskModel() {
+  return GetModel(TaskModel);
+}
+
+export { TaskModel };
+```
+
+#### Build the authentication routes
+
+The auth controller handles user registration, login, and profile retrieval. Registration creates a new user, login validates credentials and returns a signed token, and the profile endpoint demonstrates the `@Authentication` decorator.
+
+```typescript [src/routes/auth.ts]
+import { Controller, Get, Post, JSONBody, HTTPResult } from "@antelopejs/interface-api";
+import { SignRaw, Authentication } from "@antelopejs/interface-auth";
+import { getUserModel } from "../db/models/user-model";
+
+class AuthController extends Controller("/api/auth") {
+  @Post("register")
+  async register(@JSONBody() body: { name: string; email: string; password: string }) {
+    const userModel = getUserModel();
+    try {
+      const inserted = await userModel.createUser(body);
+      const userId = inserted[0];
+      const token = await SignRaw(
+        { userId, email: body.email },
+        { expiresIn: "24h" }
+      );
+      return { token, user: { id: userId, name: body.name, email: body.email } };
+    } catch (error: any) {
+      return new HTTPResult(400, { error: error.message });
+    }
+  }
+
+  @Post("login")
+  async login(@JSONBody() body: { email: string; password: string }) {
+    const userModel = getUserModel();
+    const user = await userModel.getUserByEmail(body.email);
+    if (!user || !user.testHash("password", body.password)) {
+      return new HTTPResult(401, { error: "Invalid credentials" });
+    }
+
+    const token = await SignRaw(
+      { userId: user._id, email: user.email },
+      { expiresIn: "24h" }
+    );
+
+    return { token };
+  }
+
+  @Get("profile")
+  async profile(@Authentication() auth: any) {
+    const userModel = getUserModel();
+    const user = await userModel.get(auth.userId);
+    if (!user) {
+      return new HTTPResult(404, { error: "User not found" });
+    }
+    return { id: user._id, name: user.name, email: user.email };
+  }
+}
+```
+
+The `register` endpoint creates a user and returns a token so the client can start making authenticated requests. The `login` endpoint resolves the user by email, then verifies the plaintext password against the stored hash with `testHash`. The `profile` endpoint uses `@Authentication` to ensure only authenticated users can access it.
+
+::tip
+The `@Hashed` modifier on the User table handles password hashing transparently on insert: the original plaintext password never reaches the database. The `HashModifier` mixin also adds a `testHash(field, value)` method to the table class so you can compare a plaintext value against the stored hash during login.
+::
+
+#### Create the Task Data API
+
+The Data API generates CRUD endpoints for the Task table with a single class definition. Decorating the class with `@Authentication()` registers an auth check as a computed property on the controller, so every generated route rejects unauthenticated requests before the handler runs.
+
+```typescript [src/data-api/tasks.ts]
+import { DataController, RegisterDataController, DefaultRoutes } from "@antelopejs/interface-data-api";
+import { Controller } from "@antelopejs/interface-api";
+import { Authentication } from "@antelopejs/interface-auth";
+import { Task } from "../db/tables/task";
+
+@RegisterDataController()
+@Authentication()
+class TaskDataController extends DataController(
+  Task,
+  DefaultRoutes.All,
+  Controller("/api/tasks")
+) {}
+```
+
+The Data API definition replaces dozens of lines of manual route handlers. The framework reads the Task table's schema and generates endpoints that accept and return data matching the table structure.
+
+#### Write the entry point
+
+The module entry point ties everything together. The `construct` function initializes the database schema and registers interface implementations. The `start` function begins listening for HTTP requests. Importing the route and data-api files ensures they are registered with the framework.
+
+```typescript [src/index.ts]
+import { RegisterSchema } from "@antelopejs/interface-database-decorators";
+
+// Import tables to register them
+import "./db/tables/user";
+import "./db/tables/task";
+
+// Import routes and data controllers to register them
+import "./routes/auth";
+import "./data-api/tasks";
+
+export async function construct(): Promise<void> {
+  // Register the database schema
+  await RegisterSchema("main");
+}
+
+export function start(): void {
+  // Application is ready
+}
+
+export async function stop(): Promise<void> {
+  // Gracefully stop operations
+}
+
+export async function destroy(): Promise<void> {
+  // Clean up resources
+}
+```
+
+The import statements at the top ensure that all `@RegisterTable`, `Controller`, and `@RegisterDataController()` declarations execute and register their targets with the framework. The `RegisterSchema("main")` call initializes the database schema that both tables reference. This module consumes interfaces from other modules but does not export any of its own, so there is no `ImplementInterface` call.
+
+#### Configure the project
+
+The `antelope.config.ts` file defines the project structure and module configuration. It tells the AntelopeJS core where to find your module and any implementation modules for the interfaces you depend on.
+
+```typescript [antelope.config.ts]
+import { defineConfig } from "@antelopejs/interface-core/config";
+
+export default defineConfig({
+  name: "task-manager",
+  modules: {
+    "my-app": {
+      source: { type: "local", path: "./" },
+    },
+  },
+});
+```
+
+::important
+You also need implementation modules for the interfaces your application uses (API server, database driver, auth provider). Add them to the `modules` section based on the implementations available for your stack.
+::
+
+#### Run the application
+
+Start the development server with the AntelopeJS CLI:
+
+```bash
+ajs project dev
+```
+
+The core loads the module, initializes the database schema, registers all controllers, and starts the HTTP server. For automatic reloading during development, add the `--watch` flag:
+
+```bash
+ajs project dev --watch
+```
+
+::
+
+## API Summary
+
+The completed application exposes the following endpoints:
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| `POST` | `/api/auth/register` | No | Create a new user account |
+| `POST` | `/api/auth/login` | No | Authenticate and receive a token |
+| `GET` | `/api/auth/profile` | Yes | Retrieve the authenticated user's profile |
+| `GET` | `/api/tasks/list` | Yes | List all tasks |
+| `GET` | `/api/tasks/get?id=<id>` | Yes | Get a single task |
+| `POST` | `/api/tasks/new` | Yes | Create a new task |
+| `PUT` | `/api/tasks/edit?id=<id>` | Yes | Update an existing task |
+| `DELETE` | `/api/tasks/delete?id=<id>` | Yes | Delete a task |
+
+Authenticated endpoints require a valid JWT token in the `x-antelopejs-auth` header:
+
+```
+x-antelopejs-auth: <token>
+```

--- a/docs/4.guides/6.troubleshooting.md
+++ b/docs/4.guides/6.troubleshooting.md
@@ -1,0 +1,62 @@
+---
+title: Troubleshooting
+description: Common errors and their solutions when working with AntelopeJS.
+navigation:
+  icon: i-ph-wrench
+---
+
+This page covers the most common errors you may encounter when developing with AntelopeJS, along with their causes and solutions.
+
+### Interface not implemented
+
+::note
+This error occurs in test mode when using stubs. The test runner uses stub mode by default, which rejects calls to interfaces that have no registered implementation.
+::
+
+Your test calls an interface function, but no module provides that interface in the test environment. Stub mode raises this error immediately rather than hanging on an unresolved proxy.
+
+::tip
+Provide a mock implementation for the interface in your test setup, or use the `implement` option in your test configuration to wire a real or partial implementation.
+::
+
+### Module failed to construct
+
+::note
+The `construct()` function threw an error during the module's initialization phase. Common causes include missing configuration values, unavailable external dependencies, or invalid setup logic.
+::
+
+The core stops the boot sequence when a module fails to construct, because subsequent modules may depend on the interfaces it provides. The error message includes the module ID and the original exception.
+
+::tip
+Check your module's `construct()` function and verify the configuration passed via `antelope.config.ts`. Make sure all required configuration keys are present and that external services (databases, APIs) are reachable before attempting to connect.
+::
+
+### Module failed to start
+
+::note
+The `start()` function threw an error. Since `start()` runs after all modules have been constructed and bindings are resolved, this typically indicates a runtime issue rather than a configuration problem.
+::
+
+The error propagates immediately and prevents subsequent modules from starting. Any modules that depend on interfaces provided by the failed module will not receive those interfaces.
+
+::tip
+Ensure external services your module depends on are available at start time. If a service may be temporarily unavailable, handle the error internally with try/catch and implement a retry strategy or graceful degradation.
+::
+
+### Unresolved interface dependencies
+
+::note
+The core validates the interface dependency graph before constructing modules. If a required interface has no provider in the current configuration, the boot fails with this error.
+::
+
+This error means a module declares that it consumes an interface, but no loaded module implements that interface. The core detects this before any `construct()` call, so the application never partially starts.
+
+::tip
+Verify that all required modules are listed in `antelope.config.ts` and that each one implements the expected interfaces. Check for typos in interface package names and ensure the implementing module's `package.json` includes the correct `implements` entry.
+::
+
+## See also
+
+- [Architecture](/docs/get-started/architecture) — How the core handles errors during lifecycle phases
+- [Testing](/docs/module-development/testing) — Test configuration and stub mode
+- [Configuration](/docs/concepts/configuration) — Module configuration reference

--- a/docs/4.guides/index.md
+++ b/docs/4.guides/index.md
@@ -1,0 +1,30 @@
+---
+title: Guides
+navigation: false
+---
+
+::card-group
+::card{icon="i-ph-arrows-split" title="API Routing" to="/docs/guides/api-routing"}
+Build HTTP APIs with controllers, route decorators, parameter extraction, and structured responses.
+::
+
+::card{icon="i-ph-database" title="Database" to="/docs/guides/database"}
+Define tables, apply modifiers for hashing and encryption, and perform CRUD operations with data models.
+::
+
+::card{icon="i-ph-lock-key" title="Authentication" to="/docs/guides/authentication"}
+Sign and validate JWT tokens, protect routes with authentication decorators, and manage server-side cookies.
+::
+
+::card{icon="i-ph-plug" title="Data API" to="/docs/guides/data-api"}
+Generate automatic CRUD endpoints from database tables with customizable routes and middleware.
+::
+
+::card{icon="i-ph-rocket" title="Full-Stack Application" to="/docs/guides/full-stack-tutorial"}
+Build a complete task management API from scratch using database, authentication, and data API interfaces.
+::
+
+::card{icon="i-ph-wrench" title="Troubleshooting" to="/docs/guides/troubleshooting"}
+Common errors and their solutions when working with AntelopeJS modules and interfaces.
+::
+::

--- a/docs/5.cli/.navigation.yml
+++ b/docs/5.cli/.navigation.yml
@@ -1,0 +1,2 @@
+title: CLI Reference
+icon: i-ph-terminal

--- a/docs/5.cli/1.introduction.md
+++ b/docs/5.cli/1.introduction.md
@@ -1,0 +1,96 @@
+---
+title: Introduction
+description: Overview of the AntelopeJS CLI — installation, command structure, global options, and configuration storage.
+navigation:
+  icon: i-ph-terminal
+---
+
+## Overview
+
+The AntelopeJS CLI (`ajs`) provides a single command-line interface for every stage of the development lifecycle. You use it to create projects, manage modules, run development servers, produce build artifacts, and configure global settings.
+
+## Installation
+
+Install the CLI globally with your preferred package manager:
+
+:::code-group
+
+```bash [npm]
+npm install -g @antelopejs/core
+```
+
+```bash [yarn]
+yarn global add @antelopejs/core
+```
+
+```bash [pnpm]
+pnpm add -g @antelopejs/core
+```
+
+:::
+
+After installation, the `ajs` command is available in your terminal. Verify it works by checking the version:
+
+```bash
+ajs --version
+```
+
+## Command Structure
+
+Every CLI invocation follows the same pattern:
+
+```bash
+ajs <command> <subcommand> [arguments] [options]
+```
+
+The CLI organizes its functionality into three top-level commands:
+
+| Command   | Description                                                        |
+|-----------|--------------------------------------------------------------------|
+| `project` | Project management — init, dev, build, start, modules, logging     |
+| `module`  | Module development — scaffold from templates, run tests            |
+| `config`  | CLI configuration — view and set global settings                   |
+
+Each top-level command contains subcommands that perform specific tasks. For example, `ajs project dev` starts the development server, while `ajs project modules add` installs new modules.
+
+## Global Options
+
+These options apply to any command:
+
+| Option                 | Description                                              |
+|------------------------|----------------------------------------------------------|
+| `-v, --version`        | Display the CLI version number                           |
+| `--verbose [=channels]`| Enable verbose (TRACE level) logging                     |
+| `--help`               | Show help for the current command                        |
+
+By default `--verbose` enables TRACE-level logging for all channels. To scope it to specific channels, pass a comma-separated list, for example `--verbose=cli.command,resolution`.
+
+## Getting Help
+
+Every command and subcommand supports the `--help` flag. Use this flag to see available subcommands, arguments, and options:
+
+```bash
+# Top-level help
+ajs --help
+
+# Help for project commands
+ajs project --help
+
+# Help for a specific subcommand
+ajs project dev --help
+```
+
+::tip
+When you are unsure about a command's syntax, append `--help` to see a usage summary directly in the terminal.
+::
+
+## Configuration Storage
+
+The CLI stores global settings in a JSON file at a platform-specific location:
+
+| Platform      | Path                                        |
+|---------------|---------------------------------------------|
+| Linux / macOS | `~/.antelopejs/config.json`                 |
+| Windows       | `%USERPROFILE%\.antelopejs\config.json`      |
+
+This file holds values such as the default interface repository URL. You manage it through the `ajs config` commands rather than editing it by hand. See the [Configuration](/docs/cli/config) page for details.

--- a/docs/5.cli/2.project.md
+++ b/docs/5.cli/2.project.md
@@ -1,0 +1,375 @@
+---
+title: Project Commands
+description: Complete reference for AntelopeJS project commands — lifecycle management, module operations, and logging configuration.
+navigation:
+  icon: i-ph-folder-open
+---
+
+## Overview
+
+The `ajs project` command group covers the full project lifecycle. This group handles project creation, development, production builds, module management, and logging configuration.
+
+## Project Lifecycle
+
+### `ajs project init`
+
+Create a new AntelopeJS project with an interactive wizard that sets up the configuration file and project structure.
+
+```bash
+ajs project init <project>
+```
+
+| Argument    | Description                                  |
+|-------------|----------------------------------------------|
+| `project`   | Name of the project directory to create      |
+
+The wizard walks you through selecting modules, configuring environments, and generating the `antelope.config.ts` file. Once complete, your project is ready for development with `ajs project dev`.
+
+**Example:**
+
+```bash
+ajs project init my-app
+```
+
+---
+
+### `ajs project dev`
+
+Start the project in development mode. The core resolves modules, installs dependencies, and launches the runtime.
+
+```bash
+ajs project dev [options]
+```
+
+| Option                     | Description                                    |
+|----------------------------|------------------------------------------------|
+| `-p, --project <path>`    | Path to the project folder                     |
+| `-e, --env <environment>` | Environment name to load                       |
+| `-w, --watch`             | Enable file watching and Hot Module Reloading (HMR) |
+| `-c, --concurrency <number>` | Number of modules to load in parallel       |
+| `--inspect [host:port]`   | Enable the Node.js debugger                    |
+| `-i, --interactive`       | Enable REPL mode for live interaction          |
+| `--verbose [=channels]`   | Enable verbose (TRACE level) logging; pass a comma-separated channel list to scope it |
+
+**Examples:**
+
+```bash
+# Start with HMR
+ajs project dev --watch
+
+# Specify project path and environment
+ajs project dev -p ./my-app -e staging
+
+# Enable the Node.js debugger
+ajs project dev --inspect 0.0.0.0:9229
+
+# Start in interactive REPL mode
+ajs project dev -i
+```
+
+::tip
+Use `ajs project dev --watch` during development for automatic HMR when source files change.
+::
+
+---
+
+### `ajs project run`
+
+An alias for `ajs project dev`. This command accepts all the same options and behaves identically.
+
+```bash
+ajs project run [options]
+```
+
+---
+
+### `ajs project build`
+
+Produce build artifacts for production deployment. The command resolves modules, bundles configuration, and writes a manifest to `.antelope/build/build.json`.
+
+```bash
+ajs project build [options]
+```
+
+| Option                     | Description                                    |
+|----------------------------|------------------------------------------------|
+| `-p, --project <path>`    | Path to the project folder                     |
+| `-e, --env <environment>` | Environment name to build for                  |
+| `--verbose [=channels]`   | Enable verbose (TRACE level) logging; pass a comma-separated channel list to scope it |
+
+**Example:**
+
+```bash
+ajs project build -e production
+```
+
+The generated `build.json` contains module manifests and a configuration hash. The `ajs project start` command reads this file to launch the application without repeating the resolution step.
+
+---
+
+### `ajs project start`
+
+Start the project from pre-built artifacts. This command loads the manifest from `.antelope/build/build.json` and skips module resolution, making startup faster and deterministic.
+
+```bash
+ajs project start [options]
+```
+
+| Option                        | Description                                    |
+|-------------------------------|------------------------------------------------|
+| `-p, --project <path>`       | Path to the project folder                     |
+| `-e, --env <environment>`    | Environment name                               |
+| `-c, --concurrency <number>` | Number of modules to load in parallel          |
+| `--verbose [=channels]`      | Enable verbose (TRACE level) logging; pass a comma-separated channel list to scope it |
+
+**Example:**
+
+```bash
+ajs project start -e production
+```
+
+---
+
+### Development-to-Production Workflow
+
+The lifecycle commands form a clear progression from development through deployment:
+
+1. **`ajs project dev`** — Run the project with live module resolution. Add `--watch` for HMR during active development.
+2. **`ajs project build`** — Generate an optimized build artifact (`build.json`) that locks down module versions and configuration.
+3. **`ajs project start`** — Launch from the build artifact in production. Skips resolution for faster, reproducible startup.
+
+```bash
+# Development
+ajs project dev --watch
+
+# Build for production
+ajs project build -e production
+
+# Start in production
+ajs project start -e production
+```
+
+## Module Management
+
+These subcommands manage the modules installed in a project. You can add, remove, list, update, and auto-install modules from the command line.
+
+### `ajs project modules add`
+
+Add one or more modules to the project.
+
+```bash
+ajs project modules add <modules...> [options]
+```
+
+| Argument   | Description                                      |
+|------------|--------------------------------------------------|
+| `modules`  | One or more module names or paths to add         |
+
+| Option                     | Description                                                      |
+|----------------------------|------------------------------------------------------------------|
+| `-m, --mode <mode>`       | Source type: `package` (npm), `git`, `local`, or `dir` (local-folder, no compilation). Defaults to `package`. |
+| `-p, --project <path>`    | Path to the project folder                                       |
+| `-e, --env <environment>` | Environment name                                                 |
+
+**Examples:**
+
+```bash
+# Add an npm package (the default mode)
+ajs project modules add @antelopejs/api
+
+# Add a local module by path
+ajs project modules add ./modules/auth --mode local
+
+# Add multiple npm modules at once
+ajs project modules add @antelopejs/api @antelopejs/database
+```
+
+---
+
+### `ajs project modules remove`
+
+Remove one or more modules from the project. Also available under the alias `rm`.
+
+```bash
+ajs project modules remove <modules...> [options]
+ajs project modules rm <modules...> [options]
+```
+
+| Argument   | Description                                      |
+|------------|--------------------------------------------------|
+| `modules`  | One or more module names to remove               |
+
+| Option                     | Description                                    |
+|----------------------------|------------------------------------------------|
+| `-p, --project <path>`    | Path to the project folder                     |
+| `-e, --env <environment>` | Environment name                               |
+| `-f, --force`             | Continue even if some of the named modules are not found |
+
+**Example:**
+
+```bash
+ajs project modules remove @antelopejs/api --force
+```
+
+---
+
+### `ajs project modules list`
+
+List all modules installed in the project. Also available under the alias `ls`.
+
+```bash
+ajs project modules list [options]
+ajs project modules ls [options]
+```
+
+| Option                     | Description                                    |
+|----------------------------|------------------------------------------------|
+| `-p, --project <path>`    | Path to the project folder                     |
+| `-e, --env <environment>` | Environment name                               |
+
+**Example:**
+
+```bash
+ajs project modules list
+```
+
+---
+
+### `ajs project modules update`
+
+Update npm modules to their latest versions. When called without arguments, all npm modules are updated. Pass specific module names to update only those.
+
+```bash
+ajs project modules update [modules...] [options]
+```
+
+| Argument   | Description                                      |
+|------------|--------------------------------------------------|
+| `modules`  | Optional list of module names to update          |
+
+| Option                     | Description                                    |
+|----------------------------|------------------------------------------------|
+| `-p, --project <path>`    | Path to the project folder                     |
+| `-e, --env <environment>` | Environment name                               |
+| `--dry-run`               | Show what would be updated without applying changes |
+
+**Examples:**
+
+```bash
+# Update all npm modules
+ajs project modules update
+
+# Preview updates without applying
+ajs project modules update --dry-run
+
+# Update a specific module
+ajs project modules update @antelopejs/api
+```
+
+---
+
+### `ajs project modules install`
+
+Analyze the project for unresolved interface imports and install the matching modules from the interface repository. This command bridges the gap between declaring interface dependencies in code and having the correct modules available at runtime.
+
+```bash
+ajs project modules install [options]
+```
+
+| Option                     | Description                                             |
+|----------------------------|---------------------------------------------------------|
+| `-p, --project <path>`    | Path to the project folder                              |
+| `-e, --env <environment>` | Environment name                                        |
+| `-g, --git <url>`         | Custom interface repository URL                         |
+
+**Example:**
+
+```bash
+ajs project modules install
+```
+
+::note
+The `install` subcommand scans your modules for interface imports that no installed module satisfies. The subcommand then queries the interface repository to find and install compatible modules automatically.
+::
+
+## Logging Configuration
+
+These subcommands control the project's logging behavior. You can view the current configuration and adjust settings such as log level, format, and module filters.
+
+### `ajs project logging show`
+
+Display the current logging configuration. Also available under the alias `ls`.
+
+```bash
+ajs project logging show [options]
+ajs project logging ls [options]
+```
+
+| Option                     | Description                                    |
+|----------------------------|------------------------------------------------|
+| `-p, --project <path>`    | Path to the project folder                     |
+| `-e, --env <environment>` | Environment name                               |
+| `-j, --json`              | Output configuration in JSON format            |
+
+**Example:**
+
+```bash
+ajs project logging show --json
+```
+
+---
+
+### `ajs project logging set`
+
+Configure logging settings for the project. You can toggle logging, control module tracking, filter which modules produce log output, and customize the log format.
+
+```bash
+ajs project logging set [options]
+```
+
+| Option                            | Description                                         |
+|-----------------------------------|-----------------------------------------------------|
+| `--enable`                        | Enable logging                                      |
+| `--disable`                       | Disable logging                                     |
+| `--enableModuleTracking`          | Enable module tracking in log output                |
+| `--disableModuleTracking`         | Disable module tracking in log output               |
+| `--includeModule <module>`        | Add a module to the inclusion filter                 |
+| `--excludeModule <module>`        | Add a module to the exclusion filter                 |
+| `--removeInclude <module>`        | Remove a module from the inclusion filter            |
+| `--removeExclude <module>`        | Remove a module from the exclusion filter            |
+| `--level <level>`                 | Set log level: `trace`, `debug`, `info`, `warn`, `error`, `default` |
+| `--format <format>`               | Set the log format template                         |
+| `--dateFormat <format>`           | Set the date format string                          |
+| `-i, --interactive`               | Configure logging interactively                     |
+| `-p, --project <path>`            | Path to the project folder                          |
+| `-e, --env <environment>`         | Environment name                                    |
+
+**Examples:**
+
+```bash
+# Enable logging at debug level
+ajs project logging set --enable --level debug
+
+# Only show logs from a specific module
+ajs project logging set --includeModule @antelopejs/api
+
+# Customize the log format for the INFO level
+ajs project logging set --level info --format "{{chalk.gray}}[{{DATE}}]{{chalk.reset}} {{ARGS}}"
+
+# Use interactive mode to configure all options
+ajs project logging set -i
+```
+
+The `--level` flag selects which level's template the `--format` string applies to (`trace`, `debug`, `info`, `warn`, `error`, or `default` for the fallback). The template accepts these placeholders:
+
+| Placeholder            | Description                                     |
+|------------------------|-------------------------------------------------|
+| `{{DATE}}`             | Timestamp formatted according to `--dateFormat` |
+| `{{ARGS}}`             | The log message content                         |
+| `{{CHANNEL}}`          | Channel name                                    |
+| `{{MODULE}}`           | Originating module ID (when module tracking is on) |
+| `{{chalk.<color>}}`    | Inline chalk directive (e.g., `{{chalk.red}}`, `{{chalk.bold}}`) — stripped when the output is redirected to a non-TTY |
+
+::tip
+Use `ajs project logging set -i` for an interactive guided experience when configuring multiple logging options at once.
+::

--- a/docs/5.cli/3.module.md
+++ b/docs/5.cli/3.module.md
@@ -1,0 +1,83 @@
+---
+title: Module Commands
+description: Reference for AntelopeJS module commands — scaffold new modules and run test suites.
+navigation:
+  icon: i-ph-puzzle-piece
+---
+
+## Overview
+
+The `ajs module` command group provides tools for module development. You use these commands to scaffold new modules from templates and to run module tests.
+
+## `ajs module init`
+
+Create a new module from a template. The command clones a template repository into the specified path and prepares the module structure for development.
+
+```bash
+ajs module init <path> [options]
+```
+
+| Argument | Description                                    |
+|----------|------------------------------------------------|
+| `path`   | Directory path where the module will be created |
+
+| Option              | Description                              |
+|---------------------|------------------------------------------|
+| `-g, --git <url>`  | URL of a custom template repository      |
+
+**Examples:**
+
+```bash
+# Create a module in the modules directory
+ajs module init ./modules/my-module
+
+# Use a custom template repository
+ajs module init ./modules/my-module --git https://github.com/your-org/module-template.git
+```
+
+The generated module includes the standard AntelopeJS module structure with source files, configuration, and test scaffolding. After initialization, add the module to your project with `ajs project modules add`.
+
+```bash
+ajs module init ./modules/auth
+ajs project modules add ./modules/auth --mode local
+```
+
+::tip
+Keep your modules in a `modules/` directory within the project for a clean file structure. Use `--mode local` when adding them to the project configuration.
+::
+
+## `ajs module test`
+
+Run the test suite for a module. When no path is provided, the command runs tests for the module in the current directory.
+
+```bash
+ajs module test [path] [options]
+```
+
+| Argument | Description                                           |
+|----------|-------------------------------------------------------|
+| `path`   | Path to the module directory (defaults to current dir) |
+
+| Option                  | Description                                        |
+|-------------------------|----------------------------------------------------|
+| `-f, --file <path>`    | Specific test file to run (can be repeated)        |
+
+**Examples:**
+
+```bash
+# Run all tests for a module
+ajs module test ./modules/my-module
+
+# Run tests in the current directory
+ajs module test
+
+# Run a specific test file
+ajs module test ./modules/my-module -f tests/auth.test.ts
+
+# Run multiple specific test files
+ajs module test ./modules/my-module -f tests/auth.test.ts -f tests/session.test.ts
+```
+
+::note
+The `-f` flag can be specified multiple times to run a subset of test files. When omitted, the command discovers and runs all test files in the module.
+::

--- a/docs/5.cli/4.config.md
+++ b/docs/5.cli/4.config.md
@@ -1,0 +1,110 @@
+---
+title: Configuration
+description: Reference for AntelopeJS CLI configuration commands — view, set, and reset global settings.
+navigation:
+  icon: i-ph-gear
+---
+
+## Overview
+
+The `ajs config` command group manages global CLI settings. These settings persist across all projects and are stored in a platform-specific configuration file.
+
+### Configuration File Location
+
+| Platform      | Path                                        |
+|---------------|---------------------------------------------|
+| Linux / macOS | `~/.antelopejs/config.json`                 |
+| Windows       | `%USERPROFILE%\.antelopejs\config.json`      |
+
+::note
+Use the `ajs config` commands to manage this file. Editing the file by hand is possible but not recommended.
+::
+
+## Configuration Keys
+
+The CLI currently supports one configuration key:
+
+| Key   | Description                                                    | Default |
+|-------|----------------------------------------------------------------|---------|
+| `git` | URL of the interface repository used by `modules install`      | AntelopeJS default repository |
+
+The `git` key controls which repository the CLI queries when running `ajs project modules install` to resolve unresolved interface imports. Changing this value lets you point the CLI at a private or organization-specific interface repository.
+
+## `ajs config show`
+
+Display all current CLI settings.
+
+```bash
+ajs config show
+```
+
+This command prints every stored key-value pair. The output is useful for confirming the active configuration before running other commands.
+
+## `ajs config get`
+
+Retrieve the value of a specific configuration key.
+
+```bash
+ajs config get <key>
+```
+
+| Argument | Description                                    |
+|----------|------------------------------------------------|
+| `key`    | The configuration key to read (e.g., `git`)    |
+
+**Example:**
+
+```bash
+ajs config get git
+```
+
+## `ajs config set`
+
+Set a configuration key to a new value.
+
+```bash
+ajs config set <key> <value>
+```
+
+| Argument | Description                                    |
+|----------|------------------------------------------------|
+| `key`    | The configuration key to update                |
+| `value`  | The new value to assign                        |
+
+**Example:**
+
+```bash
+ajs config set git https://github.com/your-org/interfaces.git
+```
+
+After running this command, the CLI uses the specified repository URL whenever `ajs project modules install` needs to resolve interface dependencies. The new value persists in the configuration file until changed or reset.
+
+## `ajs config reset`
+
+Reset all CLI settings to their default values.
+
+```bash
+ajs config reset [options]
+```
+
+| Option          | Description                                    |
+|-----------------|------------------------------------------------|
+| `-y, --yes`    | Skip the confirmation prompt                   |
+
+**Examples:**
+
+```bash
+# Reset with confirmation prompt
+ajs config reset
+
+# Reset without confirmation
+ajs config reset --yes
+```
+
+::caution
+Resetting the configuration removes all custom settings. Any custom interface repository URL reverts to the default AntelopeJS repository.
+::
+
+## See also
+
+- [Configuration](/docs/concepts/configuration) — Configuration file reference and options

--- a/docs/5.cli/5.cheat-sheet.md
+++ b/docs/5.cli/5.cheat-sheet.md
@@ -1,0 +1,137 @@
+---
+title: Cheat Sheet
+description: Quick reference for every AntelopeJS CLI command, option, and common workflow.
+navigation:
+  icon: i-ph-lightning
+---
+
+## Installation
+
+| Package Manager | Command                            |
+|-----------------|------------------------------------|
+| npm             | `npm install -g @antelopejs/core`  |
+| yarn            | `yarn global add @antelopejs/core` |
+| pnpm            | `pnpm add -g @antelopejs/core`     |
+
+## Project Commands
+
+| Command                                    | Description                                      |
+|--------------------------------------------|--------------------------------------------------|
+| `ajs project init <project>`               | Create a new project with the interactive wizard  |
+| `ajs project dev [options]`                | Run the project in development mode               |
+| `ajs project run [options]`                | Alias for `ajs project dev`                       |
+| `ajs project build [options]`              | Build production artifacts (`build.json`)         |
+| `ajs project start [options]`              | Start from pre-built artifacts                    |
+| `ajs project modules add <modules...>`     | Add one or more modules                           |
+| `ajs project modules remove <modules...>`  | Remove modules (alias: `rm`)                      |
+| `ajs project modules list`                 | List installed modules (alias: `ls`)              |
+| `ajs project modules update [modules...]`  | Update npm modules to latest versions             |
+| `ajs project modules install`              | Auto-install modules for unresolved interfaces    |
+| `ajs project logging show`                 | Display logging configuration (alias: `ls`)       |
+| `ajs project logging set`                  | Configure logging settings                        |
+
+## Module Commands
+
+| Command                      | Description                                    |
+|------------------------------|------------------------------------------------|
+| `ajs module init <path>`     | Scaffold a new module from a template          |
+| `ajs module test [path]`     | Run the test suite for a module                |
+
+## Config Commands
+
+| Command                         | Description                              |
+|---------------------------------|------------------------------------------|
+| `ajs config show`              | Display all CLI settings                 |
+| `ajs config get <key>`         | Get a specific setting value             |
+| `ajs config set <key> <value>` | Set a configuration value                |
+| `ajs config reset`             | Reset all settings to defaults           |
+
+## General Options
+
+| Option        | Description                                          |
+|---------------|------------------------------------------------------|
+| `--help`      | Show help for any command                            |
+| `-v, --version` | Display the CLI version                           |
+| `--verbose [=channels]` | Enable verbose (TRACE level) logging; scope to a comma-separated channel list |
+
+## Common Dev Options
+
+These options are shared across `ajs project dev`, `ajs project run`, `ajs project build`, and `ajs project start`:
+
+| Option                        | Available In            | Description                          |
+|-------------------------------|-------------------------|--------------------------------------|
+| `-p, --project <path>`       | dev, build, start       | Path to the project folder           |
+| `-e, --env <environment>`    | dev, build, start       | Environment name                     |
+| `-c, --concurrency <number>` | dev, start              | Number of parallel module loads      |
+| `-w, --watch`                | dev                     | Enable Hot Module Reloading (HMR)    |
+| `--inspect [host:port]`      | dev                     | Enable the Node.js debugger          |
+| `-i, --interactive`          | dev                     | Enable REPL mode                     |
+
+## Quick Workflows
+
+### New Project
+
+Scaffold a project and start developing with HMR:
+
+```bash
+ajs project init my-project
+cd my-project
+ajs project dev --watch
+```
+
+### Build and Deploy
+
+Generate production artifacts and start the application:
+
+```bash
+ajs project build -e production
+ajs project start -e production
+```
+
+### Add Modules
+
+Install modules from npm, local paths, or auto-detect from interface imports:
+
+```bash
+# Add from npm (default mode)
+ajs project modules add @antelopejs/api
+
+# Add a local module
+ajs project modules add ./modules/auth --mode local
+
+# Auto-install from interface imports
+ajs project modules install
+```
+
+### Create and Test a Module
+
+Scaffold a module from a template and run its test suite:
+
+```bash
+ajs module init ./modules/my-module
+ajs module test ./modules/my-module
+```
+
+### Update Modules
+
+Check for available updates and apply them:
+
+```bash
+# Preview updates
+ajs project modules update --dry-run
+
+# Apply updates
+ajs project modules update
+```
+
+### Configure Logging
+
+Enable logging and inspect the current configuration:
+
+```bash
+# Enable debug-level logging
+ajs project logging set --enable --level debug
+
+# Check current logging config
+ajs project logging show --json
+```

--- a/docs/5.cli/index.md
+++ b/docs/5.cli/index.md
@@ -1,0 +1,26 @@
+---
+title: CLI Reference
+navigation: false
+---
+
+::card-group
+::card{icon="i-ph-terminal" title="Introduction" to="/docs/cli/introduction"}
+Overview of the AntelopeJS CLI, installation, command structure, and global options.
+::
+
+::card{icon="i-ph-folder-open" title="Project Commands" to="/docs/cli/project"}
+Manage projects with init, dev, build, start, module management, and logging configuration.
+::
+
+::card{icon="i-ph-puzzle-piece" title="Module Commands" to="/docs/cli/module"}
+Scaffold new modules from templates and run module test suites.
+::
+
+::card{icon="i-ph-gear" title="Configuration" to="/docs/cli/config"}
+View and manage global CLI settings such as the interface repository URL.
+::
+
+::card{icon="i-ph-lightning" title="Cheat Sheet" to="/docs/cli/cheat-sheet"}
+Quick reference tables for every CLI command, option, and common workflow.
+::
+::

--- a/docs/6.community/.navigation.yml
+++ b/docs/6.community/.navigation.yml
@@ -1,0 +1,2 @@
+title: Community
+icon: i-ph-users

--- a/docs/6.community/1.getting-help.md
+++ b/docs/6.community/1.getting-help.md
@@ -1,0 +1,129 @@
+---
+title: Getting Help
+description: Need help with Antelopejs? Here's where to ask questions and how to get the best answers fast.
+navigation:
+  icon: i-ph-question
+---
+
+## Getting Support
+
+Stuck on something? No worries - there are plenty of ways to get help with Antelopejs. This guide will show you where to ask questions and how to get the best answers.
+
+## Where to Get Help
+
+### GitHub Discussions
+
+The main place to ask questions is our [GitHub Discussions](https://github.com/antelopejs/antelopejs/discussions) forum. It's perfect for:
+
+- Asking detailed technical questions
+- Suggesting new features
+- Sharing what you've built
+- Talking with other developers
+
+To use it:
+
+1. Go to the [Discussions page](https://github.com/antelopejs/antelopejs/discussions)
+2. Check if someone already asked your question
+3. Click "New discussion" if you need to create a new topic
+
+::card{icon="i-simple-icons-github" title="GitHub Discussions"}
+Best for: Bigger questions, feature ideas, and conversations that need code examples.
+::
+
+### Discord Chat
+
+For quick help, join our [Discord server](https://discord.gg/yS53x6FXQj) where you can:
+
+- Chat with the developers
+- Get fast answers to simple questions
+- Join community events
+- Meet other Antelopejs users
+
+::card{icon="i-ph-discord-logo" title="Discord"}
+Best for: Quick questions, getting unstuck, and hanging out with the community.
+::
+
+### Other Places
+
+- **Stack Overflow**: Tag your question with `antelopejs` on [Stack Overflow](https://stackoverflow.com/questions/tagged/antelopejs)
+- **Twitter**: Follow [@antelopejs](https://twitter.com/antelopejs) for news and updates
+
+## How to Ask Good Questions
+
+Follow these tips to get better answers, faster:
+
+### 1. Give the Full Picture
+
+Don't just say what's broken - explain:
+
+- What you're trying to build
+- How you're trying to do it
+- What you've already tried
+- Show your relevant code
+
+### 2. Do a Little Research
+
+Before asking:
+
+- Check the docs
+- Search through old discussions
+- Try debugging it yourself
+- Look at examples
+
+### 3. Share a Simple Example
+
+When showing code:
+
+- Keep it short - just the relevant parts
+- Format it properly in code blocks
+- Include the exact error messages as text
+- Tell us your versions (Node.js, Antelopejs, OS)
+
+### 4. Be Clear About the Problem
+
+Compare these:
+
+❌ "It's not working!"
+
+✅ "When I run `ajs project run`, I get this error: `Error: Cannot find module 'example'`"
+
+## Common Issues
+
+::card{icon="i-ph-wrench" title="Quick Fixes"}
+Here are solutions to problems many people run into.
+::
+
+### Module Loading Problems
+
+If your modules aren't loading:
+
+- Double-check your `antelope.config.ts` file
+- Make sure you've imported all needed interfaces
+- Check version compatibility
+- Look for path problems
+
+### Interface Issues
+
+If interfaces aren't working:
+
+- Check your folder structure follows `interfaces/[name]/`
+- Make sure you've implemented all required methods
+- Check your TypeScript types
+- Verify you've connected everything with `ImplementInterface`
+
+## Help Improve Antelopejs
+
+### Report Bugs
+
+Found a bug?
+
+1. Check if someone already reported it
+2. Create a simple test case that shows the problem
+3. Follow our [bug reporting guide](2.how-to-report-bugs.md)
+
+### Improve the Docs
+
+Spot something confusing or missing in the docs?
+
+- For small fixes: [Edit the page on GitHub](https://github.com/AntelopeJS/antelopejs.com/tree/main/content/docs)
+- For bigger changes: [Open an issue](https://github.com/antelopejs/antelopejs/issues/new) explaining what needs improvement

--- a/docs/6.community/2.how-to-report-bugs.md
+++ b/docs/6.community/2.how-to-report-bugs.md
@@ -1,0 +1,133 @@
+---
+title: How to Report Bugs
+description: Found a bug? Here's how to report it so we can fix it quickly.
+navigation:
+  icon: i-ph-bug
+---
+
+## Reporting Bugs Effectively
+
+Good bug reports help us fix problems faster. Here's how to submit one that gets results.
+
+## Before You Report
+
+### Bug or Question?
+
+First, let's figure out what you're dealing with:
+
+- **Need help using Antelopejs?** → Read [Getting help](1.getting-help.md)
+- **Found something broken?** → You're in the right place
+
+Not sure? Start a chat in [GitHub Discussions](https://github.com/antelopejs/antelopejs/discussions). If it turns out to be a bug, we can always convert it to an issue.
+
+### Check if It's Already Known
+
+Save everyone some time:
+
+1. Look through [open issues](https://github.com/antelopejs/antelopejs/issues) on GitHub
+2. Browse [discussions](https://github.com/antelopejs/antelopejs/discussions) for similar problems
+3. If someone already reported it, add your info to that thread instead
+
+::card{icon="i-ph-magnifying-glass" title="Search Tips"}
+Try using exact error messages in your search. No luck? Try different words or phrases.
+::
+
+## Creating a Great Bug Report
+
+A helpful bug report needs three things: how to recreate the problem, what happened, and details about your setup.
+
+### 1. Create a Simple Test Case
+
+The most helpful thing you can provide is a simple example that shows the bug:
+
+1. Make a fresh project with just the basics
+2. Add only the code needed to show the problem
+3. Cut out anything unrelated
+4. Write down exactly how to trigger the bug
+
+The best examples:
+
+- Focus on just one issue
+- Include minimal code
+- Are easy for us to run
+- Show the problem every time
+
+### 2. Share Your Setup
+
+Tell us about your environment:
+
+| Information          | How to Get It                        |
+| -------------------- | ------------------------------------ |
+| Antelopejs version   | Type `ajs --version`                 |
+| Node.js version      | Type `node --version`                |
+| Operating system     | What OS and version you're using     |
+| Package manager      | npm, yarn, or pnpm (with version)    |
+| Related dependencies | The important ones from package.json |
+
+### 3. Tell Us What Happened
+
+Clearly explain:
+
+- What you were trying to do
+- What you thought would happen
+- What actually happened instead
+- The exact error messages (text, not screenshots)
+- Steps to make it happen again
+
+## Submitting Your Report
+
+Once you've got everything ready:
+
+1. Head to [Antelopejs issues](https://github.com/antelopejs/antelopejs/issues)
+2. Click "New Issue"
+3. Pick the "Bug Report" template
+4. Fill in all the sections with your info
+5. Include your test case or link to a repo
+6. Add screenshots only if they really help explain the issue
+
+::card{icon="i-ph-clipboard-text" title="Report Template"}
+
+```markdown
+**What's wrong?**
+A simple description of the problem.
+
+**How to see it**
+Steps to make it happen:
+
+1. Set up a project with '...'
+2. Add this code '...'
+3. Run this command '...'
+4. See this error
+
+**What I expected**
+What should have happened instead.
+
+**My setup**
+
+- Antelopejs: v1.0.0
+- Node.js: v16.14.0
+- OS: Ubuntu 20.04
+- Using: npm 8.3.0
+
+**More info**
+Anything else that might help.
+```
+
+::
+
+## After You Report
+
+After you submit:
+
+- **Stay available** for questions we might have
+- **Keep an eye on the issue** as we look into it
+- **Try out fixes** when we release them
+- **Be patient** as we work through all reported issues
+
+## Security Issues
+
+Found a security problem? That's different:
+
+::caution{icon="i-ph-lock-key"}
+**Don't post security bugs publicly.** Instead, follow our [security policy](https://github.com/antelopejs/antelopejs/security/policy) to report them privately.
+::

--- a/docs/6.community/3.contribution.md
+++ b/docs/6.community/3.contribution.md
@@ -1,0 +1,203 @@
+---
+title: Contributing to Antelopejs
+description: Learn how to contribute to the Antelopejs ecosystem through code, documentation, and community participation.
+navigation:
+  icon: i-ph-git-pull-request
+---
+
+## Contributing Guide
+
+This guide will help you contribute to Antelopejs, whether you're a developer, writer, or community member.
+
+## Ecosystem Overview
+
+The Antelopejs ecosystem consists of two main repository groups:
+
+| Organization                                | Purpose                             |
+| ------------------------------------------- | ----------------------------------- |
+| [antelopejs](https://github.com/antelopejs) | Core framework and official modules |
+
+## Ways to Contribute
+
+### Community Support
+
+- Answer questions in [GitHub Discussions](https://github.com/antelopejs/antelopejs/discussions)
+- Help with issue triage by reproducing reported bugs
+- Share your solutions to common problems
+- Provide feedback on new features and proposals
+
+### Reporting Issues
+
+Before creating a new issue:
+
+1. For bugs, follow our [bug reporting guide](2.how-to-report-bugs.md)
+2. For feature requests, check existing issues and discussions
+3. Submit module-specific ideas to the relevant repository
+4. For broader ideas, start a discussion in the Ideas section
+
+### Documentation Improvements
+
+Documentation is critical for user success:
+
+- Fix typos or clarify existing content
+- Add missing examples or code samples
+- Improve organization or navigation
+- Translate documentation to other languages
+
+## Pull Request Process
+
+### Before Starting
+
+1. **Bug fixes**: Check if there's an existing issue
+2. **Features**: Open a discussion first to align with project goals
+3. **Documentation**: For typo fixes, consider combining multiple corrections
+
+### Development Workflow
+
+1. Fork the repository to your GitHub account
+2. Clone your fork to your local machine
+3. Create a feature branch with a descriptive name
+4. Make changes following the code standards
+5. Write tests for new features or bug fixes
+6. Ensure all tests pass locally
+7. Submit your pull request
+
+### Commit Guidelines
+
+We follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+Common types include:
+
+- `feat`: (new feature for the user, not a new feature for build script)
+- `fix`: (bug fix for the user, not a fix to a build script)
+- `docs`: (changes to the documentation)
+- `style`: (formatting, missing semi colons, etc; no production code change)
+- `refactor`: (refactoring production code, no behavior changes, eg. renaming a variable)
+- `test`: (adding missing tests, refactoring tests; no production code change)
+- `chore`: (updating grunt tasks etc; no production code change)
+- `vcs`: (version control system related, eg. git)
+- `ci`: (continuous integration related, eg. github actions)
+- `build`: (build system or external dependencies changes, eg. npm, yarn, build related bash scripts)
+- `utils`: (scripts or tools around the project, eg. scripts to generate changelogs)
+
+Examples:
+
+```
+feat(api): add support for custom headers
+fix(auth): correct token validation logic
+docs(readme): update installation instructions
+```
+
+### Pull Request Guidelines
+
+- Use a clear, descriptive title following commit conventions
+- Reference related issues in the description (e.g., "Fixes #123")
+- Keep each PR focused on a single task or feature
+- Respond promptly to reviewer feedback
+
+## Decision Making Process
+
+This flowchart guides our PR review process:
+
+<Mermaid>
+flowchart TB
+  subgraph "PR Review Process"
+    direction TB
+    start([Pull Request Submitted])
+    kind{What type of change?}
+    documentation[Documentation Change]
+    feature[New Feature]
+    bugfix[Bug Fix]
+    doc_review[Review for clarity and accuracy]
+    feature_review[Assess necessity and implementation]
+    bugfix_type{Is it a straightforward fix?}
+    simple_fix[Verify fix and code quality]
+    complex_fix[Review potential side effects]
+    add_labels[Add priority labels]
+    await_input[Await maintainer input]
+    approve[Approve]
+    merge[Merge when approved by 2+ team members]
+    start --> kind
+    kind --> documentation
+    kind --> feature
+    kind --> bugfix
+    documentation --> doc_review
+    doc_review --> approve
+    feature --> feature_review
+    feature_review --> await_input
+    bugfix --> bugfix_type
+    bugfix_type -->|Yes| simple_fix
+    bugfix_type -->|No| complex_fix
+    simple_fix --> approve
+    complex_fix --> add_labels
+    add_labels --> await_input
+    await_input --> approve
+    approve --> merge
+  end
+  style start fill:#fff,stroke:#333,stroke-width:1px
+  style doc_review fill:#fff,stroke:#333,stroke-width:1px
+  style feature_review fill:#fff,stroke:#333,stroke-width:1px
+  style simple_fix fill:#fff,stroke:#333,stroke-width:1px
+  style complex_fix fill:#fff,stroke:#333,stroke-width:1px
+  style add_labels fill:#fff,stroke:#333,stroke-width:1px
+  style await_input fill:#fff,stroke:#333,stroke-width:1px
+  style kind fill:#e1f5fe,stroke:#0288d1,stroke-width:1px
+  style bugfix_type fill:#e1f5fe,stroke:#0288d1,stroke-width:1px
+  style approve fill:#e8f5e9,stroke:#388e3c,stroke-width:1px
+  style merge fill:#e8f5e9,stroke:#388e3c,stroke-width:1px
+  style documentation fill:#fff,stroke:#333,stroke-width:1px
+  style feature fill:#fff,stroke:#333,stroke-width:1px
+  style bugfix fill:#fff,stroke:#333,stroke-width:1px
+</Mermaid>
+
+## Creating Generic Interfaces
+
+If you've built something useful with Antelopejs, consider turning it into a generic interface that others can implement:
+
+### Why Create Generic Interfaces?
+
+- **Ecosystem Growth**: Generic interfaces allow multiple implementations to flourish
+- **Flexibility**: Users can switch between implementations based on their needs
+- **Collaboration**: Different developers can focus on specific implementations
+- **Standardization**: Establishes common patterns across the ecosystem
+
+### From Feature to Interface
+
+1. Identify functionality that could benefit from multiple implementations
+2. Abstract the core behavior into a clear interface definition
+3. Document the interface requirements thoroughly
+4. Create a reference implementation as a module
+
+### Interface Best Practices
+
+- Keep interfaces focused on a single responsibility
+- Design with future extensibility in mind
+- Provide detailed type definitions
+- Include example usage in documentation
+- Reference related interfaces when appropriate
+
+For detailed guidance, refer to our [Module documentation](/docs/module-development/creating-a-module) and [Exporting Interfaces](/docs/module-development/exporting-interfaces) guide.
+
+## Proposing RFCs
+
+For significant framework changes:
+
+1. Start by implementing your idea as a module when possible
+2. Open a discussion with code examples and rationale
+3. If appropriate, your proposal will be marked as an RFC
+
+RFC stages:
+
+- `rfc: active` - Open for community feedback
+- `rfc: approved` - Accepted by the core team
+- `rfc: ready to implement` - Issue created for implementation
+- `rfc: shipped` - Implemented in a release
+- `rfc: archived` - Not approved but preserved for reference

--- a/docs/6.community/4.framework.md
+++ b/docs/6.community/4.framework.md
@@ -1,0 +1,119 @@
+---
+title: Framework Development
+description: Guidelines for contributing to the Antelopejs core framework.
+navigation:
+  icon: i-ph-code-block
+---
+
+## Contributing to the Core Framework
+
+The Antelopejs core framework is open-source and welcomes contributions from everyone. This guide will help you understand how to contribute specifically to the core framework components.
+
+## Setting Up Your Environment
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) v18 or higher
+- [Git](https://git-scm.com/) for version control
+- A code editor (we recommend [Visual Studio Code](https://code.visualstudio.com/))
+
+### Development Environment Setup
+
+```bash
+# 1. Fork the repository
+# Visit https://github.com/antelopejs/antelopejs and click "Fork"
+
+# 2. Clone your fork
+git clone https://github.com/YOUR_USERNAME/antelopejs.git
+cd antelopejs
+
+# 3. Install dependencies
+npm install
+
+# 4. Create a feature branch
+git checkout -b feature/my-improvement
+```
+
+### Development Workflow
+
+#### Testing Changes
+
+We recommend a test-driven approach when developing new features or fixing bugs:
+
+1. **Write tests first** to define expected behavior
+2. **Implement your changes** to satisfy the tests
+3. **Run the test suite** to verify functionality
+
+```bash
+# Run all tests
+npm test
+
+# Run specific tests
+npm test -- -t "feature name"
+```
+
+#### Using the Playground
+
+The repository includes a playground for manual testing:
+
+1. Navigate to the `playground/` directory
+2. Make adjustments to the example application
+3. Start the development server:
+
+```bash
+npm run dev
+```
+
+4. Verify your changes work as expected and all unit tests pass
+
+#### Code Quality
+
+Maintain high code quality by following these practices:
+
+```bash
+# Check code style
+npm run lint
+
+# Fix code style issues automatically
+npm run lint:fix
+```
+
+## Core Design Principles
+
+When modifying the framework, adhere to these guiding principles:
+
+| Principle         | Description                                                               |
+| ----------------- | ------------------------------------------------------------------------- |
+| **Modularity**    | Features should be self-contained with clear boundaries                   |
+| **Compatibility** | Preserve backward compatibility unless there's a compelling reason not to |
+| **Performance**   | New features shouldn't introduce significant overhead                     |
+| **Simplicity**    | Favor straightforward solutions over complex ones                         |
+| **Testability**   | All code should be thoroughly tested                                      |
+
+## Documentation Requirements
+
+Documentation is as important as code:
+
+- **Code comments**: Add JSDoc comments to all public APIs
+- **Documentation files**: Update relevant markdown files in `docs/`
+- **Examples**: Include practical usage examples
+- **Type definitions**: Keep TypeScript definitions accurate and complete
+
+## Release Cycle
+
+Antelopejs follows a structured release process:
+
+1. **Development**: Features are built on feature branches
+2. **Review**: Pull requests undergo code review
+3. **Integration**: Approved changes are merged to main
+4. **Testing**: Comprehensive testing of integration
+5. **Release**: Publishing to npm with semantic versioning
+6. **Documentation**: Release notes and documentation updates
+
+## Getting Support
+
+If you need help with framework development:
+
+- Ask questions in [GitHub Discussions](https://github.com/antelopejs/antelopejs/discussions)
+- Join the community chat for real-time assistance
+- Review existing PRs and issues for similar work

--- a/docs/6.community/index.md
+++ b/docs/6.community/index.md
@@ -1,0 +1,23 @@
+---
+title: Community
+description: Need help with Antelopejs? Here's where to ask questions and how to get the best answers fast.
+navigation: false
+---
+
+::card-group
+::card{icon="i-ph-question" title="Getting Help" to="/docs/community/getting-help"}
+Stuck on something? Don't bang your head against the wall - we've all been there! Check out where to ask questions and get friendly help from fellow developers.
+::
+
+::card{icon="i-ph-bug" title="How to Report Bugs" to="/docs/community/how-to-report-bugs"}
+Found a bug? First of all, thanks! Knowing what's broken helps us make things better. Here's how to report issues so we can squash them quickly.
+::
+
+::card{icon="i-ph-git-pull-request" title="Contribution" to="/docs/community/contribution"}
+Ready to roll up your sleeves? Whether you're a coding wizard, docs enthusiast, or just have great ideas, there's a place for you in our community.
+::
+
+::card{icon="i-ph-code-block" title="Framework" to="/docs/community/framework"}
+Interested in contributing to the core? Learn about the development setup, design principles, and how to submit changes.
+::
+::


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds the full framework documentation under `docs/`, structured as a Nuxt Content
docs site (numbered sections with `.navigation.yml` and `index.md` landing pages).

Sections included:

- **Get Started** — introduction, installation, quick start, architecture
- **Concepts** — interfaces, modules, proxies, configuration, logging, core utilities, runtime, glossary
- **Module Development** — creating a module, exporting interfaces, testing, interface registry
- **Guides** — API routing, database, authentication, data API, full-stack tutorial, troubleshooting
- **CLI** — introduction, project, module, config, cheat sheet
- **Community** — getting help, how to report bugs, contribution, framework

43 files, ~5.5k lines total.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [ ] I have run `ajs module exports generate` and committed any updated interface files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a complete documentation site under `docs/` for the Antelopejs framework — 43 new files (~5,500 lines) covering six major sections: Get Started, Concepts, Module Development, Guides, CLI Reference, and Community. The content is thorough, technically accurate, and consistently structured as a Nuxt Content docs site with MDC components.

- **Get Started & Concepts** introduce the interface-based architecture, module lifecycle, proxy types (AsyncProxy / EventProxy / RegisteringProxy), logging, core utilities, and runtime API with well-matched code examples.
- **Module Development & Guides** walk through creating modules, exporting interfaces, testing (including contract tests), and four practical guides culminating in a full-stack task-management tutorial.
- **CLI Reference** documents every `ajs` command group with argument tables, option tables, and worked examples; the cheat sheet is a helpful companion.
- **Community** pages cover support channels, bug reporting, contribution workflow, and framework development guidelines.

<h3>Confidence Score: 4/5</h3>

The documentation is comprehensive and technically consistent; merging is safe once the broken internal link in the community section is corrected.

One broken relative link in docs/6.community/1.getting-help.md will silently 404 in the rendered site. The remaining findings are non-blocking: a hardcoded encryption key example, a Mermaid component that may need explicit registration, and a minor pattern inconsistency in the core-utilities reference. The content itself is correct and well written across all 43 files.

docs/6.community/1.getting-help.md contains the broken internal link that needs correction. docs/4.guides/2.database.md and docs/1.get-started/4.architecture.md have minor quality issues worth addressing.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/6.community/1.getting-help.md | New file: getting-help page with support channels and question tips; contains a broken relative file link (2.how-to-report-bugs.md) that won't resolve in Nuxt Content. |
| docs/4.guides/2.database.md | New file: database guide with table definitions, modifiers, and CRUD; encryption example uses a hardcoded literal key that normalizes a security anti-pattern. |
| docs/1.get-started/4.architecture.md | New file: architecture overview with Mermaid diagrams using the custom Mermaid component rather than standard fenced code blocks — portability issue flagged. |
| docs/2.concepts/6.core-utilities.md | New file: core utilities reference; InterfaceFunction example uses simplified direct-export pattern inconsistent with the internal-namespace pattern taught throughout the rest of the docs. |
| docs/4.guides/5.full-stack-tutorial.md | New file: comprehensive end-to-end tutorial building a task management API with auth, database tables, models, and Data API — well sequenced. |
| docs/3.module-development/2.exporting-interfaces.md | New file: step-by-step guide for embedded vs standalone interface packages, proxy patterns, and ImplementInterface usage — thorough. |
| docs/5.cli/2.project.md | New file: complete project command reference with lifecycle, module management, and logging subcommands — all options documented with examples. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    GS["1. Get Started\n(introduction, installation,\nquick-start, architecture)"]
    C["2. Concepts\n(interfaces, modules, proxies,\nconfiguration, logging,\ncore utilities, runtime, glossary)"]
    MD["3. Module Development\n(creating a module, exporting\ninterfaces, testing,\ninterface registry)"]
    G["4. Guides\n(API routing, database,\nauthentication, data API,\nfull-stack tutorial, troubleshooting)"]
    CLI["5. CLI Reference\n(introduction, project,\nmodule, config, cheat sheet)"]
    COM["6. Community\n(getting help, bug reports,\ncontribution, framework dev)"]

    GS --> C
    C --> MD
    MD --> G
    G --> CLI
    CLI --> COM
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    GS["1. Get Started\n(introduction, installation,\nquick-start, architecture)"]
    C["2. Concepts\n(interfaces, modules, proxies,\nconfiguration, logging,\ncore utilities, runtime, glossary)"]
    MD["3. Module Development\n(creating a module, exporting\ninterfaces, testing,\ninterface registry)"]
    G["4. Guides\n(API routing, database,\nauthentication, data API,\nfull-stack tutorial, troubleshooting)"]
    CLI["5. CLI Reference\n(introduction, project,\nmodule, config, cheat sheet)"]
    COM["6. Community\n(getting help, bug reports,\ncontribution, framework dev)"]

    GS --> C
    C --> MD
    MD --> G
    G --> CLI
    CLI --> COM
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
docs/6.community/1.getting-help.md:122
**Broken relative file link**

The link `[bug reporting guide](2.how-to-report-bugs.md)` uses a bare relative filename. In a Nuxt Content site the numeric prefix is stripped from URLs, so this renders as `/docs/community/2.how-to-report-bugs.md` or simply breaks — it will not resolve to the expected page. Use the absolute path that Nuxt Content produces for this file instead, e.g. `/docs/community/how-to-report-bugs`.

### Issue 2 of 4
docs/4.guides/2.database.md:114-123
The example passes a hardcoded 32-character string as the `secretKey`. Readers who copy-paste this snippet risk committing a static key to source control. Using `process.env.ENCRYPTION_KEY` shows the correct pattern and makes the insecurity of a literal value immediately obvious.

```suggestion
@RegisterTable("users", "main")
class User extends Table.with(EncryptionModifier) {
  @Index()
  declare email: string;

  @Encrypted({ secretKey: process.env.ENCRYPTION_KEY! })
  declare socialSecurityNumber: string;

  declare name: string;
}
```

### Issue 3 of 4
docs/2.concepts/6.core-utilities.md:24-29
**InterfaceFunction pattern differs from recommended style**

This example exports `InterfaceFunction` results directly as the public API (`export const GetUser = InterfaceFunction<...>()`). Every other section in the documentation — Interfaces, Exporting Interfaces, and the full-stack tutorial — uses the recommended two-layer pattern: proxies are kept in an `internal` namespace, and public wrapper functions forward calls to them. A reader who arrives at this page first may adopt the simplified style and later be confused by the wrapper-function pattern elsewhere. Consider aligning this example with the pattern taught throughout the rest of the docs.

### Issue 4 of 4
docs/1.get-started/4.architecture.md:27-34
**`<Mermaid>` component may not be universally supported**

The diagrams use a custom `<Mermaid>` Vue component rather than the standard fenced code block syntax (` ```mermaid `). If this component is not registered in the docs site's global components, the diagram tags will render as raw HTML instead of rendered diagrams. Standard Nuxt Content supports Mermaid via fenced code blocks out of the box. Verify that the `<Mermaid>` component is explicitly registered, or switch to the fenced-code-block syntax to ensure portability.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add framework documentation"](https://github.com/antelopejs/antelopejs/commit/c9dbb410e21a7b93009efb2eadbbcd4786013aa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42069447)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->