### PR TITLE
fix(watch): adopt runtime-created files and dirs, guard reloads by content signature

### DIFF
--- a/src/core/watch/file-watcher.ts
+++ b/src/core/watch/file-watcher.ts
@@ -62,6 +62,9 @@ export class FileWatcher {
   }
 
   startWatching(): void {
+    if (this.stopped) {
+      return;
+    }
     for (const dir of this.watchedDirs) {
       if (this.watchers.has(dir)) {
         continue;
@@ -130,7 +133,7 @@ export class FileWatcher {
   }
 
   async handleFileChange(filePath: string): Promise<void> {
-    if (this.isExcludedPath(filePath)) {
+    if (this.stopped || this.isExcludedPath(filePath)) {
       return;
     }
 

--- a/src/core/watch/file-watcher.ts
+++ b/src/core/watch/file-watcher.ts
@@ -22,6 +22,7 @@ export class FileWatcher {
     { hash: string; listeners: FileChangeListener[] }
   >();
   private changeChains = new Map<string, Promise<void>>();
+  private stopped = false;
 
   constructor(
     private fs: IFileSystem,
@@ -87,10 +88,12 @@ export class FileWatcher {
   }
 
   stopWatching(): void {
+    this.stopped = true;
     for (const watcher of this.watchers.values()) {
       watcher.close();
     }
     this.watchers.clear();
+    this.changeChains.clear();
   }
 
   private enqueueChange(dir: string, filePath: string): void {
@@ -177,6 +180,9 @@ export class FileWatcher {
     }
 
     entry.hash = newHash;
+    if (this.stopped) {
+      return;
+    }
     for (const listener of entry.listeners) {
       listener(filePath);
     }
@@ -278,6 +284,9 @@ export class FileWatcher {
   }
 
   private notifyModuleChange(moduleId: string): void {
+    if (this.stopped) {
+      return;
+    }
     for (const listener of this.listeners) {
       listener(moduleId);
     }

--- a/src/core/watch/file-watcher.ts
+++ b/src/core/watch/file-watcher.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { type FSWatcher, watch } from "node:fs";
 import * as path from "node:path";
 import type { IFileSystem } from "../../types";
@@ -10,14 +11,17 @@ const EXCLUDED_WATCH_DIRS = [".git", "node_modules"];
 
 export class FileWatcher {
   private filesHash = new Map<string, { moduleId: string; hash: string }>();
+  private moduleFiles = new Map<string, Set<string>>();
   private listeners: ModuleChangeListener[] = [];
   private excludedDirs = new Set(EXCLUDED_WATCH_DIRS);
   private watchers = new Map<string, FSWatcher>();
   private watchedDirs = new Set<string>();
+  private dirModules = new Map<string, string>();
   private watchedFiles = new Map<
     string,
     { hash: string; listeners: FileChangeListener[] }
   >();
+  private changeChains = new Map<string, Promise<void>>();
 
   constructor(
     private fs: IFileSystem,
@@ -70,7 +74,7 @@ export class FileWatcher {
             ? filename.toString()
             : filename;
           const filePath = path.join(dir, fileName);
-          void this.handleFileChange(filePath);
+          this.enqueueChange(dir, filePath);
         });
         watcher.on("error", (err) => {
           console.error(`FileWatcher error for ${dir}:`, err);
@@ -89,6 +93,39 @@ export class FileWatcher {
     this.watchers.clear();
   }
 
+  private enqueueChange(dir: string, filePath: string): void {
+    const previous = this.changeChains.get(dir) ?? Promise.resolve();
+    const next = previous
+      .then(() => this.handleFileChange(filePath))
+      .catch((err) => {
+        console.error(`FileWatcher error handling ${filePath}:`, err);
+      });
+    this.changeChains.set(dir, next);
+  }
+
+  private setFileEntry(filePath: string, moduleId: string, hash: string): void {
+    const existing = this.filesHash.get(filePath);
+    if (existing && existing.moduleId !== moduleId) {
+      this.moduleFiles.get(existing.moduleId)?.delete(filePath);
+    }
+    this.filesHash.set(filePath, { moduleId, hash });
+    let files = this.moduleFiles.get(moduleId);
+    if (!files) {
+      files = new Set();
+      this.moduleFiles.set(moduleId, files);
+    }
+    files.add(filePath);
+  }
+
+  private deleteFileEntry(filePath: string): void {
+    const existing = this.filesHash.get(filePath);
+    if (!existing) {
+      return;
+    }
+    this.filesHash.delete(filePath);
+    this.moduleFiles.get(existing.moduleId)?.delete(filePath);
+  }
+
   async handleFileChange(filePath: string): Promise<void> {
     if (this.isExcludedPath(filePath)) {
       return;
@@ -103,11 +140,12 @@ export class FileWatcher {
 
     const entry = this.filesHash.get(filePath);
     if (!entry) {
+      await this.handleNewPath(filePath);
       return;
     }
 
     if (!(await this.fs.exists(filePath))) {
-      this.filesHash.delete(filePath);
+      this.deleteFileEntry(filePath);
       this.notifyModuleChange(entry.moduleId);
       return;
     }
@@ -119,7 +157,7 @@ export class FileWatcher {
 
     const newHash = await this.hasher.hashFile(filePath);
     if (newHash !== entry.hash) {
-      this.filesHash.set(filePath, { moduleId: entry.moduleId, hash: newHash });
+      this.setFileEntry(filePath, entry.moduleId, newHash);
       this.notifyModuleChange(entry.moduleId);
     }
   }
@@ -144,8 +182,85 @@ export class FileWatcher {
     }
   }
 
+  private async handleNewPath(filePath: string): Promise<void> {
+    if (!(await this.fs.exists(filePath))) {
+      this.handleRemovedDir(filePath);
+      return;
+    }
+    const moduleId = this.dirModules.get(path.dirname(filePath));
+    if (!moduleId) {
+      return;
+    }
+    const stat = await this.fs.stat(filePath);
+    if (stat.isDirectory()) {
+      if (this.watchedDirs.has(filePath)) {
+        return;
+      }
+      await this.exploreDir(moduleId, filePath);
+      this.startWatching();
+      this.notifyModuleChange(moduleId);
+      return;
+    }
+
+    const hash = await this.hasher.hashFile(filePath);
+    if (!(await this.fs.exists(filePath))) {
+      return;
+    }
+    this.setFileEntry(filePath, moduleId, hash);
+    this.notifyModuleChange(moduleId);
+  }
+
+  private handleRemovedDir(dirPath: string): void {
+    if (!this.watchedDirs.has(dirPath)) {
+      return;
+    }
+    const moduleId = this.dirModules.get(dirPath);
+    this.pruneDir(dirPath);
+    if (moduleId) {
+      this.notifyModuleChange(moduleId);
+    }
+  }
+
+  private pruneDir(dirPath: string): void {
+    const prefix = `${dirPath}${path.sep}`;
+    for (const dir of this.watchedDirs) {
+      if (dir !== dirPath && !dir.startsWith(prefix)) {
+        continue;
+      }
+      this.watchedDirs.delete(dir);
+      this.dirModules.delete(dir);
+      this.changeChains.delete(dir);
+      const watcher = this.watchers.get(dir);
+      if (watcher) {
+        watcher.close();
+        this.watchers.delete(dir);
+      }
+    }
+    for (const filePath of this.filesHash.keys()) {
+      if (filePath.startsWith(prefix)) {
+        this.deleteFileEntry(filePath);
+      }
+    }
+  }
+
+  getModuleSignature(moduleId: string): string {
+    const files = this.moduleFiles.get(moduleId);
+    const entries: string[] = [];
+    if (files) {
+      for (const filePath of files) {
+        const entry = this.filesHash.get(filePath);
+        if (entry) {
+          entries.push(`${filePath}\0${entry.hash}`);
+        }
+      }
+    }
+    entries.sort();
+    return createHash("sha256").update(entries.join("\n")).digest("hex");
+  }
+
   private async exploreDir(moduleId: string, dirPath: string): Promise<void> {
     this.watchedDirs.add(dirPath);
+    this.dirModules.set(dirPath, moduleId);
     const entries = await this.fs.readdir(dirPath);
     for (const entry of entries) {
       const fullPath = path.join(dirPath, entry);
@@ -157,7 +272,7 @@ export class FileWatcher {
         await this.exploreDir(moduleId, fullPath);
       } else {
         const hash = await this.hasher.hashFile(fullPath);
-        this.filesHash.set(fullPath, { moduleId, hash });
+        this.setFileEntry(fullPath, moduleId, hash);
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,14 +103,21 @@ async function setupWatching(
   loaderContext: LoaderContext,
 ): Promise<void> {
   const watcher = new FileWatcher(fs);
-  const hotReload = new HotReload(async (moduleId) =>
-    reloadWatchedModule(manager, moduleId, loaderContext),
-  );
+  const loadedSignatures = new Map<string, string>();
+  const hotReload = new HotReload(async (moduleId) => {
+    const signature = watcher.getModuleSignature(moduleId);
+    if (loadedSignatures.get(moduleId) === signature) {
+      return;
+    }
+    await reloadWatchedModule(manager, moduleId, loaderContext);
+    loadedSignatures.set(moduleId, signature);
+  });
 
   for (const { module } of manager.getLoadedModules()) {
     if (module.manifest?.source?.type === "local") {
       const watchDirs = getWatchDirs(module.manifest.source);
       await watcher.scanModule(module.id, module.manifest.folder, watchDirs);
+      loadedSignatures.set(module.id, watcher.getModuleSignature(module.id));
     }
   }
 

--- a/test/core/watch/file-watcher.integration.test.ts
+++ b/test/core/watch/file-watcher.integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { NodeFileSystem } from "../../../src/core/filesystem";
@@ -40,6 +40,78 @@ describe("FileWatcher Integration", () => {
     try {
       await writeFile(path.join(tempDir, "test.js"), "export const v = 2;");
       await changePromise;
+    } finally {
+      watcher.stopWatching();
+    }
+  });
+
+  it("reloads for a directory created at runtime", async function () {
+    this.timeout(5000);
+
+    const watcher = new FileWatcher(new NodeFileSystem());
+    await watcher.scanModule("test", tempDir);
+
+    const changePromise = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("Timed out waiting for change")),
+        2000,
+      );
+      watcher.onModuleChanged((id) => {
+        if (id === "test") {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+    });
+
+    watcher.startWatching();
+
+    try {
+      const pageDir = path.join(tempDir, "page");
+      await mkdir(pageDir);
+      await writeFile(path.join(pageDir, "page.js"), "export const p = 1;");
+      await changePromise;
+    } finally {
+      watcher.stopWatching();
+    }
+  });
+
+  it("adopts a file created at runtime so later edits also reload", async function () {
+    this.timeout(5000);
+
+    const watcher = new FileWatcher(new NodeFileSystem());
+    await watcher.scanModule("test", tempDir);
+
+    let count = 0;
+    watcher.onModuleChanged((id) => {
+      if (id === "test") {
+        count++;
+      }
+    });
+
+    const reaches = (target: number) =>
+      new Promise<void>((resolve, reject) => {
+        const check = setInterval(() => {
+          if (count >= target) {
+            clearInterval(check);
+            clearTimeout(timeout);
+            resolve();
+          }
+        }, 25);
+        const timeout = setTimeout(() => {
+          clearInterval(check);
+          reject(new Error(`Timed out waiting for ${target} changes`));
+        }, 2000);
+      });
+
+    watcher.startWatching();
+
+    try {
+      const added = path.join(tempDir, "added.js");
+      await writeFile(added, "export const a = 1;");
+      await reaches(1);
+      await writeFile(added, "export const a = 2;");
+      await reaches(2);
     } finally {
       watcher.stopWatching();
     }

--- a/test/core/watch/file-watcher.test.ts
+++ b/test/core/watch/file-watcher.test.ts
@@ -306,6 +306,29 @@ describe("FileWatcher", () => {
     expect(changes).to.deep.equal([]);
   });
 
+  it("does not adopt or re-arm watchers for a new directory after stopWatching", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile("/mod/index.js", "v1");
+
+    const watcher = new FileWatcher(fs);
+    await watcher.scanModule("mod", "/mod");
+    watcher.startWatching();
+
+    const changes: string[] = [];
+    watcher.onModuleChanged((id) => changes.push(id));
+
+    watcher.stopWatching();
+
+    await fs.writeFile("/mod/page/page.js", "class Empty {}");
+    await watcher.handleFileChange("/mod/page");
+    watcher.startWatching();
+
+    expect(changes).to.deep.equal([]);
+    expect(
+      (watcher as unknown as { watchers: Map<string, unknown> }).watchers.size,
+    ).to.equal(0);
+  });
+
   it("does not notify watched-file listeners after stopWatching", async () => {
     const fs = new InMemoryFileSystem();
     await fs.writeFile("/project/antelope.config.ts", "original");

--- a/test/core/watch/file-watcher.test.ts
+++ b/test/core/watch/file-watcher.test.ts
@@ -288,6 +288,42 @@ describe("FileWatcher", () => {
     expect(changes).to.deep.equal([]);
   });
 
+  it("does not notify module changes after stopWatching", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile("/mod/a.txt", "a");
+
+    const watcher = new FileWatcher(fs);
+    await watcher.scanModule("mod", "/mod");
+
+    const changes: string[] = [];
+    watcher.onModuleChanged((id) => changes.push(id));
+
+    watcher.stopWatching();
+
+    await fs.writeFile("/mod/a.txt", "b");
+    await watcher.handleFileChange("/mod/a.txt");
+
+    expect(changes).to.deep.equal([]);
+  });
+
+  it("does not notify watched-file listeners after stopWatching", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile("/project/antelope.config.ts", "original");
+
+    const watcher = new FileWatcher(fs);
+    const changes: string[] = [];
+    await watcher.watchFile("/project/antelope.config.ts", (p) =>
+      changes.push(p),
+    );
+
+    watcher.stopWatching();
+
+    await fs.writeFile("/project/antelope.config.ts", "modified");
+    await watcher.handleFileChange("/project/antelope.config.ts");
+
+    expect(changes).to.deep.equal([]);
+  });
+
   it("skips excluded directories when scanning", async () => {
     const fs = new InMemoryFileSystem();
     await fs.writeFile("/mod/.git/ignored.txt", "x");

--- a/test/core/watch/file-watcher.test.ts
+++ b/test/core/watch/file-watcher.test.ts
@@ -102,7 +102,7 @@ describe("FileWatcher", () => {
     expect(listener2).to.have.lengthOf(1);
   });
 
-  it("does not notify when an untracked temp file appears", async () => {
+  it("adopts a new source file so later edits behave like it was always there", async () => {
     const fs = new InMemoryFileSystem();
     await fs.writeFile("/mod/index.js", "v1");
 
@@ -112,15 +112,167 @@ describe("FileWatcher", () => {
     const changes: string[] = [];
     watcher.onModuleChanged((id) => changes.push(id));
 
-    await fs.writeFile("/mod/_tmp_1234_abcdef", "intermediate");
-    await watcher.handleFileChange("/mod/_tmp_1234_abcdef");
-    await fs.rm("/mod/_tmp_1234_abcdef");
-    await watcher.handleFileChange("/mod/_tmp_1234_abcdef");
+    await fs.writeFile("/mod/page.js", "class Page {}");
+    await watcher.handleFileChange("/mod/page.js");
+    expect(changes).to.deep.equal(["mod"]);
+
+    changes.length = 0;
+    await watcher.handleFileChange("/mod/page.js");
+    expect(changes).to.deep.equal([]);
+
+    await fs.writeFile("/mod/page.js", "class Page { render() {} }");
+    await watcher.handleFileChange("/mod/page.js");
+    expect(changes).to.deep.equal(["mod"]);
+  });
+
+  it("tracks module signature changes for added, edited, and removed files", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile("/mod/index.js", "v1");
+
+    const watcher = new FileWatcher(fs);
+    await watcher.scanModule("mod", "/mod");
+
+    const initial = watcher.getModuleSignature("mod");
+
+    await fs.writeFile("/mod/page.js", "class Page {}");
+    await watcher.handleFileChange("/mod/page.js");
+    const afterAdd = watcher.getModuleSignature("mod");
+    expect(afterAdd).to.not.equal(initial);
+
+    await fs.writeFile("/mod/page.js", "class Page { render() {} }");
+    await watcher.handleFileChange("/mod/page.js");
+    expect(watcher.getModuleSignature("mod")).to.not.equal(afterAdd);
+
+    await fs.rm("/mod/page.js");
+    await watcher.handleFileChange("/mod/page.js");
+    expect(watcher.getModuleSignature("mod")).to.equal(initial);
+  });
+
+  it("returns to the pre-trigger signature after a transient temp file appears and is removed", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile("/mod/index.js", "v1");
+
+    const watcher = new FileWatcher(fs);
+    await watcher.scanModule("mod", "/mod");
+
+    const baseline = watcher.getModuleSignature("mod");
+
+    await fs.writeFile("/mod/index.js.tmp.5678", "intermediate garbage");
+    await watcher.handleFileChange("/mod/index.js.tmp.5678");
+    expect(watcher.getModuleSignature("mod")).to.not.equal(baseline);
+
+    await fs.rm("/mod/index.js.tmp.5678");
+    await watcher.handleFileChange("/mod/index.js.tmp.5678");
+    expect(watcher.getModuleSignature("mod")).to.equal(baseline);
+  });
+
+  it("watches a directory created at runtime and reloads for it", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile("/mod/index.js", "v1");
+
+    const watcher = new FileWatcher(fs);
+    await watcher.scanModule("mod", "/mod");
+
+    const changes: string[] = [];
+    watcher.onModuleChanged((id) => changes.push(id));
+
+    await fs.writeFile("/mod/page/page.js", "class Empty {}");
+    await watcher.handleFileChange("/mod/page");
+    expect(changes).to.deep.equal(["mod"]);
+
+    changes.length = 0;
+    await fs.writeFile("/mod/page/page.js", "class Full { render() {} }");
+    await watcher.handleFileChange("/mod/page/page.js");
+    expect(changes).to.deep.equal(["mod"]);
+  });
+
+  it("recurses into nested directories created at runtime", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile("/mod/index.js", "v1");
+
+    const watcher = new FileWatcher(fs);
+    await watcher.scanModule("mod", "/mod");
+
+    const changes: string[] = [];
+    watcher.onModuleChanged((id) => changes.push(id));
+
+    await fs.writeFile("/mod/category/xy/page.js", "class Xy {}");
+    await watcher.handleFileChange("/mod/category");
+    expect(changes).to.deep.equal(["mod"]);
+
+    changes.length = 0;
+    await fs.writeFile("/mod/category/xy/page.js", "class Xy { render() {} }");
+    await watcher.handleFileChange("/mod/category/xy/page.js");
+    expect(changes).to.deep.equal(["mod"]);
+  });
+
+  it("re-adopts a directory that was removed and recreated", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile("/mod/index.js", "v1");
+
+    const watcher = new FileWatcher(fs);
+    await watcher.scanModule("mod", "/mod");
+
+    const changes: string[] = [];
+    watcher.onModuleChanged((id) => changes.push(id));
+
+    await fs.writeFile("/mod/page/page.js", "class A {}");
+    await watcher.handleFileChange("/mod/page");
+    expect(changes).to.deep.equal(["mod"]);
+
+    changes.length = 0;
+    await fs.rm("/mod/page/page.js");
+    await fs.rm("/mod/page");
+    await watcher.handleFileChange("/mod/page");
+    expect(changes).to.deep.equal(["mod"]);
+
+    changes.length = 0;
+    await fs.writeFile("/mod/page/page.js", "class B {}");
+    await watcher.handleFileChange("/mod/page");
+    expect(changes).to.deep.equal(["mod"]);
+
+    changes.length = 0;
+    await fs.writeFile("/mod/page/page.js", "class B { render() {} }");
+    await watcher.handleFileChange("/mod/page/page.js");
+    expect(changes).to.deep.equal(["mod"]);
+  });
+
+  it("clears the module signature contribution of a removed directory", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile("/mod/index.js", "v1");
+
+    const watcher = new FileWatcher(fs);
+    await watcher.scanModule("mod", "/mod");
+
+    const baseline = watcher.getModuleSignature("mod");
+
+    await fs.writeFile("/mod/page/page.js", "class A {}");
+    await watcher.handleFileChange("/mod/page");
+    expect(watcher.getModuleSignature("mod")).to.not.equal(baseline);
+
+    await fs.rm("/mod/page/page.js");
+    await fs.rm("/mod/page");
+    await watcher.handleFileChange("/mod/page");
+    expect(watcher.getModuleSignature("mod")).to.equal(baseline);
+  });
+
+  it("ignores a new directory that has no owning module", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile("/project/antelope.config.ts", "x");
+
+    const watcher = new FileWatcher(fs);
+    await watcher.watchFile("/project/antelope.config.ts", () => {});
+
+    const changes: string[] = [];
+    watcher.onModuleChanged((id) => changes.push(id));
+
+    await fs.mkdir("/project/newdir", { recursive: true });
+    await watcher.handleFileChange("/project/newdir");
 
     expect(changes).to.deep.equal([]);
   });
 
-  it("notifies exactly once for an atomic-write rename over a tracked file", async () => {
+  it("ignores a node_modules directory created at runtime", async () => {
     const fs = new InMemoryFileSystem();
     await fs.writeFile("/mod/index.js", "v1");
 
@@ -130,14 +282,10 @@ describe("FileWatcher", () => {
     const changes: string[] = [];
     watcher.onModuleChanged((id) => changes.push(id));
 
-    await fs.writeFile("/mod/index.js.tmp.5678", "v2");
-    await watcher.handleFileChange("/mod/index.js.tmp.5678");
-    await fs.writeFile("/mod/index.js", "v2");
-    await fs.rm("/mod/index.js.tmp.5678");
-    await watcher.handleFileChange("/mod/index.js");
-    await watcher.handleFileChange("/mod/index.js.tmp.5678");
+    await fs.writeFile("/mod/node_modules/dep/index.js", "x");
+    await watcher.handleFileChange("/mod/node_modules");
 
-    expect(changes).to.deep.equal(["mod"]);
+    expect(changes).to.deep.equal([]);
   });
 
   it("skips excluded directories when scanning", async () => {

--- a/test/index.launch.test.ts
+++ b/test/index.launch.test.ts
@@ -96,6 +96,10 @@ describe("launch", () => {
     sinon.stub(ModuleManager.prototype, "startAll");
 
     const scanStub = sinon.stub(FileWatcher.prototype, "scanModule").resolves();
+    let signatureSeq = 0;
+    sinon
+      .stub(FileWatcher.prototype, "getModuleSignature")
+      .callsFake(() => `sig-${signatureSeq++}`);
     sinon
       .stub(FileWatcher.prototype, "onModuleChanged")
       .callsFake((listener) => listener("modA"));

--- a/test/integration/hmr.test.ts
+++ b/test/integration/hmr.test.ts
@@ -110,6 +110,83 @@ describe("HMR end-to-end", () => {
     }
   });
 
+  it("adopts a source file added at runtime and reloads for it and its later edits", async function () {
+    this.timeout(20000);
+
+    const projectFolder = await fs.mkdtemp(
+      path.join(os.tmpdir(), "ajs-hmr-add-"),
+    );
+    const modulePath = path.join(projectFolder, "mod");
+    const markerPath = path.join(projectFolder, "marker.txt");
+    const startCountPath = path.join(projectFolder, "start-count.txt");
+    const indexPath = path.join(modulePath, "index.js");
+
+    await fs.mkdir(modulePath, { recursive: true });
+    await fs.writeFile(
+      path.join(modulePath, "package.json"),
+      JSON.stringify({ name: "mod", version: "1.0.0", main: "index.js" }),
+    );
+    const src = `const fs = require("node:fs");
+let cfg;
+exports.construct = (c) => { cfg = c; };
+exports.start = () => {
+  const prev = fs.existsSync(cfg.startCountPath)
+    ? parseInt(fs.readFileSync(cfg.startCountPath, "utf-8"), 10) || 0
+    : 0;
+  fs.writeFileSync(cfg.startCountPath, String(prev + 1));
+  fs.writeFileSync(cfg.markerPath, "v1");
+};
+exports.stop = () => {};
+exports.destroy = () => {};
+`;
+    await fs.writeFile(indexPath, src);
+
+    const config = {
+      name: "hmr-add-test",
+      modules: {
+        mod: {
+          source: { type: "local", path: "./mod", main: "index.js" },
+          config: { markerPath, startCountPath },
+        },
+      },
+    };
+    await fs.writeFile(
+      path.join(projectFolder, "antelope.config.ts"),
+      `export default ${JSON.stringify(config)};\n`,
+    );
+
+    let manager: ModuleManager | undefined;
+    try {
+      manager = await launch(projectFolder, "default", { watch: true });
+      await waitFor(async () => (await readMarker(markerPath)) === "v1", 2000);
+
+      const addedPath = path.join(modulePath, "helper.js");
+      await fs.writeFile(addedPath, "module.exports = 1;");
+      await waitFor(
+        async () =>
+          parseInt(await fs.readFile(startCountPath, "utf-8"), 10) === 2,
+        MARKER_TIMEOUT_MS,
+      );
+
+      await fs.writeFile(addedPath, "module.exports = 2;");
+      await waitFor(
+        async () =>
+          parseInt(await fs.readFile(startCountPath, "utf-8"), 10) === 3,
+        MARKER_TIMEOUT_MS,
+      );
+
+      expect(parseInt(await fs.readFile(startCountPath, "utf-8"), 10)).to.equal(
+        3,
+      );
+    } finally {
+      if (manager) {
+        await manager.stopAll();
+        await manager.destroyAll();
+      }
+      await fs.rm(projectFolder, { recursive: true, force: true });
+    }
+  });
+
   it("does not reload when atomic-write temp files appear", async function () {
     this.timeout(20000);
 


### PR DESCRIPTION
## Problem

The `FileWatcher` only tracked files and directories that existed at boot. Anything created at runtime — a new page or category directory, or a new source file dropped into an already-watched directory — produced no reload, because `node:fs.watch` is non-recursive and nothing adopted the new path. This is the blank-page symptom for the CMS Builder, which creates pages/categories as brand-new directories: edits inside them never triggered a hot reload.

Ditching new-file support (e.g. only watching directories that existed at boot) was explicitly not acceptable — a `page.ts` added to an existing directory must start behaving as if it had always been there.

## Changes

- **Adopt runtime-created paths.** A newly created directory is explored, watched, and its files hashed; a newly created file is hashed into the tracked set. Both notify their owning module, so a path created after boot behaves as if it were scanned at boot.
- **Prune on directory removal.** Removing a directory releases its `fs.watch` handles and clears the dir/module maps and file hashes, so a delete-then-recreate is re-adopted (and watcher handles don't leak).
- **Serialize change handling per watched directory.** The create/delete events of an atomic-write temp file can't interleave and strand a stale entry, while unrelated directories stay decoupled.
- **Gate reloads on a per-module content signature.** After the debounce settles, the reload is skipped when the module's tracked-file signature equals what was last loaded. Transient temp files net to no change (no reload storm); real edits/additions/removals reload exactly once. The baseline advances only after a successful reload.

## Tests

Runtime file/dir adoption and later-edit tracking, nested-dir recursion, delete-then-recreate, signature transitions and transient-file no-op, plus HMR end-to-end coverage for added files and atomic-write temps. Pre-existing tests that only asserted the previously-incomplete behavior were reworked to assert adoption/signature semantics.

`tsc` clean, biome clean, full unit suite passing.

https://claude.ai/code/session_01FB6s8NgRtoXTrdyJMPcDPX

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `FileWatcher` so that directories and files created after the process starts are fully adopted into the watch set: a new directory is explored recursively and watched, a new file is hashed and tracked, and both trigger a module reload. It also adds pruning on directory removal (releasing OS handles and clearing maps), per-directory promise-chaining to serialise change events within a directory, and a content-signature gate in `setupWatching` so that transient temp files (atomic-write patterns) net to no reload when they disappear before the debounce fires.

- **`src/core/watch/file-watcher.ts`**: adds `moduleFiles`/`dirModules` bookkeeping, `enqueueChange` serialisation, `handleNewPath`/`pruneDir` for runtime adoption and directory removal, a `stopped` flag guarding `startWatching`/`notifyModuleChange`, and `getModuleSignature` for content-based deduplication.
- **`src/index.ts`**: wraps the hot-reload callback with a `getModuleSignature` comparison, storing the baseline after each successful reload so a pure transient-file cycle never fires `reloadWatchedModule`.
- **Tests**: new unit tests for adoption, signature transitions, delete-then-recreate, stop guards, and exclusion; new integration and HMR end-to-end tests for added files and atomic-write temp files.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is well-scoped to the file-watcher subsystem, all new code paths are guarded by the stopped flag, and the suite covers adoption, pruning, signature gating, and stop-while-in-flight scenarios.

Every new code path in handleNewPath, pruneDir, and startWatching is protected by the stopped flag so a mid-flight stopWatching call cannot create leaked OS handles or fire spurious notifications. The changeChains serialisation correctly prevents interleaved create/delete events from stranding stale entries. The signature gate in index.ts correctly captures the pre-reload state to preserve the eventual-consistency guarantee. Unit, integration, and end-to-end HMR tests cover the scenarios that originally motivated the change.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/core/watch/file-watcher.ts | Core watcher rewrite: adds runtime adoption (handleNewPath, exploreDir, pruneDir), per-directory promise-chain serialisation, stopped flag, and getModuleSignature; logic is internally consistent and all edge cases are guarded. |
| src/index.ts | Wraps hot-reload callback with signature comparison and baseline initialisation; the pre-reload capture is intentional to preserve eventual-consistency for modules that write files at startup. |
| test/core/watch/file-watcher.test.ts | Comprehensive unit tests for adoption, signature lifecycle, delete-then-recreate, stop guards, and exclusions; previous incomplete tests updated to assert correct adoption/signature semantics. |
| test/core/watch/file-watcher.integration.test.ts | Integration tests using real fs verify runtime directory creation and later-edit tracking against the actual Node.js watcher path. |
| test/integration/hmr.test.ts | End-to-end HMR test added for a file added at runtime and its subsequent edits; covers the full launch → adopt → reload cycle. |
| test/index.launch.test.ts | Adds a stub for getModuleSignature returning monotonically distinct values so the signature gate never suppresses the forced module-change notification in the launch integration test. |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OS watcher event\nfilename in dir] --> B[enqueueChange\ndir, filePath]
    B --> C[Chain prev.then\nhandleFileChange]
    C --> D{stopped?}
    D -- yes --> E[return]
    D -- no --> F{watchedFiles\nhas filePath?}
    F -- yes --> G[handleWatchedFileChange\nhash compare, fire listeners]
    F -- no --> H{filesHash\nhas filePath?}
    H -- yes --> I{fs.exists?}
    I -- no --> J[deleteFileEntry\nnotifyModuleChange]
    I -- yes --> K[hashFile\nif changed → setFileEntry\nnotifyModuleChange]
    H -- no --> L[handleNewPath]
    L --> M{fs.exists?}
    M -- no --> N[handleRemovedDir\n→ pruneDir\nclose watchers, clear maps]
    M -- yes --> O{dirModules\nhas parent dir?}
    O -- no --> P[return\nnot a module dir]
    O -- yes --> Q{isDirectory?}
    Q -- yes --> R[exploreDir recursive\n+ startWatching\nnotifyModuleChange]
    Q -- no --> S[hashFile\nsetFileEntry\nnotifyModuleChange]
    T[notifyModuleChange] --> U[hotReload.queue moduleId]
    U --> V[Debounce settles]
    V --> W[getModuleSignature current]
    W --> X{sig == loadedSig?}
    X -- yes --> Y[skip reload\ntransient change]
    X -- no --> Z[reloadWatchedModule\nloadedSig = current]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[OS watcher event\nfilename in dir] --> B[enqueueChange\ndir, filePath]
    B --> C[Chain prev.then\nhandleFileChange]
    C --> D{stopped?}
    D -- yes --> E[return]
    D -- no --> F{watchedFiles\nhas filePath?}
    F -- yes --> G[handleWatchedFileChange\nhash compare, fire listeners]
    F -- no --> H{filesHash\nhas filePath?}
    H -- yes --> I{fs.exists?}
    I -- no --> J[deleteFileEntry\nnotifyModuleChange]
    I -- yes --> K[hashFile\nif changed → setFileEntry\nnotifyModuleChange]
    H -- no --> L[handleNewPath]
    L --> M{fs.exists?}
    M -- no --> N[handleRemovedDir\n→ pruneDir\nclose watchers, clear maps]
    M -- yes --> O{dirModules\nhas parent dir?}
    O -- no --> P[return\nnot a module dir]
    O -- yes --> Q{isDirectory?}
    Q -- yes --> R[exploreDir recursive\n+ startWatching\nnotifyModuleChange]
    Q -- no --> S[hashFile\nsetFileEntry\nnotifyModuleChange]
    T[notifyModuleChange] --> U[hotReload.queue moduleId]
    U --> V[Debounce settles]
    V --> W[getModuleSignature current]
    W --> X{sig == loadedSig?}
    X -- yes --> Y[skip reload\ntransient change]
    X -- no --> Z[reloadWatchedModule\nloadedSig = current]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/core/watch/file-watcher.ts`, line 89-94 ([link](https://github.com/antelopejs/antelopejs/blob/3f985d9094d06347a59f32999d2b81f5a8efe027/src/core/watch/file-watcher.ts#L89-L94)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`stopWatching` leaves `changeChains` promises in flight**

   `stopWatching` closes OS watchers and clears `this.watchers`, but leaves `this.changeChains` untouched. Any promise already in a chain will continue to resolve after stop, calling `handleFileChange` → `notifyModuleChange` → `hotReload.queue`. Because `queue` calls `scheduleFlush` unconditionally when a module isn't in-flight, this re-arms the debounce timer after `hotReload.clear()` has already been called (the shutdown handler clears `hotReload` before it calls `stopWatching`). A reload can therefore fire against an already-stopped `ModuleManager`, producing a caught-but-logged error and potentially interfering with the restart flow.

   Clearing `changeChains` in `stopWatching` prevents stale handlers from re-arming the queue.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/core/watch/file-watcher.ts
   Line: 89-94

   Comment:
   **`stopWatching` leaves `changeChains` promises in flight**

   `stopWatching` closes OS watchers and clears `this.watchers`, but leaves `this.changeChains` untouched. Any promise already in a chain will continue to resolve after stop, calling `handleFileChange` → `notifyModuleChange` → `hotReload.queue`. Because `queue` calls `scheduleFlush` unconditionally when a module isn't in-flight, this re-arms the debounce timer after `hotReload.clear()` has already been called (the shutdown handler clears `hotReload` before it calls `stopWatching`). A reload can therefore fire against an already-stopped `ModuleManager`, producing a caught-but-logged error and potentially interfering with the restart flow.

   Clearing `changeChains` in `stopWatching` prevents stale handlers from re-arming the queue.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(watch): guard startWatching and hand..."](https://github.com/antelopejs/antelopejs/commit/861690fffb1f1e9a3c36ffe5664ee4f9519eb57a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43290456)</sub>

<!-- /greptile_comment -->