### PR TITLE
chore(deps): floating semver range for @antelopejs/interface-core in playground

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -6,6 +6,6 @@
   },
   "dependencies": {
     "@antelopejs/core": "link:..",
-    "@antelopejs/interface-core": "^0.0.2"
+    "@antelopejs/interface-core": "^0.0.6"
   }
 }

--- a/playground/pnpm-lock.yaml
+++ b/playground/pnpm-lock.yaml
@@ -12,20 +12,20 @@ importers:
         specifier: link:..
         version: link:..
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.6
+        version: 0.0.6
 
 packages:
 
-  '@antelopejs/interface-core@0.0.2':
-    resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
+  '@antelopejs/interface-core@0.0.6':
+    resolution: {integrity: sha512-OMna86iT/ylL6wJl6FCPw9ieddULXGs4jTmeiDBNEXYQ9acnVXjS/+SaN0UR0h7oY7WTD9VwKXVwG95qjNIA1w==}
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.2':
+  '@antelopejs/interface-core@0.0.6':
     dependencies:
       reflect-metadata: 0.2.2
 


### PR DESCRIPTION
## Summary

Aligns the playground's `@antelopejs/interface-core` dependency with the floating semver-range convention (supported since @antelopejs/core 1.4.5) and bumps it to the latest published version.

- `playground/package.json`: `@antelopejs/interface-core` `^0.0.2` → `^0.0.6` (latest published)
- `playground/pnpm-lock.yaml`: refreshed accordingly

The root `package.json` already pins `@antelopejs/interface-core` at `^0.0.6`, so no change was needed there. `@antelopejs/core: link:..` in the playground is intentionally left untouched. `playground/antelope.config.ts` only references `type: "local"` modules, so no config change applies.

## Verification

- `pnpm build` — passes
- `pnpm test:unit` — passes (538 tests)
- `pnpm test:playground` — end-to-end, all 3 phases pass with interface-core 0.0.6

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `@antelopejs/interface-core` in the playground from `^0.0.2` to `^0.0.6`, aligning it with the version already pinned in the root `package.json`. The lockfile is refreshed accordingly with the updated integrity hash.

- `playground/package.json`: specifier updated from `^0.0.2` to `^0.0.6`, matching the root dependency.
- `playground/pnpm-lock.yaml`: resolved version and integrity hash updated from `0.0.2` to `0.0.6`; the `reflect-metadata` snapshot is preserved unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is limited to the playground directory, aligning a dev-only dependency version with what the root workspace already declares.

The playground is a non-published dev environment, and the only change is bumping @antelopejs/interface-core from 0.0.2 to 0.0.6 to match the root package.json. The lockfile integrity hash is refreshed and consistent. The PR description confirms tests pass.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| playground/package.json | Single-line bump of `@antelopejs/interface-core` from `^0.0.2` to `^0.0.6`, matching the root package.json; no other changes. |
| playground/pnpm-lock.yaml | Lockfile updated to resolve `@antelopejs/interface-core` at `0.0.6` with a refreshed integrity hash; `reflect-metadata` snapshot is unchanged. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["root/package.json\n@antelopejs/interface-core: ^0.0.6"] -->|"already aligned"| C["NPM registry\n@antelopejs/interface-core@0.0.6"]
    B["playground/package.json\n@antelopejs/interface-core: ^0.0.2 → ^0.0.6"] -->|"this PR"| C
    C --> D["playground/pnpm-lock.yaml\nresolved: 0.0.6\nintegrity: sha512-OMna86..."]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["root/package.json\n@antelopejs/interface-core: ^0.0.6"] -->|"already aligned"| C["NPM registry\n@antelopejs/interface-core@0.0.6"]
    B["playground/package.json\n@antelopejs/interface-core: ^0.0.2 → ^0.0.6"] -->|"this PR"| C
    C --> D["playground/pnpm-lock.yaml\nresolved: 0.0.6\nintegrity: sha512-OMna86..."]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump @antelopejs/interface-..."](https://github.com/antelopejs/antelopejs/commit/32944a182b1ad999372136f0f83e6ea0f9644a08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44402433)</sub>

<!-- /greptile_comment -->