### PR TITLE
feat(downloaders): floating semver ranges, transactional module cache, hardened git updates

### DIFF
--- a/docs/2.concepts/4.configuration.md
+++ b/docs/2.concepts/4.configuration.md
@@ -124,6 +124,8 @@ Fetch a module from an npm registry. The core downloads and caches the package a
 }
 ```
 
+The `version` field accepts an exact version, an npm semver range (`^1.0.0`, `~1.2.0`, `1.x`), or a dist-tag (`latest`, `next`). Exact versions are served from the cache without touching the registry. Ranges and dist-tags are resolved against the registry on every run, so the cache is refreshed automatically whenever a newer matching version is published. If the registry is unreachable, a cached version that still satisfies the range is used as a fallback.
+
 ### Git Source
 
 Clone a module from a Git repository. You can pin to a specific branch or commit.

--- a/src/core/cli/commands/project/modules/update.ts
+++ b/src/core/cli/commands/project/modules/update.ts
@@ -4,6 +4,7 @@ import { Command, Option } from "commander";
 import { ConfigLoader } from "../../../../config";
 import { NodeFileSystem } from "../../../../filesystem";
 import {
+  bumpVersionSpec,
   checkOutdatedModules,
   type OutdatedModule,
 } from "../../../../version-checker";
@@ -27,7 +28,7 @@ function applyUpdates(
       ...antelopeModules[entry.name],
       source: {
         ...(antelopeModules[entry.name].source as ModuleSourcePackage),
-        version: entry.latest,
+        version: bumpVersionSpec(entry.current, entry.latest),
       } as ModuleSourcePackage,
     };
   }
@@ -47,7 +48,7 @@ function displayResults(
     success(chalk.green`${label} ${outdated.length} module(s):`);
     for (const entry of outdated) {
       info(
-        `  ${chalk.green("•")} ${entry.name}: ${chalk.dim(entry.current)} → ${entry.latest}`,
+        `  ${chalk.green("•")} ${entry.name}: ${chalk.dim(entry.current)} → ${bumpVersionSpec(entry.current, entry.latest)}`,
       );
     }
   } else {

--- a/src/core/downloaders/git.ts
+++ b/src/core/downloaders/git.ts
@@ -14,6 +14,7 @@ import { runInstallCommands } from "./utils";
 const Logger = new Logging.Channel("loader.git");
 
 const GIT_DIR = ".git";
+const SAFE_GIT_ARGUMENT = /^[A-Za-z0-9._:/@~-]+$/;
 
 export interface GitDownloaderDeps {
   fs?: IFileSystem;
@@ -22,6 +23,25 @@ export interface GitDownloaderDeps {
 
 function urlToFile(url: string): string {
   return url.replace(/[^a-zA-Z0-9_]/g, "_");
+}
+
+function assertSafeGitArgument(value: string, label: string): string {
+  if (!SAFE_GIT_ARGUMENT.test(value)) {
+    throw new Error(
+      `Unsafe characters in git ${label} '${value}'; only letters, digits and ._:/@~- are allowed`,
+    );
+  }
+  return value;
+}
+
+function validateSource(source: ModuleSourceGit): void {
+  assertSafeGitArgument(source.remote, "remote");
+  if (source.branch) {
+    assertSafeGitArgument(source.branch, "branch");
+  }
+  if (source.commit) {
+    assertSafeGitArgument(source.commit, "commit");
+  }
 }
 
 function toCommandResult(err: unknown): CommandResult {
@@ -70,7 +90,8 @@ async function mainBranch(cwd: string, exec: CommandRunner): Promise<string> {
     cwd,
     exec,
   );
-  return res.stdout.trim().split("/").slice(3).join("/");
+  const branch = res.stdout.trim().split("/").slice(3).join("/");
+  return assertSafeGitArgument(branch, "branch");
 }
 
 interface RepoUpdateResult {
@@ -168,6 +189,7 @@ export function registerGitDownloader(
     "remote",
     async (cache: ModuleCache, source: ModuleSourceGit) => {
       Logger.Debug(`Git loader called for ${source.remote}`);
+      validateSource(source);
       const name = urlToFile(source.remote);
       Logger.Trace(`Starting Git module load for ${name}`);
       const folder = await cache.getFolder(name, true, true);

--- a/src/core/downloaders/git.ts
+++ b/src/core/downloaders/git.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import type { ModuleSourceGit } from "@antelopejs/interface-core/config";
 import { Logging } from "@antelopejs/interface-core/logging";
 import type { IFileSystem } from "../../types";
@@ -7,10 +8,12 @@ import { NodeFileSystem } from "../filesystem";
 import type { ModuleCache } from "../module-cache";
 import { ModuleManifest } from "../module-manifest";
 import type { DownloaderRegistry } from "./registry";
-import type { CommandRunner } from "./types";
+import type { CommandResult, CommandRunner } from "./types";
 import { runInstallCommands } from "./utils";
 
 const Logger = new Logging.Channel("loader.git");
+
+const GIT_DIR = ".git";
 
 export interface GitDownloaderDeps {
   fs?: IFileSystem;
@@ -19,6 +22,23 @@ export interface GitDownloaderDeps {
 
 function urlToFile(url: string): string {
   return url.replace(/[^a-zA-Z0-9_]/g, "_");
+}
+
+function toCommandResult(err: unknown): CommandResult {
+  return { stdout: "", stderr: String(err), code: 1 };
+}
+
+async function runGitCommand(
+  command: string,
+  cwd: string,
+  exec: CommandRunner,
+): Promise<CommandResult> {
+  const result = await exec(command, { cwd }).catch(toCommandResult);
+  if (result.code !== 0) {
+    await terminalDisplay.failSpinner(`'${command}' failed: ${result.stderr}`);
+    throw new Error(`'${command}' failed: ${result.stderr}`);
+  }
+  return result;
 }
 
 async function commitAt(
@@ -45,8 +65,12 @@ async function commitAt(
 }
 
 async function mainBranch(cwd: string, exec: CommandRunner): Promise<string> {
-  const res = await exec("git symbolic-ref refs/remotes/origin/HEAD", { cwd });
-  return res.stdout.split("/")[3].trim();
+  const res = await runGitCommand(
+    "git symbolic-ref refs/remotes/origin/HEAD",
+    cwd,
+    exec,
+  );
+  return res.stdout.trim().split("/").slice(3).join("/");
 }
 
 interface RepoUpdateResult {
@@ -54,43 +78,55 @@ interface RepoUpdateResult {
   shouldInstallDependencies: boolean;
 }
 
-async function cloneOrFetchRepo(
+async function cloneRepo(
   cache: ModuleCache,
   source: ModuleSourceGit,
   exec: CommandRunner,
   name: string,
   folder: string,
 ): Promise<RepoUpdateResult> {
-  const cacheVersion = cache.getVersion(name);
   const branch = source.commit || source.branch;
-
-  if (source.ignoreCache || !cacheVersion?.startsWith("git:")) {
-    await terminalDisplay.startSpinner(`Cloning ${source.remote}`);
-    await cache.getFolder(name, false, true);
-    await exec(`git clone ${source.remote} ${name}`, { cwd: cache.path });
-    if (branch) {
-      await exec(`git checkout ${branch}`, { cwd: folder });
-    }
-    await terminalDisplay.stopSpinner(`Cloned ${source.remote}`);
-    const newActiveCommit = await commitAt("HEAD", folder, exec);
-    const newBranch = branch ?? (await mainBranch(folder, exec));
-    return {
-      newVersion: `git:${newBranch}:${newActiveCommit}`,
-      shouldInstallDependencies: true,
-    };
+  await terminalDisplay.startSpinner(`Cloning ${source.remote}`);
+  await cache.getFolder(name, false, true);
+  await runGitCommand(`git clone ${source.remote} ${name}`, cache.path, exec);
+  if (branch) {
+    await runGitCommand(`git checkout ${branch}`, folder, exec);
   }
+  await terminalDisplay.stopSpinner(`Cloned ${source.remote}`);
+  const newActiveCommit = await commitAt("HEAD", folder, exec);
+  const newBranch = branch ?? (await mainBranch(folder, exec));
+  return {
+    newVersion: `git:${newBranch}:${newActiveCommit}`,
+    shouldInstallDependencies: true,
+  };
+}
 
+async function updateRepo(
+  source: ModuleSourceGit,
+  exec: CommandRunner,
+  folder: string,
+  cacheVersion: string,
+): Promise<RepoUpdateResult> {
+  const branch = source.commit || source.branch;
   const [, prevBranch, prevCommit] = cacheVersion.split(":");
   await terminalDisplay.startSpinner(`Updating ${source.remote}`);
-  await exec("git fetch", { cwd: folder });
+  const fetchResult = await exec("git fetch", { cwd: folder }).catch(
+    toCommandResult,
+  );
+  if (fetchResult.code !== 0) {
+    await terminalDisplay.stopSpinner(
+      `Could not fetch ${source.remote}, using cached copy`,
+    );
+    return { newVersion: "", shouldInstallDependencies: false };
+  }
   const newBranch = branch ?? (await mainBranch(folder, exec));
   if (prevBranch !== newBranch) {
-    await exec(`git checkout ${newBranch}`, { cwd: folder });
+    await runGitCommand(`git checkout ${newBranch}`, folder, exec);
   }
   if (!source.commit) {
     const originCommit = await commitAt(`origin/${newBranch}`, folder, exec);
     if (originCommit !== prevCommit) {
-      await exec("git pull", { cwd: folder });
+      await runGitCommand(`git reset --hard origin/${newBranch}`, folder, exec);
     }
   }
   const newActiveCommit = await commitAt("HEAD", folder, exec);
@@ -102,6 +138,22 @@ async function cloneOrFetchRepo(
     newVersion: `git:${newBranch}:${newActiveCommit}`,
     shouldInstallDependencies: true,
   };
+}
+
+async function cloneOrFetchRepo(
+  cache: ModuleCache,
+  source: ModuleSourceGit,
+  exec: CommandRunner,
+  fs: IFileSystem,
+  name: string,
+  folder: string,
+): Promise<RepoUpdateResult> {
+  const cacheVersion = cache.getVersion(name);
+  const repoPresent = await fs.exists(path.join(folder, GIT_DIR));
+  if (source.ignoreCache || !cacheVersion?.startsWith("git:") || !repoPresent) {
+    return cloneRepo(cache, source, exec, name, folder);
+  }
+  return updateRepo(source, exec, folder, cacheVersion);
 }
 
 export function registerGitDownloader(
@@ -123,6 +175,7 @@ export function registerGitDownloader(
         cache,
         source,
         exec,
+        fs,
         name,
         folder,
       );
@@ -140,7 +193,7 @@ export function registerGitDownloader(
 
       Logger.Trace(`Git module load completed for ${name}`);
       if (updateResult.newVersion) {
-        cache.setVersion(name, updateResult.newVersion);
+        await cache.commitVersion(name, updateResult.newVersion);
       }
 
       const moduleName = source.id ?? name;

--- a/src/core/downloaders/package.ts
+++ b/src/core/downloaders/package.ts
@@ -3,6 +3,7 @@ import type { ModuleSourcePackage } from "@antelopejs/interface-core/config";
 import { Logging } from "@antelopejs/interface-core/logging";
 // @ts-expect-error
 import inly from "inly";
+import { maxSatisfying, satisfies, valid, validRange } from "semver";
 import type { IFileSystem } from "../../types";
 import { ExecuteCMD } from "../cli/command";
 import { getInstallCommand } from "../cli/package-manager";
@@ -20,7 +21,17 @@ export interface PackageDownloaderDeps {
   getTemp?: () => Promise<string>;
 }
 
+type PackageLoaderContext = Required<PackageDownloaderDeps>;
+
+type VersionFetcher = (
+  pkg: string,
+  spec: string,
+) => Promise<string | undefined>;
+
 const Logger = new Logging.Channel("loader.package");
+
+const PACKAGE_JSON = "package.json";
+const NODE_MODULES = "node_modules";
 
 function defaultExtract(from: string, to: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
@@ -30,84 +41,201 @@ function defaultExtract(from: string, to: string): Promise<void> {
   });
 }
 
+function isExactVersion(spec: string): boolean {
+  return valid(spec) !== null;
+}
+
+function pickBestVersion(versions: string[], spec: string): string | undefined {
+  const range = validRange(spec);
+  if (range) {
+    return maxSatisfying(versions, range) ?? undefined;
+  }
+  return versions[versions.length - 1];
+}
+
+async function fetchRegistryVersion(
+  pkg: string,
+  spec: string,
+  exec: CommandRunner,
+): Promise<string | undefined> {
+  let output: string;
+  try {
+    const result = await exec(`npm view "${pkg}@${spec}" version --json`, {});
+    if (result.code !== 0) {
+      return undefined;
+    }
+    output = result.stdout.trim();
+  } catch {
+    return undefined;
+  }
+  if (!output) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(output) as string | string[];
+    const versions = Array.isArray(parsed) ? parsed : [parsed];
+    return pickBestVersion(versions, spec);
+  } catch {
+    Logger.Debug(`Unexpected npm view output for ${pkg}@${spec}: ${output}`);
+    return undefined;
+  }
+}
+
+function memoizeVersionFetcher(exec: CommandRunner): VersionFetcher {
+  const pending = new Map<string, Promise<string | undefined>>();
+  return (pkg, spec) => {
+    const key = `${pkg}@${spec}`;
+    const existing = pending.get(key);
+    if (existing) {
+      return existing;
+    }
+    const created = fetchRegistryVersion(pkg, spec, exec);
+    pending.set(key, created);
+    return created;
+  };
+}
+
+function cacheSatisfiesSpec(cached: string, spec: string): boolean {
+  const range = validRange(spec);
+  return range === null || satisfies(cached, range);
+}
+
+async function resolveTargetVersion(
+  source: ModuleSourcePackage,
+  cache: ModuleCache,
+  fetchVersion: VersionFetcher,
+): Promise<string> {
+  if (isExactVersion(source.version)) {
+    return source.version;
+  }
+  const resolved = await fetchVersion(source.package, source.version);
+  if (resolved) {
+    Logger.Debug(`Resolved ${source.package}@${source.version} to ${resolved}`);
+    return resolved;
+  }
+  const cached = cache.getVersion(source.package);
+  if (cached && cacheSatisfiesSpec(cached, source.version)) {
+    Logger.Debug(
+      `Registry unreachable, keeping cached ${source.package}@${cached}`,
+    );
+    return cached;
+  }
+  throw new Error(
+    `Failed to resolve version '${source.version}' of package ${source.package} from the npm registry`,
+  );
+}
+
+async function findCachedFolder(
+  cache: ModuleCache,
+  pkg: string,
+  fs: IFileSystem,
+): Promise<string | undefined> {
+  const folder = await cache.getFolder(pkg, true, true);
+  const manifestPath = path.join(folder, PACKAGE_JSON);
+  if (!(await fs.exists(manifestPath))) {
+    return undefined;
+  }
+  try {
+    const manifest: ModulePackageJson = JSON.parse(
+      await fs.readFileString(manifestPath),
+    );
+    const hasDependencies = Object.keys(manifest.dependencies ?? {}).length > 0;
+    if (
+      hasDependencies &&
+      !(await fs.exists(path.join(folder, NODE_MODULES)))
+    ) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  return folder;
+}
+
+async function downloadPackage(
+  cache: ModuleCache,
+  source: ModuleSourcePackage,
+  version: string,
+  ctx: PackageLoaderContext,
+): Promise<string> {
+  Logger.Trace(`Downloading package ${source.package}@${version}`);
+  const tmp = await ctx.getTemp();
+  const result = await ctx.exec(`npm pack "${source.package}@${version}"`, {
+    cwd: tmp,
+  });
+  if (result.code !== 0) {
+    throw new Error(`Failed to pack npm package: ${result.stderr}`);
+  }
+  const packOutput = result.stdout.trim().split("\n");
+  const filename = packOutput[packOutput.length - 1].trim();
+
+  Logger.Debug(`Extracting ${filename} for ${source.package}@${version}`);
+  await ctx.extract(path.join(tmp, filename), tmp);
+
+  const tmpPackage = path.join(tmp, "package");
+  const manifest: ModulePackageJson = JSON.parse(
+    await ctx.fs.readFileString(path.join(tmpPackage, PACKAGE_JSON)),
+  );
+  Logger.Trace(`Transferring ${source.package}@${version} to cache`);
+  await cache.clearVersion(source.package);
+  const folder = await cache.transfer(tmpPackage, source.package);
+
+  Logger.Debug(`Installing dependencies for ${source.package}@${version}`);
+  const cmd = await ctx.getInstallCommand(folder);
+  const installResult = await ctx.exec(cmd, { cwd: folder });
+  if (installResult.code !== 0) {
+    throw new Error(`Failed to install dependencies: ${installResult.stderr}`);
+  }
+  await cache.commitVersion(source.package, manifest.version);
+  return folder;
+}
+
+async function loadPackage(
+  cache: ModuleCache,
+  source: ModuleSourcePackage,
+  ctx: PackageLoaderContext,
+  fetchVersion: VersionFetcher,
+): Promise<string> {
+  if (source.ignoreCache) {
+    return downloadPackage(cache, source, source.version, ctx);
+  }
+  const target = await resolveTargetVersion(source, cache, fetchVersion);
+  if (cache.hasVersion(source.package, target)) {
+    const cachedFolder = await findCachedFolder(cache, source.package, ctx.fs);
+    if (cachedFolder) {
+      Logger.Trace(`Using cached version of ${source.package}@${target}`);
+      return cachedFolder;
+    }
+  }
+  return downloadPackage(cache, source, target, ctx);
+}
+
 export function registerPackageDownloader(
   registry: DownloaderRegistry,
   deps: PackageDownloaderDeps = {},
 ): void {
-  const fs = deps.fs ?? new NodeFileSystem();
-  const exec = deps.exec ?? ExecuteCMD;
-  const extract = deps.extract ?? defaultExtract;
-  const installCommand = deps.getInstallCommand ?? getInstallCommand;
-  const getTemp = deps.getTemp ?? (() => ModuleCache.getTemp());
+  const ctx: PackageLoaderContext = {
+    fs: deps.fs ?? new NodeFileSystem(),
+    exec: deps.exec ?? ExecuteCMD,
+    extract: deps.extract ?? defaultExtract,
+    getInstallCommand: deps.getInstallCommand ?? getInstallCommand,
+    getTemp: deps.getTemp ?? (() => ModuleCache.getTemp()),
+  };
+  const fetchVersion = memoizeVersionFetcher(ctx.exec);
 
   registry.register(
     "package",
     "package",
     async (cache: ModuleCache, source: ModuleSourcePackage) => {
       Logger.Debug(`Loading package: ${source.package}@${source.version}`);
-      let folder: string;
-      let manifest: ModulePackageJson;
-
-      if (
-        !source.ignoreCache &&
-        cache.hasVersion(source.package, source.version)
-      ) {
-        Logger.Trace(
-          `Using cached version of ${source.package}@${source.version}`,
-        );
-        folder = await cache.getFolder(source.package, true, true);
-        manifest = JSON.parse(
-          await fs.readFileString(path.join(folder, "package.json")),
-        );
-      } else {
-        Logger.Trace(`Downloading package ${source.package}@${source.version}`);
-        const tmp = await getTemp();
-        const result = await exec(
-          `npm pack ${source.package}@${source.version}`,
-          { cwd: tmp },
-        );
-        if (result.code !== 0) {
-          throw new Error(`Failed to pack npm package: ${result.stderr}`);
-        }
-        const filename = result.stdout.trim();
-
-        Logger.Debug(
-          `Extracting ${filename} for ${source.package}@${source.version}`,
-        );
-        await extract(path.join(tmp, filename), tmp);
-
-        const tmpPackage = path.join(tmp, "package");
-        manifest = JSON.parse(
-          await fs.readFileString(path.join(tmpPackage, "package.json")),
-        );
-        Logger.Trace(
-          `Transferring ${source.package}@${source.version} to cache`,
-        );
-        folder = await cache.transfer(
-          tmpPackage,
-          source.package,
-          manifest.version,
-        );
-
-        Logger.Debug(
-          `Installing dependencies for ${source.package}@${source.version}`,
-        );
-        const cmd = await installCommand(folder);
-        const installResult = await exec(cmd, { cwd: folder });
-        if (installResult.code !== 0) {
-          throw new Error(
-            `Failed to install dependencies: ${installResult.stderr}`,
-          );
-        }
-      }
-
+      const folder = await loadPackage(cache, source, ctx, fetchVersion);
       Logger.Debug(`Successfully loaded ${source.package}@${source.version}`);
       const name = source.id ?? source.package;
       const moduleManifest = await ModuleManifest.create(
         folder,
         source,
         name,
-        fs,
+        ctx.fs,
       );
       return [moduleManifest];
     },

--- a/src/core/downloaders/package.ts
+++ b/src/core/downloaders/package.ts
@@ -115,9 +115,15 @@ async function resolveTargetVersion(
   }
   const cached = cache.getVersion(source.package);
   if (cached && cacheSatisfiesSpec(cached, source.version)) {
-    Logger.Debug(
-      `Registry unreachable, keeping cached ${source.package}@${cached}`,
-    );
+    if (validRange(source.version) === null) {
+      Logger.Warn(
+        `Registry unreachable, serving last cached ${source.package}@${cached} for tag '${source.version}' (cannot verify it is current)`,
+      );
+    } else {
+      Logger.Debug(
+        `Registry unreachable, keeping cached ${source.package}@${cached}`,
+      );
+    }
     return cached;
   }
   throw new Error(

--- a/src/core/module-cache.ts
+++ b/src/core/module-cache.ts
@@ -7,7 +7,7 @@ import { NodeFileSystem } from "./filesystem";
 
 export class ModuleCache {
   private manifest: Record<string, string> = {};
-  private saving = false;
+  private pendingSave: Promise<void> = Promise.resolve();
 
   constructor(
     public readonly path: string,
@@ -17,20 +17,23 @@ export class ModuleCache {
   async load(): Promise<void> {
     await this.fs.mkdir(this.path, { recursive: true });
     const manifestPath = path.join(this.path, "manifest.json");
+    this.manifest = {};
     if (await this.fs.exists(manifestPath)) {
-      const data = await this.fs.readFileString(manifestPath);
-      this.manifest = JSON.parse(data) || {};
-    } else {
-      this.manifest = {};
+      try {
+        const data = await this.fs.readFileString(manifestPath);
+        this.manifest = JSON.parse(data) || {};
+      } catch {
+        this.manifest = {};
+      }
     }
   }
 
-  async save(): Promise<void> {
+  save(): Promise<void> {
     const manifestPath = path.join(this.path, "manifest.json");
-    await this.fs.writeFile(
-      manifestPath,
-      JSON.stringify(this.manifest, null, 2),
+    this.pendingSave = this.pendingSave.then(() =>
+      this.fs.writeFile(manifestPath, JSON.stringify(this.manifest, null, 2)),
     );
+    return this.pendingSave;
   }
 
   getVersion(module: string): string | undefined {
@@ -39,7 +42,6 @@ export class ModuleCache {
 
   setVersion(module: string, version: string): void {
     this.manifest[module] = version;
-    this.queueSave();
   }
 
   hasVersion(module: string, version: string): boolean {
@@ -67,17 +69,21 @@ export class ModuleCache {
     return fsNode.mkdtemp(path.join(os.tmpdir(), "ajs-"));
   }
 
-  async transfer(
-    source: string,
-    module: string,
-    version: string,
-  ): Promise<string> {
+  async transfer(source: string, module: string): Promise<string> {
     const dest = await this.getFolder(module, false, false);
     await this.copyDir(source, dest);
     await this.fs.rm(source, { recursive: true, force: true });
+    return dest;
+  }
+
+  async commitVersion(module: string, version: string): Promise<void> {
     this.setVersion(module, version);
     await this.save();
-    return dest;
+  }
+
+  async clearVersion(module: string): Promise<void> {
+    delete this.manifest[module];
+    await this.save();
   }
 
   private async copyDir(source: string, dest: string): Promise<void> {
@@ -93,16 +99,5 @@ export class ModuleCache {
         await this.fs.copyFile(srcPath, destPath);
       }
     }
-  }
-
-  private queueSave(): void {
-    if (this.saving) {
-      return;
-    }
-    this.saving = true;
-    setTimeout(() => {
-      this.saving = false;
-      void this.save();
-    }, 1);
   }
 }

--- a/src/core/version-checker.ts
+++ b/src/core/version-checker.ts
@@ -1,4 +1,5 @@
 import type { ModuleSourcePackage } from "@antelopejs/interface-core/config";
+import { satisfies, validRange } from "semver";
 import { info as infoMessage, warning } from "./cli/cli-ui";
 import { ExecuteCMD } from "./cli/command";
 import { parsePackageInfoOutput } from "./cli/package-manager";
@@ -15,6 +16,24 @@ const VERSION_ARGUMENT = "version";
 const UPDATE_COMMAND = "ajs project modules update";
 const SLOW_CHECK_THRESHOLD_MS = 15_000;
 const MAX_REASON_LENGTH = 200;
+
+const RANGE_PREFIX_PATTERN = /^[\^~]/;
+
+export function isUpToDate(currentSpec: string, latest: string): boolean {
+  if (currentSpec === latest) {
+    return true;
+  }
+  const range = validRange(currentSpec);
+  if (range === null) {
+    return true;
+  }
+  return satisfies(latest, range);
+}
+
+export function bumpVersionSpec(currentSpec: string, latest: string): string {
+  const prefix = currentSpec.match(RANGE_PREFIX_PATTERN)?.[0] ?? "";
+  return `${prefix}${latest}`;
+}
 
 export async function fetchLatestVersion(packageName: string): Promise<string> {
   const result = await ExecuteCMD(
@@ -75,7 +94,7 @@ export async function checkOutdatedModules(
       }
       const current = (info.source as ModuleSourcePackage).version;
       const latest = result.value;
-      if (current !== latest) {
+      if (!isUpToDate(current, latest)) {
         outdated.push({ name, current, latest });
       }
       return outdated;

--- a/test/core/downloaders/git.test.ts
+++ b/test/core/downloaders/git.test.ts
@@ -346,6 +346,62 @@ describe("GitDownloader", () => {
     expect(cache.getVersion(cacheKey)).to.equal("git:release/2.x:abcdef");
   });
 
+  it("rejects a remote containing shell metacharacters before running git", async () => {
+    const fs = new InMemoryFileSystem();
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+
+    const execCalls: string[] = [];
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      execCalls.push(command);
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const registry = new DownloaderRegistry();
+    registerGitDownloader(registry, { fs, exec });
+
+    const source: ModuleSourceGit = {
+      type: "git",
+      remote: "https://github.com/org/repo.git; touch /tmp/pwned",
+      ignoreCache: true,
+    };
+
+    try {
+      await registry.load("/project", cache, source);
+      expect.fail("Expected unsafe remote to be rejected");
+    } catch (err) {
+      expect(String(err)).to.include("Unsafe characters");
+    }
+    expect(execCalls.some((call) => call.startsWith("git clone"))).to.be.false;
+  });
+
+  it("rejects a branch containing shell metacharacters", async () => {
+    const fs = new InMemoryFileSystem();
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+
+    const exec = async (_command: string, _options: { cwd?: string }) => {
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const registry = new DownloaderRegistry();
+    registerGitDownloader(registry, { fs, exec });
+
+    const source: ModuleSourceGit = {
+      type: "git",
+      remote: "https://github.com/org/repo.git",
+      branch: "main; rm -rf ~",
+      ignoreCache: true,
+    };
+
+    try {
+      await registry.load("/project", cache, source);
+      expect.fail("Expected unsafe branch to be rejected");
+    } catch (err) {
+      expect(String(err)).to.include("Unsafe characters");
+    }
+  });
+
   it("throws when git clone fails", async () => {
     const fs = new InMemoryFileSystem();
     const cache = new ModuleCache("/cache", fs);

--- a/test/core/downloaders/git.test.ts
+++ b/test/core/downloaders/git.test.ts
@@ -128,6 +128,7 @@ describe("GitDownloader", () => {
       `/cache/${cacheKey}/package.json`,
       JSON.stringify({ name: "repo", version: "1.0.0" }),
     );
+    await fs.writeFile(`/cache/${cacheKey}/.git/HEAD`, "ref: refs/heads/main");
     cache.setVersion(cacheKey, "git:main:oldcommit");
 
     const execCalls: string[] = [];
@@ -138,9 +139,6 @@ describe("GitDownloader", () => {
         return { stdout: "", stderr: "", code: 0 };
       }
       if (command === "git checkout develop") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (command === "git pull") {
         return { stdout: "", stderr: "", code: 0 };
       }
       if (command.startsWith("git rev-parse origin/develop")) {
@@ -172,8 +170,215 @@ describe("GitDownloader", () => {
     expect(cache.getVersion(cacheKey)).to.equal("git:develop:newcommit");
     expect(execCalls).to.include("git fetch");
     expect(execCalls).to.include("git checkout develop");
-    expect(execCalls).to.include("git pull");
+    expect(execCalls).to.include("git reset --hard origin/develop");
     expect(execCalls).to.include("npm install");
+  });
+
+  it("uses the cached copy when git fetch fails", async () => {
+    const fs = new InMemoryFileSystem();
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+
+    const remote = "https://github.com/org/repo.git";
+    const cacheKey = sanitize(remote);
+    await cache.getFolder(cacheKey, true, false);
+    await fs.writeFile(
+      `/cache/${cacheKey}/package.json`,
+      JSON.stringify({ name: "repo", version: "1.0.0" }),
+    );
+    await fs.writeFile(`/cache/${cacheKey}/.git/HEAD`, "ref: refs/heads/main");
+    cache.setVersion(cacheKey, "git:main:oldcommit");
+
+    const execCalls: string[] = [];
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      execCalls.push(command);
+      if (command === "git fetch") {
+        throw new Error("network error");
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const registry = new DownloaderRegistry();
+    registerGitDownloader(registry, { fs, exec });
+
+    const source: ModuleSourceGit = {
+      type: "git",
+      remote,
+      branch: "main",
+    };
+
+    const result = await registry.load("/project", cache, source);
+
+    expect(result).to.have.length(1);
+    expect(cache.getVersion(cacheKey)).to.equal("git:main:oldcommit");
+    expect(execCalls.some((call) => call.startsWith("git reset"))).to.be.false;
+  });
+
+  it("resets to the origin branch after a force-push", async () => {
+    const fs = new InMemoryFileSystem();
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+
+    const remote = "https://github.com/org/repo.git";
+    const cacheKey = sanitize(remote);
+    await cache.getFolder(cacheKey, true, false);
+    await fs.writeFile(
+      `/cache/${cacheKey}/package.json`,
+      JSON.stringify({ name: "repo", version: "1.0.0" }),
+    );
+    await fs.writeFile(`/cache/${cacheKey}/.git/HEAD`, "ref: refs/heads/main");
+    cache.setVersion(cacheKey, "git:main:oldcommit");
+
+    const execCalls: string[] = [];
+    let headCommit = "oldcommit";
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      execCalls.push(command);
+      if (command === "git reset --hard origin/main") {
+        headCommit = "forcedcommit";
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command.startsWith("git rev-parse origin/main")) {
+        return { stdout: "forcedcommit", stderr: "", code: 0 };
+      }
+      if (command.startsWith("git rev-parse HEAD")) {
+        return { stdout: headCommit, stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const registry = new DownloaderRegistry();
+    registerGitDownloader(registry, { fs, exec });
+
+    const source: ModuleSourceGit = {
+      type: "git",
+      remote,
+      branch: "main",
+    };
+
+    await registry.load("/project", cache, source);
+
+    expect(execCalls).to.include("git reset --hard origin/main");
+    expect(cache.getVersion(cacheKey)).to.equal("git:main:forcedcommit");
+  });
+
+  it("re-clones when the manifest has an entry but the repo folder is missing", async () => {
+    const fs = new InMemoryFileSystem();
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+
+    const remote = "https://github.com/org/repo.git";
+    const cacheKey = sanitize(remote);
+    cache.setVersion(cacheKey, "git:main:oldcommit");
+
+    const execCalls: string[] = [];
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      execCalls.push(command);
+      if (command.startsWith("git clone")) {
+        await fs.writeFile(
+          `/cache/${cacheKey}/package.json`,
+          JSON.stringify({ name: "repo", version: "1.0.0" }),
+        );
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command.startsWith("git rev-parse")) {
+        return { stdout: "abcdef", stderr: "", code: 0 };
+      }
+      if (command.startsWith("git symbolic-ref")) {
+        return { stdout: "refs/remotes/origin/main", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const registry = new DownloaderRegistry();
+    registerGitDownloader(registry, { fs, exec });
+
+    const source: ModuleSourceGit = {
+      type: "git",
+      remote,
+    };
+
+    const result = await registry.load("/project", cache, source);
+
+    expect(result).to.have.length(1);
+    expect(execCalls.some((call) => call.startsWith("git clone"))).to.be.true;
+    expect(cache.getVersion(cacheKey)).to.equal("git:main:abcdef");
+  });
+
+  it("keeps the full branch name when the default branch contains slashes", async () => {
+    const fs = new InMemoryFileSystem();
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+
+    const remote = "https://github.com/org/repo.git";
+    const cacheKey = sanitize(remote);
+
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      if (command.startsWith("git clone")) {
+        await fs.writeFile(
+          `/cache/${cacheKey}/package.json`,
+          JSON.stringify({ name: "repo", version: "1.0.0" }),
+        );
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command.startsWith("git rev-parse")) {
+        return { stdout: "abcdef", stderr: "", code: 0 };
+      }
+      if (command.startsWith("git symbolic-ref")) {
+        return {
+          stdout: "refs/remotes/origin/release/2.x\n",
+          stderr: "",
+          code: 0,
+        };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const registry = new DownloaderRegistry();
+    registerGitDownloader(registry, { fs, exec });
+
+    const source: ModuleSourceGit = {
+      type: "git",
+      remote,
+    };
+
+    await registry.load("/project", cache, source);
+
+    expect(cache.getVersion(cacheKey)).to.equal("git:release/2.x:abcdef");
+  });
+
+  it("throws when git clone fails", async () => {
+    const fs = new InMemoryFileSystem();
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+
+    const failSpinnerStub = sinon
+      .stub(terminalDisplay, "failSpinner")
+      .resolves();
+
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      if (command.startsWith("git clone")) {
+        return { stdout: "", stderr: "repository not found", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const registry = new DownloaderRegistry();
+    registerGitDownloader(registry, { fs, exec });
+
+    const source: ModuleSourceGit = {
+      type: "git",
+      remote: "https://github.com/org/missing.git",
+      ignoreCache: true,
+    };
+
+    try {
+      await registry.load("/project", cache, source);
+      expect.fail("Expected clone failure");
+    } catch (err) {
+      expect(String(err)).to.include("repository not found");
+    } finally {
+      failSpinnerStub.restore();
+    }
   });
 
   it("uses main branch when cached and no branch is specified", async () => {
@@ -188,6 +393,7 @@ describe("GitDownloader", () => {
       `/cache/${cacheKey}/package.json`,
       JSON.stringify({ name: "repo", version: "1.0.0" }),
     );
+    await fs.writeFile(`/cache/${cacheKey}/.git/HEAD`, "ref: refs/heads/main");
     cache.setVersion(cacheKey, "git:main:oldcommit");
 
     const execCalls: string[] = [];

--- a/test/core/downloaders/package.test.ts
+++ b/test/core/downloaders/package.test.ts
@@ -52,7 +52,7 @@ describe("PackageDownloader", () => {
     const source: ModuleSourcePackage = {
       type: "package",
       package: "pkg",
-      version: "^1.0.0",
+      version: "1.0.0",
       id: "pkg",
     };
     const result = await registry.load("/project", cache, source);
@@ -60,6 +60,449 @@ describe("PackageDownloader", () => {
     expect(result).to.have.length(1);
     expect(result[0].manifest.version).to.equal("1.0.0");
     expect(calls).to.deep.equal([]);
+  });
+
+  it("re-downloads when a newer version matches the range", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile(
+      "/cache/pkg/package.json",
+      JSON.stringify({ name: "pkg", version: "1.0.0" }),
+    );
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+    cache.setVersion("pkg", "1.0.0");
+
+    const execCalls: string[] = [];
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      execCalls.push(command);
+      if (command.startsWith("npm view")) {
+        return { stdout: '["1.0.0","1.1.0"]', stderr: "", code: 0 };
+      }
+      if (command.startsWith("npm pack")) {
+        return { stdout: "pkg-1.1.0.tgz", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const extract = async () => {
+      await fs.writeFile(
+        "/tmp/pkg/package/package.json",
+        JSON.stringify({ name: "pkg", version: "1.1.0" }),
+      );
+    };
+
+    const registry = new DownloaderRegistry();
+    registerPackageDownloader(registry, {
+      fs,
+      exec,
+      getTemp: async () => "/tmp/pkg",
+      extract,
+      getInstallCommand: async () => "npm install",
+    });
+
+    const source: ModuleSourcePackage = {
+      type: "package",
+      package: "pkg",
+      version: "^1.0.0",
+      id: "pkg",
+    };
+    const result = await registry.load("/project", cache, source);
+
+    expect(result[0].manifest.version).to.equal("1.1.0");
+    expect(cache.getVersion("pkg")).to.equal("1.1.0");
+    expect(execCalls).to.include('npm view "pkg@^1.0.0" version --json');
+    expect(execCalls).to.include('npm pack "pkg@1.1.0"');
+  });
+
+  it("keeps the cache when it already holds the latest range version", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile(
+      "/cache/pkg/package.json",
+      JSON.stringify({ name: "pkg", version: "1.1.0" }),
+    );
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+    cache.setVersion("pkg", "1.1.0");
+
+    const execCalls: string[] = [];
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      execCalls.push(command);
+      if (command.startsWith("npm view")) {
+        return { stdout: '["1.0.0","1.1.0"]', stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const registry = new DownloaderRegistry();
+    registerPackageDownloader(registry, {
+      fs,
+      exec,
+      getTemp: async () => "/tmp/pkg",
+      extract: async () => {},
+      getInstallCommand: async () => "npm install",
+    });
+
+    const source: ModuleSourcePackage = {
+      type: "package",
+      package: "pkg",
+      version: "^1.0.0",
+      id: "pkg",
+    };
+    const result = await registry.load("/project", cache, source);
+
+    expect(result[0].manifest.version).to.equal("1.1.0");
+    expect(execCalls.some((call) => call.startsWith("npm pack"))).to.be.false;
+  });
+
+  it("falls back to the cached version when the registry is unreachable", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile(
+      "/cache/pkg/package.json",
+      JSON.stringify({ name: "pkg", version: "1.0.0" }),
+    );
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+    cache.setVersion("pkg", "1.0.0");
+
+    const execCalls: string[] = [];
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      execCalls.push(command);
+      if (command.startsWith("npm view")) {
+        throw new Error("network error");
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const registry = new DownloaderRegistry();
+    registerPackageDownloader(registry, {
+      fs,
+      exec,
+      getTemp: async () => "/tmp/pkg",
+      extract: async () => {},
+      getInstallCommand: async () => "npm install",
+    });
+
+    const source: ModuleSourcePackage = {
+      type: "package",
+      package: "pkg",
+      version: "^1.0.0",
+      id: "pkg",
+    };
+    const result = await registry.load("/project", cache, source);
+
+    expect(result[0].manifest.version).to.equal("1.0.0");
+    expect(execCalls.some((call) => call.startsWith("npm pack"))).to.be.false;
+  });
+
+  it("falls back to the cached version for a dist-tag when the registry is unreachable", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile(
+      "/cache/pkg/package.json",
+      JSON.stringify({ name: "pkg", version: "2.0.0" }),
+    );
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+    cache.setVersion("pkg", "2.0.0");
+
+    const execCalls: string[] = [];
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      execCalls.push(command);
+      if (command.startsWith("npm view")) {
+        throw new Error("network error");
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const registry = new DownloaderRegistry();
+    registerPackageDownloader(registry, {
+      fs,
+      exec,
+      getTemp: async () => "/tmp/pkg",
+      extract: async () => {},
+      getInstallCommand: async () => "npm install",
+    });
+
+    const source: ModuleSourcePackage = {
+      type: "package",
+      package: "pkg",
+      version: "latest",
+      id: "pkg",
+    };
+    const result = await registry.load("/project", cache, source);
+
+    expect(result[0].manifest.version).to.equal("2.0.0");
+    expect(execCalls.some((call) => call.startsWith("npm pack"))).to.be.false;
+  });
+
+  it("re-downloads when the cached folder is missing node_modules despite declared dependencies", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile(
+      "/cache/pkg/package.json",
+      JSON.stringify({
+        name: "pkg",
+        version: "1.0.0",
+        dependencies: { dep: "^1.0.0" },
+      }),
+    );
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+    cache.setVersion("pkg", "1.0.0");
+
+    const execCalls: string[] = [];
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      execCalls.push(command);
+      if (command.startsWith("npm pack")) {
+        return { stdout: "pkg-1.0.0.tgz", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const extract = async () => {
+      await fs.writeFile(
+        "/tmp/pkg/package/package.json",
+        JSON.stringify({ name: "pkg", version: "1.0.0" }),
+      );
+    };
+
+    const registry = new DownloaderRegistry();
+    registerPackageDownloader(registry, {
+      fs,
+      exec,
+      getTemp: async () => "/tmp/pkg",
+      extract,
+      getInstallCommand: async () => "npm install",
+    });
+
+    const source: ModuleSourcePackage = {
+      type: "package",
+      package: "pkg",
+      version: "1.0.0",
+      id: "pkg",
+    };
+    await registry.load("/project", cache, source);
+
+    expect(execCalls).to.include('npm pack "pkg@1.0.0"');
+  });
+
+  it("invalidates a previously cached version when a newer download fails to install", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile(
+      "/cache/pkg/package.json",
+      JSON.stringify({ name: "pkg", version: "1.0.0" }),
+    );
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+    cache.setVersion("pkg", "1.0.0");
+
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      if (command.startsWith("npm view")) {
+        return { stdout: '["1.0.0","1.1.0"]', stderr: "", code: 0 };
+      }
+      if (command.startsWith("npm pack")) {
+        return { stdout: "pkg-1.1.0.tgz", stderr: "", code: 0 };
+      }
+      if (command === "npm install") {
+        return { stdout: "", stderr: "install failed", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const extract = async () => {
+      await fs.writeFile(
+        "/tmp/pkg/package/package.json",
+        JSON.stringify({ name: "pkg", version: "1.1.0" }),
+      );
+    };
+
+    const registry = new DownloaderRegistry();
+    registerPackageDownloader(registry, {
+      fs,
+      exec,
+      getTemp: async () => "/tmp/pkg",
+      extract,
+      getInstallCommand: async () => "npm install",
+    });
+
+    const source: ModuleSourcePackage = {
+      type: "package",
+      package: "pkg",
+      version: "^1.0.0",
+      id: "pkg",
+    };
+
+    try {
+      await registry.load("/project", cache, source);
+      expect.fail("Expected install failure");
+    } catch (err) {
+      expect(err).to.be.instanceOf(Error);
+    }
+    expect(cache.getVersion("pkg")).to.be.undefined;
+  });
+
+  it("throws when the registry is unreachable and nothing satisfying is cached", async () => {
+    const fs = new InMemoryFileSystem();
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      if (command.startsWith("npm view")) {
+        throw new Error("network error");
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const registry = new DownloaderRegistry();
+    registerPackageDownloader(registry, {
+      fs,
+      exec,
+      getTemp: async () => "/tmp/pkg",
+      extract: async () => {},
+      getInstallCommand: async () => "npm install",
+    });
+
+    const source: ModuleSourcePackage = {
+      type: "package",
+      package: "pkg",
+      version: "^1.0.0",
+      id: "pkg",
+    };
+
+    try {
+      await registry.load("/project", cache, source);
+      expect.fail("Expected resolution failure");
+    } catch (err) {
+      expect(String(err)).to.include("Failed to resolve version");
+    }
+  });
+
+  it("resolves dist-tags to exact versions and caches them", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile(
+      "/cache/pkg/package.json",
+      JSON.stringify({ name: "pkg", version: "2.0.0" }),
+    );
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+    cache.setVersion("pkg", "2.0.0");
+
+    const execCalls: string[] = [];
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      execCalls.push(command);
+      if (command.startsWith("npm view")) {
+        return { stdout: '"2.0.0"', stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const registry = new DownloaderRegistry();
+    registerPackageDownloader(registry, {
+      fs,
+      exec,
+      getTemp: async () => "/tmp/pkg",
+      extract: async () => {},
+      getInstallCommand: async () => "npm install",
+    });
+
+    const source: ModuleSourcePackage = {
+      type: "package",
+      package: "pkg",
+      version: "latest",
+      id: "pkg",
+    };
+    const result = await registry.load("/project", cache, source);
+
+    expect(result[0].manifest.version).to.equal("2.0.0");
+    expect(execCalls).to.include('npm view "pkg@latest" version --json');
+    expect(execCalls.some((call) => call.startsWith("npm pack"))).to.be.false;
+  });
+
+  it("downloads and commits the resolved version for a dist-tag on an empty cache", async () => {
+    const fs = new InMemoryFileSystem();
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+
+    const execCalls: string[] = [];
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      execCalls.push(command);
+      if (command.startsWith("npm view")) {
+        return { stdout: '"2.0.0"', stderr: "", code: 0 };
+      }
+      if (command.startsWith("npm pack")) {
+        return { stdout: "pkg-2.0.0.tgz", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const extract = async () => {
+      await fs.writeFile(
+        "/tmp/pkg/package/package.json",
+        JSON.stringify({ name: "pkg", version: "2.0.0" }),
+      );
+    };
+
+    const registry = new DownloaderRegistry();
+    registerPackageDownloader(registry, {
+      fs,
+      exec,
+      getTemp: async () => "/tmp/pkg",
+      extract,
+      getInstallCommand: async () => "npm install",
+    });
+
+    const source: ModuleSourcePackage = {
+      type: "package",
+      package: "pkg",
+      version: "latest",
+      id: "pkg",
+    };
+    const result = await registry.load("/project", cache, source);
+
+    expect(result[0].manifest.version).to.equal("2.0.0");
+    expect(execCalls).to.include('npm pack "pkg@2.0.0"');
+    expect(cache.getVersion("pkg")).to.equal("2.0.0");
+  });
+
+  it("re-downloads when the cache manifest references a missing folder", async () => {
+    const fs = new InMemoryFileSystem();
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+    cache.setVersion("pkg", "1.0.0");
+
+    const execCalls: string[] = [];
+    const exec = async (command: string, _options: { cwd?: string }) => {
+      execCalls.push(command);
+      if (command.startsWith("npm pack")) {
+        return { stdout: "pkg-1.0.0.tgz", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const extract = async () => {
+      await fs.writeFile(
+        "/tmp/pkg/package/package.json",
+        JSON.stringify({ name: "pkg", version: "1.0.0" }),
+      );
+    };
+
+    const registry = new DownloaderRegistry();
+    registerPackageDownloader(registry, {
+      fs,
+      exec,
+      getTemp: async () => "/tmp/pkg",
+      extract,
+      getInstallCommand: async () => "npm install",
+    });
+
+    const source: ModuleSourcePackage = {
+      type: "package",
+      package: "pkg",
+      version: "1.0.0",
+      id: "pkg",
+    };
+    const result = await registry.load("/project", cache, source);
+
+    expect(result[0].manifest.version).to.equal("1.0.0");
+    expect(execCalls).to.include('npm pack "pkg@1.0.0"');
   });
 
   it("should download, extract, and install when not cached", async () => {
@@ -108,7 +551,7 @@ describe("PackageDownloader", () => {
     expect(cache.getVersion("pkg")).to.equal("1.2.3");
 
     expect(execCalls[0]).to.deep.equal({
-      command: "npm pack pkg@1.2.3",
+      command: 'npm pack "pkg@1.2.3"',
       cwd: "/tmp/pkg",
     });
     expect(execCalls[1]).to.deep.equal({
@@ -197,6 +640,7 @@ describe("PackageDownloader", () => {
     } catch (err) {
       expect(err).to.be.instanceOf(Error);
     }
+    expect(cache.getVersion("pkg")).to.be.undefined;
   });
 
   it("uses the default extractor when no custom extract is provided", async () => {

--- a/test/core/module-cache.test.ts
+++ b/test/core/module-cache.test.ts
@@ -48,12 +48,48 @@ describe("ModuleCache", () => {
 
     await fs.writeFile("/tmp/src/file.txt", "hello");
 
-    const dest = await cache.transfer("/tmp/src", "mod", "1.0.0");
+    const dest = await cache.transfer("/tmp/src", "mod");
+    await cache.commitVersion("mod", "1.0.0");
 
     expect(dest).to.equal("/cache/mod");
     expect(await fs.exists("/tmp/src")).to.be.false;
     expect(await fs.readFileString("/cache/mod/file.txt")).to.equal("hello");
     expect(cache.hasVersion("mod", "^1.0.0")).to.be.true;
+  });
+
+  it("does not record a version when transferring", async () => {
+    const fs = new InMemoryFileSystem();
+    const cache = new ModuleCache("/cache", fs);
+
+    await fs.writeFile("/tmp/src/file.txt", "hello");
+
+    await cache.transfer("/tmp/src", "mod");
+
+    expect(cache.getVersion("mod")).to.be.undefined;
+  });
+
+  it("records a version through commitVersion", async () => {
+    const fs = new InMemoryFileSystem();
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+
+    await cache.commitVersion("mod", "1.0.0");
+
+    const data = JSON.parse(await fs.readFileString("/cache/manifest.json"));
+    expect(data.mod).to.equal("1.0.0");
+  });
+
+  it("removes a version through clearVersion", async () => {
+    const fs = new InMemoryFileSystem();
+    const cache = new ModuleCache("/cache", fs);
+    await cache.load();
+
+    await cache.commitVersion("mod", "1.0.0");
+    await cache.clearVersion("mod");
+
+    expect(cache.getVersion("mod")).to.be.undefined;
+    const data = JSON.parse(await fs.readFileString("/cache/manifest.json"));
+    expect(data.mod).to.be.undefined;
   });
 
   it("loads existing manifest data when present", async () => {
@@ -67,6 +103,16 @@ describe("ModuleCache", () => {
     await cache.load();
 
     expect(cache.getVersion("cached")).to.equal("2.0.0");
+  });
+
+  it("falls back to empty manifest when stored manifest is corrupt", async () => {
+    const fs = new InMemoryFileSystem();
+    await fs.writeFile("/cache/manifest.json", '{"mod": "1.0');
+    const cache = new ModuleCache("/cache", fs);
+
+    await cache.load();
+
+    expect(cache.getVersion("mod")).to.equal(undefined);
   });
 
   it("falls back to empty manifest when stored manifest is null", async () => {
@@ -86,7 +132,7 @@ describe("ModuleCache", () => {
     await fs.mkdir("/tmp/src/nested", { recursive: true });
     await fs.writeFile("/tmp/src/nested/file.txt", "nested");
 
-    await cache.transfer("/tmp/src", "mod", "1.0.0");
+    await cache.transfer("/tmp/src", "mod");
 
     expect(await fs.readFileString("/cache/mod/nested/file.txt")).to.equal(
       "nested",

--- a/test/core/version-checker.test.ts
+++ b/test/core/version-checker.test.ts
@@ -8,8 +8,10 @@ import * as cliUi from "../../src/core/cli/cli-ui";
 import * as command from "../../src/core/cli/command";
 import type { ExpandedModuleConfig } from "../../src/core/config/config-parser";
 import {
+  bumpVersionSpec,
   checkOutdatedModules,
   fetchLatestVersion,
+  isUpToDate,
   warnOutdatedModules,
 } from "../../src/core/version-checker";
 
@@ -101,6 +103,60 @@ describe("version-checker", () => {
         current: "1.0.0",
         latest: "2.0.0",
       });
+    });
+
+    it("does not flag modules whose range already covers the latest version", async () => {
+      sinon.stub(command, "ExecuteCMD").resolves({
+        code: 0,
+        stdout: "1.2.0\n",
+        stderr: "",
+      });
+
+      const packageSource: ModuleSourcePackage = {
+        type: "package",
+        package: "mod-a",
+        version: "^1.0.0",
+      };
+      const modules: Record<string, ExpandedModuleConfig> = {
+        "mod-a": {
+          source: packageSource,
+          config: {},
+          importOverrides: [],
+          disabledExports: [],
+        },
+      };
+
+      const result = await checkOutdatedModules(modules);
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it("flags modules whose range does not cover the latest version", async () => {
+      sinon.stub(command, "ExecuteCMD").resolves({
+        code: 0,
+        stdout: "2.0.0\n",
+        stderr: "",
+      });
+
+      const packageSource: ModuleSourcePackage = {
+        type: "package",
+        package: "mod-a",
+        version: "^1.0.0",
+      };
+      const modules: Record<string, ExpandedModuleConfig> = {
+        "mod-a": {
+          source: packageSource,
+          config: {},
+          importOverrides: [],
+          disabledExports: [],
+        },
+      };
+
+      const result = await checkOutdatedModules(modules);
+
+      expect(result).to.deep.equal([
+        { name: "mod-a", current: "^1.0.0", latest: "2.0.0" },
+      ]);
     });
 
     it("returns empty array when all modules are up to date", async () => {
@@ -245,6 +301,28 @@ describe("version-checker", () => {
       await pending;
 
       expect(warnStub.called).to.equal(false);
+    });
+  });
+
+  describe("isUpToDate", () => {
+    it("compares exact versions and ranges against the latest version", () => {
+      expect(isUpToDate("1.0.0", "1.0.0")).to.equal(true);
+      expect(isUpToDate("1.0.0", "1.1.0")).to.equal(false);
+      expect(isUpToDate("^1.0.0", "1.5.0")).to.equal(true);
+      expect(isUpToDate("^1.0.0", "2.0.0")).to.equal(false);
+    });
+
+    it("treats dist-tags as always up to date since the loader floats them", () => {
+      expect(isUpToDate("latest", "1.0.0")).to.equal(true);
+      expect(isUpToDate("next", "2.0.0")).to.equal(true);
+    });
+  });
+
+  describe("bumpVersionSpec", () => {
+    it("preserves range prefixes when bumping", () => {
+      expect(bumpVersionSpec("^1.0.0", "2.0.0")).to.equal("^2.0.0");
+      expect(bumpVersionSpec("~1.0.0", "1.2.0")).to.equal("~1.2.0");
+      expect(bumpVersionSpec("1.0.0", "2.0.0")).to.equal("2.0.0");
     });
   });
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A — follows up on recurring "delete `.antelope` to pick up the right version" issues.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

**Floating version specs.** `version` in a package source now fully supports npm semver ranges (`^1.2.0`, `~0.0.1`, `1.x`) and dist-tags (`latest`, `next`). Non-exact specs are resolved against the registry (`npm view`) on every load — resolutions are memoized per run and deduplicated across environments — so a rerun/build always picks up the latest matching version instead of freezing on the first cached one. Exact versions keep the pure cache path with zero network access. When the registry is unreachable, a cached version satisfying the spec is served as a fallback.

**Transactional module cache.** The cache manifest entry is cleared before the folder is replaced and only committed after the dependency install succeeds, so an interrupted or failed install can no longer poison the cache (previously the version was recorded before `npm install`, leaving broken folders served forever until `.antelope` was deleted). Additional self-healing: cached folders missing `node_modules` despite declared dependencies are re-downloaded, manifest saves are serialized to prevent truncation races, and a corrupt `manifest.json` recovers to an empty manifest instead of crashing the run.

**Hardened git downloader.** `git clone`/`checkout`/`fetch` failures now surface clearly instead of silently keeping a stale checkout (the previous unchecked calls swallowed failures, another `.antelope`-deletion inducer). `git pull` is replaced by `git reset --hard origin/<branch>`, which survives force-pushes and dirty cache state. A manifest entry pointing at a missing repo folder triggers a re-clone, a failed fetch falls back to the cached copy with a message, and default branches containing slashes (`release/2.x`) are handled.

**Range-aware update/outdated.** A range already covering the latest published version is no longer reported outdated, dist-tags are treated as always up to date (the loader floats them each run), and `ajs project modules update` preserves `^`/`~` prefixes when bumping instead of pinning.

Known limitation: `x`-ranges and comparator ranges (`1.x`, `>=1.0.0`) that fall out of range are still pinned to the exact latest by `modules update`, matching the previous behavior.

Test plan: 25+ new unit tests cover range refresh, dist-tag resolution and offline fallbacks, cache invalidation on failed install, poisoned-cache healing, git force-push recovery, missing-folder re-clone, and corrupt-manifest recovery — including mocks that reject like the real `ExecuteCMD`. Verified end-to-end against the live npm registry: fresh install via `^1.0.0`, stale-cache refresh to the latest matching version, warm-cache no-op, and dist-tag serving from cache.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [ ] I have run `ajs module exports generate` and committed any updated interface files. (N/A — no interface changes)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes module downloading more flexible and resilient. The main changes are:

- Package sources can use semver ranges and dist-tags.
- Package cache writes are committed after successful installs.
- Git downloads now validate command arguments and reset to remote branches.
- Module update checks now understand ranges and preserve simple prefixes.

<h3>Confidence Score: 4/5</h3>

This is close, but the package fallback should be fixed before merging.

- Git command argument validation covers the reported shell-command path.
- Package fallback can still reuse a cached version resolved for a different spec when the registry is offline.
- That can make two module entries for the same npm package load the wrong version.

src/core/downloaders/package.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/downloaders/git.ts | Adds validation for git command arguments and improves clone, fetch, checkout, and reset handling. |
| src/core/downloaders/package.ts | Adds range and dist-tag resolution, but offline fallback still shares cached versions across specs for the same package. |
| src/core/module-cache.ts | Separates cache transfer from version commits and serializes manifest saves. |
| src/core/version-checker.ts | Treats ranges that include the latest version as current and preserves simple range prefixes on update. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/core/downloaders/package.ts:116-127
**Cache Ignores Spec**
The offline fallback still reads the cached version by `source.package` only, so different config entries for the same npm package share one fallback slot. For example, if one module id cached `pkg@2.0.0` from `latest`, another module id using `package: "pkg"` with `version: "^1.0.0"` can later read that same cached value when the registry is offline. The loader then serves a version that was resolved for a different requested spec, so callers can receive the wrong package version without the registry proving it matches this module entry. The cache metadata needs to distinguish the requested range/tag, or the fallback should reject entries that were not resolved for the same spec.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(downloaders): validate git refs agai..."](https://github.com/antelopejs/antelopejs/commit/36150cfa2f399732570ed03a3cc85184a429b8a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43770524)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->