### PR TITLE
docs: declare table fields with @Field and @Relation decorators in guide examples

### DIFF
--- a/docs/4.guides/2.database.md
+++ b/docs/4.guides/2.database.md
@@ -25,24 +25,28 @@ All table classes, decorators, modifiers, and model functions referenced in this
 
 ## Defining Tables
 
-You define tables as classes that extend the `Table` base class. The `@RegisterTable` decorator registers the class with the database system under a specific table name and schema. Each property on the class represents a column.
+You define tables as classes that extend the `Table` base class. The `@RegisterTable` decorator registers the class with the database system under a specific table name and schema. Each property on the class represents a column, declared with the `@Field` decorator.
 
 ```typescript [src/db/tables/user.ts]
-import { Table, RegisterTable, Index } from "@antelopejs/interface-database-decorators";
+import { Table, RegisterTable, Field, Index } from "@antelopejs/interface-database-decorators";
 
 @RegisterTable("users", "main")
 class User extends Table {
   @Index()
+  @Field("string")
   declare email: string;
 
+  @Field("string")
   declare name: string;
+
+  @Field("number")
   declare age: number;
 }
 
 export { User };
 ```
 
-The first argument to `@RegisterTable` is the table name and the second is the schema name. Default values on properties define the column types and provide fallback values for new records. The `@Index` decorator marks a property as indexed for faster lookups.
+The first argument to `@RegisterTable` is the table name and the second is the schema name. The `@Field` decorator declares the column type for each property: a primitive token (`"string"`, `"number"`, `"boolean"`, `"date"`), an array (`["string"]`), a nested record, or an io-ts codec. Properties without `@Field` are omitted from the table definition handed to the database adapter. The `@Index` decorator marks a property as indexed for faster lookups.
 
 ::note
 `Table` is a base class, not a decorator. Always extend it with `class MyTable extends Table`.
@@ -53,20 +57,26 @@ The first argument to `@RegisterTable` is the table name and the second is the s
 The `@Index` decorator marks a property for database indexing. Indexes speed up queries that filter or sort by the indexed column. You can group multiple columns into a composite index by specifying a group name.
 
 ```typescript [src/db/tables/product.ts]
-import { Table, RegisterTable, Index } from "@antelopejs/interface-database-decorators";
+import { Table, RegisterTable, Field, Index } from "@antelopejs/interface-database-decorators";
 
 @RegisterTable("products", "main")
 class Product extends Table {
   @Index()
+  @Field("string")
   declare sku: string;
 
   @Index({ group: "category_brand" })
+  @Field("string")
   declare category: string;
 
   @Index({ group: "category_brand" })
+  @Field("string")
   declare brand: string;
 
+  @Field("string")
   declare name: string;
+
+  @Field("number")
   declare price: number;
 }
 
@@ -74,6 +84,30 @@ export { Product };
 ```
 
 Properties with the same `group` value form a composite index. Queries that filter by both `category` and `brand` benefit from the composite index.
+
+## Relations
+
+The `@Relation` decorator declares a link from a field to another table. It is declarative metadata only — database implementations do not enforce it with foreign key constraints — but introspection tooling consumes it to expose the links between tables.
+
+```typescript [src/db/tables/order.ts]
+import { Table, RegisterTable, Field, Index, Relation } from "@antelopejs/interface-database-decorators";
+import { User } from "./user";
+
+@RegisterTable("orders", "main")
+class Order extends Table {
+  @Index()
+  @Field("string")
+  @Relation({ to: () => User })
+  declare userId: string;
+
+  @Field("number")
+  declare total: number;
+}
+
+export { Order };
+```
+
+The `to` option is a thunk returning the target table class (lazy, to allow forward references). Use `toField` to point at a field other than the target's primary key, and `many: true` when the field holds an array of target keys.
 
 ## Table Modifiers
 
@@ -84,17 +118,20 @@ Modifiers add specialized behavior to table properties. Apply modifiers through 
 The `HashModifier` enables the `@Hashed` decorator for properties that store hashed values, such as passwords. Hashed values are one-way transformed before storage and cannot be reversed.
 
 ```typescript [src/db/tables/user.ts]
-import { Table, RegisterTable, Index, Hashed } from "@antelopejs/interface-database-decorators";
+import { Table, RegisterTable, Field, Index, Hashed } from "@antelopejs/interface-database-decorators";
 import { HashModifier } from "@antelopejs/interface-database-decorators";
 
 @RegisterTable("users", "main")
 class User extends Table.with(HashModifier) {
   @Index()
+  @Field("string")
   declare email: string;
 
   @Hashed()
+  @Field("string")
   declare password: string;
 
+  @Field("string")
   declare name: string;
 }
 
@@ -108,17 +145,20 @@ When a record is inserted or updated, the `password` field is automatically hash
 The `EncryptionModifier` enables the `@Encrypted` decorator for properties that must be stored encrypted. Unlike hashing, encrypted values can be decrypted when read back.
 
 ```typescript [src/db/tables/user.ts]
-import { Table, RegisterTable, Index, Encrypted } from "@antelopejs/interface-database-decorators";
+import { Table, RegisterTable, Field, Index, Encrypted } from "@antelopejs/interface-database-decorators";
 import { EncryptionModifier } from "@antelopejs/interface-database-decorators";
 
 @RegisterTable("users", "main")
 class User extends Table.with(EncryptionModifier) {
   @Index()
+  @Field("string")
   declare email: string;
 
   @Encrypted({ secretKey: "change-me-to-a-32-char-key-12345" })
+  @Field("string")
   declare socialSecurityNumber: string;
 
+  @Field("string")
   declare name: string;
 }
 
@@ -132,20 +172,24 @@ Encrypted fields are transparently encrypted on write and decrypted on read. The
 You can apply multiple modifiers at once by passing them all to `Table.with()`. This combination enables both `@Hashed` and `@Encrypted` decorators on the same table class.
 
 ```typescript [src/db/tables/user.ts]
-import { Table, RegisterTable, Index, Hashed, Encrypted } from "@antelopejs/interface-database-decorators";
+import { Table, RegisterTable, Field, Index, Hashed, Encrypted } from "@antelopejs/interface-database-decorators";
 import { HashModifier, EncryptionModifier } from "@antelopejs/interface-database-decorators";
 
 @RegisterTable("users", "main")
 class User extends Table.with(HashModifier, EncryptionModifier) {
   @Index()
+  @Field("string")
   declare email: string;
 
   @Hashed()
+  @Field("string")
   declare password: string;
 
   @Encrypted({ secretKey: "change-me-to-a-32-char-key-12345" })
+  @Field("string")
   declare socialSecurityNumber: string;
 
+  @Field("string")
   declare name: string;
 }
 
@@ -249,7 +293,7 @@ When inserting a record with a `@Hashed` property, the value is hashed before st
 The `@Fixture` decorator provides seed data for development and testing. It takes a generator function that returns an array of records to insert when the table is first created.
 
 ```typescript [src/db/tables/role.ts]
-import { Table, RegisterTable, Fixture } from "@antelopejs/interface-database-decorators";
+import { Table, RegisterTable, Field, Fixture } from "@antelopejs/interface-database-decorators";
 
 @Fixture(() => [
   { name: "admin", permissions: ["read", "write", "delete"] },
@@ -258,8 +302,11 @@ import { Table, RegisterTable, Fixture } from "@antelopejs/interface-database-de
 ])
 @RegisterTable("roles", "main")
 class Role extends Table {
+  @Field("string")
   declare name: string;
-  permissions: string[] = [];
+
+  @Field(["string"])
+  declare permissions: string[];
 }
 
 export { Role };

--- a/docs/4.guides/4.data-api.md
+++ b/docs/4.guides/4.data-api.md
@@ -180,15 +180,23 @@ With this override the Get route becomes `GET /api/tasks/by-id?id=<id>` instead 
 The Data API works directly with tables defined using the database decorators. Here is a complete example that defines a table and exposes it as a CRUD API.
 
 ```typescript [src/db/tables/task.ts]
-import { Table, RegisterTable, Index } from "@antelopejs/interface-database-decorators";
+import { Table, RegisterTable, Field, Index, Relation } from "@antelopejs/interface-database-decorators";
+import { User } from "./user";
 
 @RegisterTable("tasks", "main")
 class Task extends Table {
   @Index()
+  @Field("string")
+  @Relation({ to: () => User })
   declare userId: string;
 
+  @Field("string")
   declare title: string;
+
+  @Field("string")
   declare description: string;
+
+  @Field("boolean")
   declare completed: boolean;
 }
 

--- a/docs/4.guides/5.full-stack-tutorial.md
+++ b/docs/4.guides/5.full-stack-tutorial.md
@@ -115,17 +115,20 @@ Set up TypeScript configuration with decorator support:
 The User table stores account credentials and profile information. The `@Hashed` modifier on the `password` property ensures passwords are hashed before storage. Extend `Table.with(HashModifier)` to enable hashing support.
 
 ```typescript [src/db/tables/user.ts]
-import { Table, RegisterTable, Index, Hashed } from "@antelopejs/interface-database-decorators";
+import { Table, RegisterTable, Field, Index, Hashed } from "@antelopejs/interface-database-decorators";
 import { HashModifier } from "@antelopejs/interface-database-decorators";
 
 @RegisterTable("users", "main")
 class User extends Table.with(HashModifier) {
   @Index()
+  @Field("string")
   declare email: string;
 
   @Hashed()
+  @Field("string")
   declare password: string;
 
+  @Field("string")
   declare name: string;
 }
 
@@ -136,18 +139,26 @@ The `@Index` decorator on `email` enables fast lookups when authenticating users
 
 #### Define the Task table
 
-The Task table stores task records associated with users. The `userId` field links each task to its owner, and the `@Index` decorator enables efficient filtering by user.
+The Task table stores task records associated with users. The `userId` field links each task to its owner: the `@Relation` decorator declares the link to the User table, and the `@Index` decorator enables efficient filtering by user.
 
 ```typescript [src/db/tables/task.ts]
-import { Table, RegisterTable, Index } from "@antelopejs/interface-database-decorators";
+import { Table, RegisterTable, Field, Index, Relation } from "@antelopejs/interface-database-decorators";
+import { User } from "./user";
 
 @RegisterTable("tasks", "main")
 class Task extends Table {
   @Index()
+  @Field("string")
+  @Relation({ to: () => User })
   declare userId: string;
 
+  @Field("string")
   declare title: string;
+
+  @Field("string")
   declare description: string;
+
+  @Field("boolean")
   declare completed: boolean;
 }
 


### PR DESCRIPTION
## Summary

All table-declaring examples in the guides used the legacy style (bare `declare` fields, no column types). This migrates them to the current `@antelopejs/interface-database-decorators` API:

- `@Field(type)` on every column — properties without `@Field` are omitted from the `TableDefinition.fields` map handed to the database adapter, so the old examples produced tables with no field definitions.
- `@Relation({ to: () => Target })` on foreign-key fields (`Task.userId`).
- New **Relations** section in the database guide documenting the `@Relation` decorator (`to`, `toField`, `many`).
- Prose updated where it taught the old style ("Default values on properties define the column types").

Matches the conventions already used by `template-todo-typescript` and the cms-* modules.

## Files

- `docs/4.guides/2.database.md` — 6 examples + new Relations section
- `docs/4.guides/4.data-api.md` — Task example
- `docs/4.guides/5.full-stack-tutorial.md` — User and Task examples

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the guide examples to use the current database decorator style.

- Adds `@Field` decorators to table fields in the database guide.
- Adds relation examples with `@Relation` for foreign-key-style fields.
- Updates the Data API and full-stack tutorial task examples.
- Revises prose about how table fields and field types are declared.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/4.guides/2.database.md | Adds field decorators across database examples, introduces relation documentation, and updates fixture and field-type prose. |
| docs/4.guides/4.data-api.md | Updates the Task table example to declare fields and relation metadata with decorators. |
| docs/4.guides/5.full-stack-tutorial.md | Updates the tutorial User and Task table examples to use decorated fields and relation metadata. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: declare table fields with @Field a..."](https://github.com/antelopejs/antelopejs/commit/885acf619fa0db6de6c47e9a0498c5e49a8d3b0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43771837)</sub>

<!-- /greptile_comment -->