### PR TITLE
feat(cli): align modules add/install with floating semver ranges

### DIFF
--- a/docs/5.cli/2.project.md
+++ b/docs/5.cli/2.project.md
@@ -171,11 +171,20 @@ ajs project modules add <modules...> [options]
 | `-p, --project <path>`    | Path to the project folder                                       |
 | `-e, --env <environment>` | Environment name                                                 |
 
+In `package` mode, a module can be given as `<name>` or `<name>@<spec>`, where the spec is an exact version, a semver range, or a dist-tag. Without a spec, the latest published version is written as a floating caret range (`^1.4.4`), so the module follows new minor and patch releases automatically. Pass an exact version to pin the module instead. Invalid specs are rejected immediately, and a module whose download fails is not added to the configuration.
+
 **Examples:**
 
 ```bash
-# Add an npm package (the default mode)
+# Add an npm package at the latest version (writes a ^ range)
 ajs project modules add @antelopejs/api
+
+# Pin an exact version
+ajs project modules add @antelopejs/api@1.4.4
+
+# Use a semver range or a dist-tag
+ajs project modules add @antelopejs/api@~1.4.0
+ajs project modules add @antelopejs/api@next
 
 # Add a local module by path
 ajs project modules add ./modules/auth --mode local

--- a/src/core/cli/commands/project/modules/add.ts
+++ b/src/core/cli/commands/project/modules/add.ts
@@ -13,10 +13,14 @@ import { DownloaderRegistry } from "../../../../downloaders/registry";
 import { NodeFileSystem } from "../../../../filesystem";
 import { ModuleCache } from "../../../../module-cache";
 import type { ModulePackageJson } from "../../../../module-manifest";
+import {
+  fetchLatestVersion,
+  toFloatingSpec,
+  validateVersionSpec,
+} from "../../../../version-checker";
 import { displayBox, error, info, success, warning } from "../../../cli-ui";
 import { ExecuteCMD } from "../../../command";
 import { Options, readConfig, writeConfig } from "../../../common";
-import { parsePackageInfoOutput } from "../../../package-manager";
 
 const LOCAL_MODULE_WATCH_DIRS = ["src"];
 const LOCAL_MODULE_BUILD_COMMAND = ["npx tsc"];
@@ -35,6 +39,91 @@ export const handlers = new Map<
     options: AddOptions,
   ) => Promise<[string, AntelopeModuleConfig | string]>
 >();
+
+interface ModuleLoadResult {
+  moduleName: string;
+  moduleConfig: AntelopeModuleConfig | string;
+  skipped: boolean;
+  failed: boolean;
+}
+
+async function downloadModuleToCache(
+  registry: DownloaderRegistry,
+  cache: ModuleCache,
+  projectPath: string,
+  moduleName: string,
+  moduleConfig: AntelopeModuleConfig,
+): Promise<boolean> {
+  const loaderIdentifier = registry.getLoaderIdentifier(
+    moduleConfig.source as any,
+  );
+  if (!loaderIdentifier) {
+    return true;
+  }
+  info(`Downloading module ${chalk.bold(moduleName)} to cache...`);
+  try {
+    const moduleManifests = await registry.load(projectPath, cache, {
+      ...moduleConfig.source,
+      id: moduleName,
+    } as any);
+    if (moduleManifests.length > 0) {
+      const manifest = moduleManifests[0];
+      if (manifest.manifest.antelopeJs?.defaultConfig) {
+        moduleConfig.config = manifest.manifest.antelopeJs.defaultConfig;
+      }
+    }
+    success(
+      `Successfully downloaded module ${chalk.bold(moduleName)} to cache`,
+    );
+    return true;
+  } catch (err: unknown) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    error(
+      `Failed to download module ${chalk.bold(moduleName)}: ${errorMessage}`,
+    );
+    return false;
+  }
+}
+
+async function displayAddResults(
+  added: string[],
+  skipped: string[],
+  failed: string[],
+): Promise<void> {
+  let resultContent = "";
+
+  if (added.length > 0) {
+    resultContent += `${chalk.green.bold("Successfully added:")}\n`;
+    added.forEach((name) => {
+      resultContent += `  • ${chalk.bold(name)}\n`;
+    });
+  }
+
+  if (skipped.length > 0) {
+    if (resultContent) resultContent += "\n";
+    resultContent += `${chalk.yellow.bold("Skipped:")}\n`;
+    skipped.forEach((name) => {
+      resultContent += `  • ${chalk.dim(name)}\n`;
+    });
+  }
+
+  if (failed.length > 0) {
+    if (resultContent) resultContent += "\n";
+    resultContent += `${chalk.red.bold("Failed:")}\n`;
+    failed.forEach((name) => {
+      resultContent += `  • ${chalk.bold(name)}\n`;
+    });
+  }
+
+  if (resultContent) {
+    const borderColor =
+      added.length > 0 ? "green" : failed.length > 0 ? "red" : "yellow";
+    await displayBox(resultContent, "📦 Module Addition Results", {
+      padding: 1,
+      borderColor,
+    });
+  }
+}
 
 export async function projectModulesAddCommand(
   modules: string[],
@@ -69,6 +158,8 @@ export async function projectModulesAddCommand(
   registerPackageDownloader(registry, { fs, exec: ExecuteCMD });
   registerGitDownloader(registry, { fs, exec: ExecuteCMD });
 
+  const failed: string[] = [];
+
   let sources = await Promise.all(
     modules.map((module) => {
       const modulePath =
@@ -89,6 +180,7 @@ export async function projectModulesAddCommand(
               ? err
               : `Failed to add module "${module}": ${String(err)}`,
           );
+          failed.push(module);
           return null;
         });
     }),
@@ -127,57 +219,35 @@ export async function projectModulesAddCommand(
   await cache.load();
 
   // Prepare module loading tasks for parallel execution
-  const moduleLoadingTasks = sources.map(async (source) => {
-    if (!source) return null;
+  const moduleLoadingTasks = sources.map(
+    async (source): Promise<ModuleLoadResult | null> => {
+      if (!source) return null;
 
-    const [moduleName, moduleConfig] = source;
+      const [moduleName, moduleConfig] = source;
 
-    // Check if module already exists
-    if (antelopeConfig.modules[moduleName]) {
-      return { moduleName, moduleConfig, skipped: true };
-    }
-
-    // Download module to cache if needed
-    if (
-      typeof moduleConfig === "object" &&
-      moduleConfig !== null &&
-      "source" in moduleConfig
-    ) {
-      const loaderIdentifier = registry.getLoaderIdentifier(
-        moduleConfig.source as any,
-      );
-      if (loaderIdentifier) {
-        info(`Downloading module ${chalk.bold(moduleName)} to cache...`);
-        try {
-          const moduleManifests = await registry.load(
-            resolvedProjectPath,
-            cache,
-            {
-              ...moduleConfig.source,
-              id: moduleName,
-            } as any,
-          );
-          if (moduleManifests.length > 0) {
-            const manifest = moduleManifests[0];
-            if (manifest.manifest.antelopeJs?.defaultConfig) {
-              moduleConfig.config = manifest.manifest.antelopeJs.defaultConfig;
-            }
-          }
-          success(
-            `Successfully downloaded module ${chalk.bold(moduleName)} to cache`,
-          );
-        } catch (error: unknown) {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
-          warning(
-            `Failed to download module ${chalk.bold(moduleName)} to cache: ${errorMessage}`,
-          );
-        }
+      // Check if module already exists
+      if (antelopeConfig.modules[moduleName]) {
+        return { moduleName, moduleConfig, skipped: true, failed: false };
       }
-    }
 
-    return { moduleName, moduleConfig, skipped: false };
-  });
+      // Download module to cache if needed
+      const downloadable =
+        typeof moduleConfig === "object" &&
+        moduleConfig !== null &&
+        "source" in moduleConfig;
+      const downloaded = downloadable
+        ? await downloadModuleToCache(
+            registry,
+            cache,
+            resolvedProjectPath,
+            moduleName,
+            moduleConfig,
+          )
+        : true;
+
+      return { moduleName, moduleConfig, skipped: false, failed: !downloaded };
+    },
+  );
 
   // Execute all module loading tasks in parallel
   const moduleResults = await Promise.all(moduleLoadingTasks);
@@ -186,9 +256,16 @@ export async function projectModulesAddCommand(
   for (const result of moduleResults) {
     if (!result) continue;
 
-    const { moduleName, moduleConfig, skipped: wasSkipped } = result;
+    const {
+      moduleName,
+      moduleConfig,
+      skipped: wasSkipped,
+      failed: hasFailed,
+    } = result;
 
-    if (wasSkipped) {
+    if (hasFailed) {
+      failed.push(moduleName);
+    } else if (wasSkipped) {
       skipped.push(moduleName);
     } else {
       env.modules[moduleName] = moduleConfig;
@@ -196,33 +273,15 @@ export async function projectModulesAddCommand(
     }
   }
 
+  if (failed.length > 0) {
+    process.exitCode = 1;
+  }
+
   // Save the updated config
   await writeConfig(resolvedProjectPath, config);
 
   // Show results
-  let resultContent = "";
-
-  if (added.length > 0) {
-    resultContent += `${chalk.green.bold("Successfully added:")}\n`;
-    added.forEach((name) => {
-      resultContent += `  • ${chalk.bold(name)}\n`;
-    });
-  }
-
-  if (skipped.length > 0) {
-    if (resultContent) resultContent += "\n";
-    resultContent += `${chalk.yellow.bold("Skipped:")}\n`;
-    skipped.forEach((name) => {
-      resultContent += `  • ${chalk.dim(name)}\n`;
-    });
-  }
-
-  if (resultContent) {
-    await displayBox(resultContent, "📦 Module Addition Results", {
-      padding: 1,
-      borderColor: added.length > 0 ? "green" : "yellow",
-    });
-  }
+  await displayAddResults(added, skipped, failed);
 }
 
 export default function () {
@@ -255,21 +314,20 @@ handlers.set("package", async (module) => {
     m,
     `Invalid npm module format: '${module}'. Use <name>@<version>, <name>version or <name>`,
   );
-  let [, name, version] = m;
-  if (!version) {
-    const result = await ExecuteCMD(`npm view ${name} version`, {});
-    if (result.code !== 0) {
-      throw new Error(`Failed to fetch version: ${result.stderr}`);
-    }
-    version = parsePackageInfoOutput(result.stdout);
+  const [, name, version] = m;
+  if (version) {
+    await validateVersionSpec(name, version);
   }
+  const resolvedVersion = version
+    ? version
+    : toFloatingSpec(await fetchLatestVersion(name));
   return [
     name,
     {
       source: {
         type: "package",
         package: name,
-        version: version,
+        version: resolvedVersion,
       },
     },
   ];

--- a/src/core/cli/commands/project/modules/add.ts
+++ b/src/core/cli/commands/project/modules/add.ts
@@ -47,6 +47,12 @@ interface ModuleLoadResult {
   failed: boolean;
 }
 
+export interface AddCommandResult {
+  added: string[];
+  skipped: string[];
+  failed: string[];
+}
+
 async function downloadModuleToCache(
   registry: DownloaderRegistry,
   cache: ModuleCache,
@@ -128,7 +134,7 @@ async function displayAddResults(
 export async function projectModulesAddCommand(
   modules: string[],
   options: AddOptions,
-) {
+): Promise<AddCommandResult | undefined> {
   console.log(""); // Add spacing for better readability
   info(`Adding modules to your project...`);
 
@@ -278,10 +284,14 @@ export async function projectModulesAddCommand(
   }
 
   // Save the updated config
-  await writeConfig(resolvedProjectPath, config);
+  if (added.length > 0) {
+    await writeConfig(resolvedProjectPath, config);
+  }
 
   // Show results
   await displayAddResults(added, skipped, failed);
+
+  return { added, skipped, failed };
 }
 
 export default function () {
@@ -303,7 +313,9 @@ export default function () {
         "Environment to add modules to",
       ).env("ANTELOPEJS_LAUNCH_ENV"),
     )
-    .action(projectModulesAddCommand);
+    .action(async (modules: string[], options: AddOptions) => {
+      await projectModulesAddCommand(modules, options);
+    });
 }
 
 // Module source handlers

--- a/src/core/cli/commands/project/modules/install.ts
+++ b/src/core/cli/commands/project/modules/install.ts
@@ -1,4 +1,8 @@
 import path from "node:path";
+import type {
+  ModuleSource,
+  ModuleSourcePackage,
+} from "@antelopejs/interface-core/config";
 import chalk from "chalk";
 import { Command, Option } from "commander";
 import inquirer from "inquirer";
@@ -35,6 +39,19 @@ interface InstallOptions {
 
 interface ConfigAnalyze {
   unresolvedImports: string[];
+}
+
+const PACKAGE_SOURCE_TYPE = "package";
+
+export function resolveInstallIdentifier(
+  source: ModuleSource,
+  identifier: string,
+): string {
+  if (source.type !== PACKAGE_SOURCE_TYPE) {
+    return identifier;
+  }
+  const version = (source as ModuleSourcePackage).version;
+  return version ? `${identifier}@${version}` : identifier;
 }
 
 // Interface for tracking modules to be installed
@@ -248,7 +265,10 @@ export default function () {
 
                   // Add to modules to install
                   modulesToInstall.push({
-                    loaderIdentifier,
+                    loaderIdentifier: resolveInstallIdentifier(
+                      source as ModuleSource,
+                      loaderIdentifier,
+                    ),
                     mode,
                     moduleName,
                     imports: [imp],

--- a/src/core/cli/commands/project/modules/install.ts
+++ b/src/core/cli/commands/project/modules/install.ts
@@ -348,6 +348,7 @@ export default function () {
             error(
               chalk.red`Failed to install modules for environment ${env} (mode: ${mode}): ${err}`,
             );
+            process.exitCode = 1;
           }
         }
         await terminalDisplay.stopSpinner(

--- a/src/core/cli/commands/project/modules/install.ts
+++ b/src/core/cli/commands/project/modules/install.ts
@@ -331,9 +331,12 @@ export default function () {
               env,
             });
 
-            if (result && result.failed.length > 0) {
+            const failedCount = result
+              ? result.failed.length
+              : loaderIdentifiers.length;
+            if (failedCount > 0) {
               error(
-                chalk.red`Failed to install ${result.failed.length} module(s) for environment ${env} (mode: ${mode})`,
+                chalk.red`Failed to install ${failedCount} module(s) for environment ${env} (mode: ${mode})`,
               );
               process.exitCode = 1;
             } else {

--- a/src/core/cli/commands/project/modules/install.ts
+++ b/src/core/cli/commands/project/modules/install.ts
@@ -325,15 +325,22 @@ export default function () {
           );
 
           try {
-            await projectModulesAddCommand(loaderIdentifiers, {
+            const result = await projectModulesAddCommand(loaderIdentifiers, {
               mode,
               project: options.project,
               env,
             });
 
-            success(
-              chalk.green`Successfully installed modules for environment ${env} (mode: ${mode})`,
-            );
+            if (result && result.failed.length > 0) {
+              error(
+                chalk.red`Failed to install ${result.failed.length} module(s) for environment ${env} (mode: ${mode})`,
+              );
+              process.exitCode = 1;
+            } else {
+              success(
+                chalk.green`Successfully installed modules for environment ${env} (mode: ${mode})`,
+              );
+            }
           } catch (err) {
             error(
               chalk.red`Failed to install modules for environment ${env} (mode: ${mode}): ${err}`,

--- a/src/core/version-checker.ts
+++ b/src/core/version-checker.ts
@@ -13,6 +13,8 @@ export interface OutdatedModule {
 
 const NPM_VIEW_COMMAND = "npm view";
 const VERSION_ARGUMENT = "version";
+const DIST_TAGS_ARGUMENT = "dist-tags --json";
+const CARET_PREFIX = "^";
 const UPDATE_COMMAND = "ajs project modules update";
 const SLOW_CHECK_THRESHOLD_MS = 15_000;
 const MAX_REASON_LENGTH = 200;
@@ -35,11 +37,51 @@ export function bumpVersionSpec(currentSpec: string, latest: string): string {
   return `${prefix}${latest}`;
 }
 
+export function toFloatingSpec(version: string): string {
+  return `${CARET_PREFIX}${version}`;
+}
+
+export async function fetchDistTags(
+  packageName: string,
+): Promise<Record<string, string>> {
+  const result = await ExecuteCMD(
+    `${NPM_VIEW_COMMAND} ${packageName} ${DIST_TAGS_ARGUMENT}`,
+    {},
+  );
+  if (result.code !== 0) {
+    throw new Error(
+      `Failed to fetch dist-tags of ${packageName}: ${result.stderr}`,
+    );
+  }
+  return JSON.parse(result.stdout) as Record<string, string>;
+}
+
+export async function validateVersionSpec(
+  packageName: string,
+  spec: string,
+): Promise<void> {
+  if (validRange(spec) !== null) {
+    return;
+  }
+  const distTags = await fetchDistTags(packageName);
+  if (spec in distTags) {
+    return;
+  }
+  throw new Error(
+    `'${spec}' is neither a valid semver range nor a dist-tag of '${packageName}'`,
+  );
+}
+
 export async function fetchLatestVersion(packageName: string): Promise<string> {
   const result = await ExecuteCMD(
     `${NPM_VIEW_COMMAND} ${packageName} ${VERSION_ARGUMENT}`,
     {},
   );
+  if (result.code !== 0) {
+    throw new Error(
+      `Failed to fetch version of ${packageName}: ${result.stderr}`,
+    );
+  }
   return parsePackageInfoOutput(result.stdout);
 }
 

--- a/test/core/cli/commands/project/modules.behavior.test.ts
+++ b/test/core/cli/commands/project/modules.behavior.test.ts
@@ -243,7 +243,7 @@ describe("project modules behavior", () => {
     expect(successStub.called).to.equal(true);
   });
 
-  it("warns when download fails with non-error", async () => {
+  it("errors and skips module when download fails with non-error", async () => {
     const config: any = { name: "proj", modules: {} };
     sinon.stub(common, "readConfig").resolves(config);
     sinon.stub(ConfigLoader.prototype, "load").resolves({ modules: {} } as any);
@@ -256,19 +256,21 @@ describe("project modules behavior", () => {
       .callsFake(() => Promise.reject("boom"));
     sinon.stub(common, "writeConfig").resolves();
 
-    const warnStub = sinon.stub(cliUi, "warning");
+    const errorStub = sinon.stub(cliUi, "error");
     sinon.stub(cliUi, "info");
     sinon.stub(cliUi, "success");
-    sinon.stub(cliUi, "error");
+    sinon.stub(cliUi, "warning");
     sinon.stub(cliUi, "displayBox").resolves();
 
     await projectModulesAddCommand(["pkg@1.0.0"], {
       mode: "package",
       project: "/tmp/project",
     });
-    expect(warnStub.called).to.equal(true);
-    const warningMsg = warnStub.firstCall.args[0] as string;
-    expect(warningMsg).to.include("boom");
+    expect(errorStub.called).to.equal(true);
+    const errorMsg = errorStub.firstCall.args[0] as string;
+    expect(errorMsg).to.include("boom");
+    expect(config.modules).to.not.have.property("pkg");
+    expect(process.exitCode).to.equal(1);
   });
 
   it("reports handler rejection with non-error", async () => {
@@ -302,7 +304,7 @@ describe("project modules behavior", () => {
     expect(errorMsg).to.include("boom");
   });
 
-  it("warns when download fails after loader identifier resolves", async () => {
+  it("errors and skips module when download fails after loader identifier resolves", async () => {
     const config: any = { name: "proj", modules: {} };
     sinon.stub(common, "readConfig").resolves(config);
     sinon.stub(common, "writeConfig").resolves();
@@ -316,10 +318,10 @@ describe("project modules behavior", () => {
         });
       });
 
-    const warnStub = sinon.stub(cliUi, "warning");
+    const errorStub = sinon.stub(cliUi, "error");
     sinon.stub(cliUi, "info");
     sinon.stub(cliUi, "success");
-    sinon.stub(cliUi, "error");
+    sinon.stub(cliUi, "warning");
     sinon.stub(cliUi, "displayBox").resolves();
 
     const originalHandler = handlers.get("local");
@@ -344,7 +346,9 @@ describe("project modules behavior", () => {
       }
     }
 
-    expect(warnStub.called).to.equal(true);
+    expect(errorStub.called).to.equal(true);
+    expect(config.modules).to.not.have.property("localmod");
+    expect(process.exitCode).to.equal(1);
   });
 
   it("handles handler errors and initializes env modules", async () => {
@@ -385,7 +389,7 @@ describe("project modules behavior", () => {
     expect(infoCalls.some((msg) => msg.includes(expectedPath))).to.equal(true);
   });
 
-  it("warns when download to cache fails but still adds module", async () => {
+  it("does not add module when download to cache fails", async () => {
     const config: any = { name: "proj", modules: {} };
     sinon.stub(common, "readConfig").resolves(config);
     const writeStub = sinon.stub(common, "writeConfig").resolves();
@@ -403,10 +407,10 @@ describe("project modules behavior", () => {
       .stub(DownloaderRegistry.prototype, "load")
       .rejects(new Error("download failed"));
 
-    const warnStub = sinon.stub(cliUi, "warning");
+    const errorStub = sinon.stub(cliUi, "error");
     sinon.stub(cliUi, "info");
     sinon.stub(cliUi, "success");
-    sinon.stub(cliUi, "error");
+    sinon.stub(cliUi, "warning");
     sinon.stub(cliUi, "displayBox").resolves();
 
     await projectModulesAddCommand(["pkg"], {
@@ -414,12 +418,13 @@ describe("project modules behavior", () => {
       project: "/tmp/project",
     });
 
-    expect(warnStub.called).to.equal(true);
+    expect(errorStub.called).to.equal(true);
     expect(writeStub.calledOnce).to.equal(true);
-    expect(config.modules).to.have.property("pkg");
+    expect(config.modules).to.not.have.property("pkg");
+    expect(process.exitCode).to.equal(1);
   });
 
-  it("package handler resolves latest version", async () => {
+  it("package handler resolves latest version as a floating caret range", async () => {
     const execStub = sinon
       .stub(command, "ExecuteCMD")
       .resolves({ code: 0, stdout: "1.2.3", stderr: "" });
@@ -431,7 +436,58 @@ describe("project modules behavior", () => {
 
     expect(execStub.called).to.equal(true);
     expect(name).to.equal("pkg");
-    expect((config as any).source.version).to.equal("1.2.3");
+    expect((config as any).source.version).to.equal("^1.2.3");
+  });
+
+  it("package handler keeps an explicit semver range without registry lookup", async () => {
+    const execStub = sinon.stub(command, "ExecuteCMD");
+    const handler = handlers.get("package")!;
+    const [name, config] = await handler("pkg@^2.0.0", {
+      mode: "package",
+      project: "/tmp/project",
+    } as any);
+
+    expect(execStub.called).to.equal(false);
+    expect(name).to.equal("pkg");
+    expect((config as any).source.version).to.equal("^2.0.0");
+  });
+
+  it("package handler accepts a registry dist-tag", async () => {
+    const execStub = sinon.stub(command, "ExecuteCMD").resolves({
+      code: 0,
+      stdout: '{"latest":"1.0.0","beta":"2.0.0-beta.1"}',
+      stderr: "",
+    });
+    const handler = handlers.get("package")!;
+    const [name, config] = await handler("pkg@beta", {
+      mode: "package",
+      project: "/tmp/project",
+    } as any);
+
+    expect(execStub.firstCall.args[0]).to.include("dist-tags");
+    expect(name).to.equal("pkg");
+    expect((config as any).source.version).to.equal("beta");
+  });
+
+  it("package handler rejects a spec that is neither range nor dist-tag", async () => {
+    sinon.stub(command, "ExecuteCMD").resolves({
+      code: 0,
+      stdout: '{"latest":"1.0.0"}',
+      stderr: "",
+    });
+    const handler = handlers.get("package")!;
+    let caught: unknown;
+    try {
+      await handler("pkg@lastest", {
+        mode: "package",
+        project: "/tmp/project",
+      } as any);
+    } catch (err) {
+      caught = err;
+    }
+    expect(String(caught)).to.include(
+      "neither a valid semver range nor a dist-tag",
+    );
   });
 
   it("package handler throws when version fetch fails", async () => {

--- a/test/core/cli/commands/project/modules.behavior.test.ts
+++ b/test/core/cli/commands/project/modules.behavior.test.ts
@@ -382,7 +382,7 @@ describe("project modules behavior", () => {
 
     expect(errorStub.called).to.equal(true);
     expect(config.modules).to.be.an("object");
-    expect(writeStub.calledOnce).to.equal(true);
+    expect(writeStub.called).to.equal(false);
 
     const expectedPath = "/tmp/project/modules/modA";
     const infoCalls = infoStub.getCalls().map((call) => call.args[0] as string);
@@ -413,14 +413,15 @@ describe("project modules behavior", () => {
     sinon.stub(cliUi, "warning");
     sinon.stub(cliUi, "displayBox").resolves();
 
-    await projectModulesAddCommand(["pkg"], {
+    const result = await projectModulesAddCommand(["pkg"], {
       mode: "package",
       project: "/tmp/project",
     });
 
     expect(errorStub.called).to.equal(true);
-    expect(writeStub.calledOnce).to.equal(true);
+    expect(writeStub.called).to.equal(false);
     expect(config.modules).to.not.have.property("pkg");
+    expect(result?.failed).to.deep.equal(["pkg"]);
     expect(process.exitCode).to.equal(1);
   });
 

--- a/test/core/cli/commands/project/modules/install.behavior.test.ts
+++ b/test/core/cli/commands/project/modules/install.behavior.test.ts
@@ -785,4 +785,96 @@ describe("project modules install behavior", () => {
 
     expect(errorStub.called).to.equal(true);
   });
+
+  it("reports failure when add resolves with failed modules", async () => {
+    const baseConfig: any = {
+      name: "proj",
+      modules: {
+        app: { source: { type: "package", package: "app", version: "1.0.0" } },
+      },
+    };
+
+    sinon.stub(common, "readConfig").resolves(baseConfig);
+    sinon
+      .stub(common, "readUserConfig")
+      .resolves({ git: common.DEFAULT_GIT_REPO });
+    sinon.stub(common, "displayNonDefaultGitWarning").resolves();
+    sinon.stub(gitOps, "loadManifestFromGit").resolves({
+      interfaces: { [ifaceName]: "test-iface", [ifaceName2]: "test-iface2" },
+      starredInterfaces: [],
+      templates: [],
+    });
+
+    sinon.stub(ConfigLoader.prototype, "load").resolves({
+      modules: {
+        app: { source: { type: "package", package: "app", version: "1.0.0" } },
+      },
+    } as any);
+
+    sinon.stub(ModuleCache.prototype, "load").resolves();
+
+    const fakeManifest = {
+      manifest: { dependencies: { [ifaceName]: "^1.0.0" } },
+      implements: [],
+      folder: tempModuleDir,
+    };
+    sinon
+      .stub(DownloaderRegistry.prototype, "load")
+      .resolves([fakeManifest as any]);
+    sinon
+      .stub(DownloaderRegistry.prototype, "getLoaderIdentifier")
+      .returns("pkg:module");
+
+    sinon.stub(ModuleManifest, "create").rejects(new Error("skip core"));
+
+    sinon.stub(gitOps, "loadInterfaceFromGit").resolves({
+      name: "iface",
+      manifest: {
+        description: "iface",
+        versions: ["1.0.0"],
+        files: {},
+        dependencies: {},
+        modules: [
+          {
+            name: "modA",
+            source: { type: "package", package: "modA", version: "1.0.0" },
+          },
+        ],
+      },
+    } as any);
+
+    sinon.stub(inquirer, "prompt").resolves({ moduleName: "modA" });
+
+    const addStub = sinon.stub(
+      projectModulesAddModule,
+      "projectModulesAddCommand",
+    );
+    addStub.resolves({ added: [], skipped: [], failed: ["modA"] });
+
+    const errorStub = sinon.stub(cliUi, "error");
+    const successStub = sinon.stub(cliUi, "success");
+    sinon.stub(cliUi, "info");
+    sinon.stub(cliUi, "warning");
+
+    sinon.stub(terminalDisplay, "startSpinner").resolves();
+    sinon.stub(terminalDisplay, "stopSpinner").resolves();
+    sinon.stub(terminalDisplay, "failSpinner").resolves();
+
+    const cmd = cmdInstall();
+    await cmd.parseAsync(["node", "test", "--project", "/tmp/project"]);
+
+    const errorMessages = errorStub
+      .getCalls()
+      .map((call) => String(call.args[0]));
+    expect(
+      errorMessages.some((msg) => msg.includes("Failed to install 1 module")),
+    ).to.equal(true);
+    const successMessages = successStub
+      .getCalls()
+      .map((call) => String(call.args[0]));
+    expect(
+      successMessages.some((msg) => msg.includes("Successfully installed")),
+    ).to.equal(false);
+    expect(process.exitCode).to.equal(1);
+  });
 });

--- a/test/core/cli/commands/project/modules/install.behavior.test.ts
+++ b/test/core/cli/commands/project/modules/install.behavior.test.ts
@@ -6,7 +6,9 @@ import inquirer from "inquirer";
 import sinon from "sinon";
 import * as cliUi from "../../../../../../src/core/cli/cli-ui";
 import * as projectModulesAddModule from "../../../../../../src/core/cli/commands/project/modules/add";
-import cmdInstall from "../../../../../../src/core/cli/commands/project/modules/install";
+import cmdInstall, {
+  resolveInstallIdentifier,
+} from "../../../../../../src/core/cli/commands/project/modules/install";
 import * as common from "../../../../../../src/core/cli/common";
 import * as gitOps from "../../../../../../src/core/cli/git-operations";
 import { terminalDisplay } from "../../../../../../src/core/cli/terminal-display";
@@ -48,6 +50,32 @@ describe("project modules install behavior", () => {
   afterEach(() => {
     sinon.restore();
     process.exitCode = undefined;
+  });
+
+  describe("resolveInstallIdentifier", () => {
+    it("appends the manifest version to package identifiers", () => {
+      const source: any = {
+        type: "package",
+        package: "modA",
+        version: "^1.0.0",
+      };
+      expect(resolveInstallIdentifier(source, "modA")).to.equal("modA@^1.0.0");
+    });
+
+    it("keeps package identifiers unchanged when the manifest omits the version", () => {
+      const source: any = { type: "package", package: "modA" };
+      expect(resolveInstallIdentifier(source, "modA")).to.equal("modA");
+    });
+
+    it("keeps non-package identifiers unchanged", () => {
+      const source: any = {
+        type: "git",
+        remote: "https://example.com/repo.git",
+      };
+      expect(
+        resolveInstallIdentifier(source, "https://example.com/repo.git"),
+      ).to.equal("https://example.com/repo.git");
+    });
   });
 
   it("errors when project config is missing", async () => {
@@ -320,6 +348,7 @@ describe("project modules install behavior", () => {
     await cmd.parseAsync(["node", "test", "--project", "/tmp/project"]);
 
     expect(addStub.called).to.equal(true);
+    expect(addStub.firstCall.args[0]).to.deep.equal(["pkg:module@1.0.0"]);
   });
 
   it("installs module and uses singular label", async () => {

--- a/test/core/cli/commands/project/modules/install.behavior.test.ts
+++ b/test/core/cli/commands/project/modules/install.behavior.test.ts
@@ -784,6 +784,7 @@ describe("project modules install behavior", () => {
     await cmd.parseAsync(["node", "test", "--project", "/tmp/project"]);
 
     expect(errorStub.called).to.equal(true);
+    expect(process.exitCode).to.equal(1);
   });
 
   it("reports failure when add resolves with failed modules", async () => {

--- a/test/core/version-checker.test.ts
+++ b/test/core/version-checker.test.ts
@@ -10,8 +10,11 @@ import type { ExpandedModuleConfig } from "../../src/core/config/config-parser";
 import {
   bumpVersionSpec,
   checkOutdatedModules,
+  fetchDistTags,
   fetchLatestVersion,
   isUpToDate,
+  toFloatingSpec,
+  validateVersionSpec,
   warnOutdatedModules,
 } from "../../src/core/version-checker";
 
@@ -323,6 +326,78 @@ describe("version-checker", () => {
       expect(bumpVersionSpec("^1.0.0", "2.0.0")).to.equal("^2.0.0");
       expect(bumpVersionSpec("~1.0.0", "1.2.0")).to.equal("~1.2.0");
       expect(bumpVersionSpec("1.0.0", "2.0.0")).to.equal("2.0.0");
+    });
+  });
+
+  describe("toFloatingSpec", () => {
+    it("prefixes the version with a caret", () => {
+      expect(toFloatingSpec("1.2.3")).to.equal("^1.2.3");
+    });
+  });
+
+  describe("fetchDistTags", () => {
+    it("parses dist-tags JSON output", async () => {
+      sinon.stub(command, "ExecuteCMD").resolves({
+        code: 0,
+        stdout: '{"latest":"1.0.0","next":"2.0.0-rc.1"}',
+        stderr: "",
+      });
+
+      const tags = await fetchDistTags("some-package");
+
+      expect(tags).to.deep.equal({ latest: "1.0.0", next: "2.0.0-rc.1" });
+    });
+
+    it("throws when npm view exits with a non-zero code", async () => {
+      sinon.stub(command, "ExecuteCMD").resolves({
+        code: 1,
+        stdout: "",
+        stderr: "not found",
+      });
+
+      try {
+        await fetchDistTags("some-package");
+        expect.fail("expected fetchDistTags to throw");
+      } catch (err) {
+        expect(String(err)).to.include("not found");
+      }
+    });
+  });
+
+  describe("validateVersionSpec", () => {
+    it("accepts a valid semver range without registry lookup", async () => {
+      const execStub = sinon.stub(command, "ExecuteCMD");
+
+      await validateVersionSpec("some-package", "^1.2.0");
+
+      expect(execStub.called).to.equal(false);
+    });
+
+    it("accepts an existing dist-tag", async () => {
+      sinon.stub(command, "ExecuteCMD").resolves({
+        code: 0,
+        stdout: '{"latest":"1.0.0","beta":"2.0.0-beta.1"}',
+        stderr: "",
+      });
+
+      await validateVersionSpec("some-package", "beta");
+    });
+
+    it("rejects a spec that is neither range nor dist-tag", async () => {
+      sinon.stub(command, "ExecuteCMD").resolves({
+        code: 0,
+        stdout: '{"latest":"1.0.0"}',
+        stderr: "",
+      });
+
+      try {
+        await validateVersionSpec("some-package", "lastest");
+        expect.fail("expected validateVersionSpec to throw");
+      } catch (err) {
+        expect(String(err)).to.include(
+          "neither a valid semver range nor a dist-tag",
+        );
+      }
     });
   });
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A — follow-up to #88.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

#88 made the package downloader resolve semver ranges and dist-tags on every run, but the CLI commands never took advantage of it: `modules add` still pinned exact versions, wrote unvalidated specs verbatim, and kept modules in the configuration even when their download failed.

- `modules add <name>` without a version now writes `^<latest>` instead of an exact pin, so floating ranges become the default experience. Pinning stays available via an explicit `<name>@<version>`.
- Explicit specs are validated before being written: semver ranges pass without network access, other values must match a registry dist-tag (`npm view <name> dist-tags`), and anything else fails immediately instead of breaking the next `project run`.
- A module whose download to cache fails (resolution or network) is no longer added to the configuration; it is reported in a `Failed` section and the command exits with code 1.
- `modules install` now carries the version declared by the interface manifest into the identifier passed to `modules add` (previously the manifest version was silently dropped and latest was resolved instead). The manifest stays authoritative; when it omits a version, the `^latest` default applies.
- `fetchLatestVersion`/`fetchDistTags` reject on non-zero exit codes from injected runners.

Deliberate status quo (discussed and kept as-is): `modules update` still pins non-caret/tilde ranges (`1.x`, `>=1 <2`) to an exact version when outdated, `^`/`~` prefixes remain preserved across major bumps, and `modules list` keeps showing the raw spec.

Breaking change note: `modules add` now fails (exit code 1, module not written) on invalid specs or failed downloads where it previously warned and wrote the module anyway.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [ ] I have run `ajs module exports generate` and committed any updated interface files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates package module add and install behavior around floating version specs. The main changes are:

- `modules add` writes caret ranges for unversioned package installs.
- Explicit package specs are validated as semver ranges or registry dist-tags.
- Failed package downloads are reported without writing failed modules to config.
- `modules install` preserves package versions declared by interface manifests.
- Version-checker helpers now fail on non-zero npm command results.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.



<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/core/cli/commands/project/modules/add.ts | Adds structured add results, package spec validation, floating default versions, and skip-on-failure config writes. |
| src/core/cli/commands/project/modules/install.ts | Passes manifest package versions into add and treats failed add results as install failures. |
| src/core/version-checker.ts | Adds helpers for caret specs, dist-tag validation, and npm command failure handling. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/core/cli/commands/project/modules/install.ts`, line 347-351 ([link](https://github.com/antelopejs/antelopejs/blob/314ff4897255b2c6bf86ab73fcd379614ac91a7c/src/core/cli/commands/project/modules/install.ts#L347-L351)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Thrown Add Failures Succeed** When `projectModulesAddCommand` rejects instead of returning a result, this catch block logs the failure but leaves `process.exitCode` unchanged. A real add failure from an unexpected write, config, or runtime error can therefore continue through the install flow and exit successfully. Set the exit code on this path too so thrown add failures fail the command.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/core/cli/commands/project/modules/install.ts
   Line: 347-351

   Comment:
   **Thrown Add Failures Succeed** When `projectModulesAddCommand` rejects instead of returning a result, this catch block logs the failure but leaves `process.exitCode` unchanged. A real add failure from an unexpected write, config, or runtime error can therefore continue through the install flow and exit successfully. Set the exit code on this path too so thrown add failures fail the command.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix(cli): exit non-zero when modules ins..."](https://github.com/antelopejs/antelopejs/commit/6217f6de3267bac8db6b7b05ed9fafce1fbddb10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43948953)</sub>

<!-- /greptile_comment -->