### PR TITLE
fix(runtime): provide the core modules interface when launching from a build artifact

### DIFF
--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -439,8 +439,10 @@ export class ModuleManager {
     interfaceSources: Map<string, Module>,
   ): void {
     const dependencies = module.manifest.manifest.dependencies ?? {};
+    const optionalDependencies =
+      module.manifest.manifest.optionalDependencies ?? {};
     for (const [iface, provider] of interfaceSources) {
-      if (iface in dependencies) {
+      if (iface in dependencies || iface in optionalDependencies) {
         associations.set(iface, provider);
         connections.set(iface, [{ module: provider.id }]);
       }

--- a/src/core/runtime/build-runtime.ts
+++ b/src/core/runtime/build-runtime.ts
@@ -187,3 +187,21 @@ export async function writeProjectBuildArtifact(
 
   await writeBuildArtifact(normalizedConfig.projectFolder, artifact, fs);
 }
+
+const loaderChannel = new Logging.Channel("loader");
+
+/**
+ * Report when a build artifact produced for one environment is being started
+ * under a different runtime environment.
+ */
+export function logEnvironmentMismatch(
+  startEnv: string,
+  buildEnv: string,
+): void {
+  if (startEnv === buildEnv) {
+    return;
+  }
+  loaderChannel.Info(
+    `Starting build created for environment '${buildEnv}' with runtime env '${startEnv}'`,
+  );
+}

--- a/src/core/runtime/launch-sequence.ts
+++ b/src/core/runtime/launch-sequence.ts
@@ -1,0 +1,181 @@
+import path from "node:path";
+import { setupAntelopeProjectLogging } from "../../logging";
+import type { LaunchOptions } from "../../types";
+import { NodeFileSystem } from "../filesystem";
+import { ModuleManager } from "../module-manager";
+import { ShutdownManager } from "../shutdown";
+import { checkOutdatedModules, warnOutdatedModules } from "../version-checker";
+import {
+  ensureBuildModulesExist,
+  logEnvironmentMismatch,
+  mapArtifactModuleEntries,
+  readBuildArtifactOrThrow,
+  warnIfBuildIsStale,
+} from "./build-runtime";
+import { registerCoreRuntimeInterface } from "./dev-server-registry";
+import {
+  buildModuleConfigs,
+  constructAndStartModules,
+  createLoaderContext,
+  ensureGraphIsValid,
+  registerCoreInterfaces,
+  registerCoreModuleInterface,
+} from "./module-loading";
+import {
+  applyVerboseChannels,
+  loadProjectConfig,
+  setupProcessHandlers,
+  withRaisedMaxListeners,
+} from "./runtime-bootstrap";
+import type {
+  LoaderConfig,
+  LoaderContext,
+  LoaderContextProvider,
+  ProjectPreparer,
+  StartedProject,
+} from "./runtime-types";
+
+function memoize(create: () => Promise<LoaderContext>): LoaderContextProvider {
+  let pending: Promise<LoaderContext> | undefined;
+  return () => {
+    pending ??= create();
+    return pending;
+  };
+}
+
+function resolveRuntimeLoaderConfig(
+  artifactConfig: LoaderConfig,
+  projectFolder: string,
+): LoaderConfig {
+  const runtimeFolder = path.resolve(projectFolder);
+  const cacheRelativeToBuild = path.relative(
+    artifactConfig.projectFolder,
+    artifactConfig.cacheFolder,
+  );
+  const cacheIsInsideProject =
+    cacheRelativeToBuild !== "" &&
+    !cacheRelativeToBuild.startsWith("..") &&
+    !path.isAbsolute(cacheRelativeToBuild);
+
+  return {
+    projectFolder: runtimeFolder,
+    cacheFolder: cacheIsInsideProject
+      ? path.join(runtimeFolder, cacheRelativeToBuild)
+      : artifactConfig.cacheFolder,
+  };
+}
+
+/**
+ * Prepare a project from its live `antelope.config.ts`, resolving and
+ * downloading module sources at launch time.
+ *
+ * Backs `ajs project run` / `ajs project dev`.
+ */
+export const prepareFromConfig: ProjectPreparer = async (
+  projectFolder,
+  env,
+) => {
+  const { fs, normalizedConfig } = await loadProjectConfig(projectFolder, env);
+  const loadContext = memoize(() => createLoaderContext(normalizedConfig, fs));
+
+  return {
+    fs,
+    dev: true,
+    logging: normalizedConfig.logging,
+    loadContext,
+    verify: async () => {
+      warnOutdatedModules(await checkOutdatedModules(normalizedConfig.modules));
+    },
+    createEntries: async () =>
+      buildModuleConfigs(normalizedConfig, await loadContext()),
+  };
+};
+
+/**
+ * Prepare a project from a pre-built `.antelope/build/build.json` artifact,
+ * skipping module resolution entirely.
+ *
+ * Backs `ajs project start`.
+ */
+export const prepareFromArtifact: ProjectPreparer = async (
+  projectFolder,
+  env,
+) => {
+  const fs = new NodeFileSystem();
+  const artifact = await readBuildArtifactOrThrow(projectFolder, fs);
+  const loaderConfig = resolveRuntimeLoaderConfig(
+    artifact.config,
+    projectFolder,
+  );
+
+  return {
+    fs,
+    dev: false,
+    logging: artifact.config.logging,
+    loadContext: memoize(() => createLoaderContext(loaderConfig, fs)),
+    verify: async () => {
+      logEnvironmentMismatch(env, artifact.env);
+      await warnIfBuildIsStale(projectFolder, artifact, fs);
+      await ensureBuildModulesExist(artifact, fs);
+    },
+    createEntries: async () => mapArtifactModuleEntries(artifact),
+  };
+};
+
+/**
+ * The boot sequence shared by every way of launching a running project.
+ *
+ * Every step below runs identically no matter where the module set came from;
+ * all variation is supplied by `prepare`, so adding a launch mode means
+ * writing a {@link ProjectPreparer} rather than re-transcribing this order.
+ * `build()` and the test harness stop short of starting modules and keep
+ * their own shorter sequences.
+ *
+ * Callers are responsible for the post-launch phase (shutdown handler
+ * registration, watching, REPL) via the returned {@link StartedProject}.
+ */
+export async function runLaunchSequence(
+  prepare: ProjectPreparer,
+  projectFolder: string,
+  env: string,
+  options: LaunchOptions,
+): Promise<StartedProject> {
+  const shutdownManager = new ShutdownManager();
+  setupProcessHandlers(shutdownManager);
+
+  const project = await prepare(projectFolder, env);
+
+  setupAntelopeProjectLogging(project.logging);
+  applyVerboseChannels(options.verbose);
+
+  await project.verify();
+
+  await registerCoreRuntimeInterface({
+    dev: project.dev,
+    projectPath: projectFolder,
+    env,
+    fs: project.fs,
+    shutdownManager,
+  });
+
+  const manager = await withRaisedMaxListeners(async () => {
+    const moduleManager = new ModuleManager();
+
+    registerCoreModuleInterface(moduleManager, project.loadContext);
+    await registerCoreInterfaces(moduleManager);
+
+    moduleManager.addModules(await project.createEntries());
+
+    ensureGraphIsValid(moduleManager);
+    await constructAndStartModules(moduleManager);
+    return moduleManager;
+  });
+
+  return {
+    manager,
+    dev: project.dev,
+    loadContext: project.loadContext,
+    fs: project.fs,
+    shutdownManager,
+  };
+}

--- a/src/core/runtime/module-loading.ts
+++ b/src/core/runtime/module-loading.ts
@@ -20,7 +20,9 @@ import type { ModuleConfig, ModuleManager } from "../module-manager";
 import { ModuleManifest } from "../module-manifest";
 import { findUnresolvedInterfaces } from "../resolution/interface-resolution";
 import type {
+  LoaderConfig,
   LoaderContext,
+  LoaderContextProvider,
   ModuleManifestEntry,
   ModuleOverrideMap,
   ModuleOverrideRef,
@@ -92,11 +94,10 @@ function toModuleSource(
   return source as ModuleSource;
 }
 
-export async function createLoaderContext(config: {
-  cacheFolder: string;
-  projectFolder: string;
-}): Promise<LoaderContext> {
-  const fs = new NodeFileSystem();
+export async function createLoaderContext(
+  config: LoaderConfig,
+  fs: NodeFileSystem = new NodeFileSystem(),
+): Promise<LoaderContext> {
   const cache = new ModuleCache(config.cacheFolder, fs);
   await cache.load();
 
@@ -116,7 +117,7 @@ export async function createLoaderContext(config: {
 
 export function registerCoreModuleInterface(
   manager: ModuleManager,
-  loaderContext: LoaderContext,
+  loadContext: LoaderContextProvider,
 ): void {
   void coreInterfaceBeta.ImplementInterface(moduleInterfaceBeta, {
     ListModules: async () => manager.listModules(),
@@ -141,6 +142,7 @@ export function registerCoreModuleInterface(
       autostart = false,
     ) => {
       const source = toModuleSource(declaration.source);
+      const loaderContext = await loadContext();
       const manifests = await loaderContext.registry.load(
         loaderContext.projectFolder,
         loaderContext.cache,
@@ -175,7 +177,11 @@ export function registerCoreModuleInterface(
       await manager.getModule(moduleId)?.destroy();
     },
     ReloadModule: async (moduleId: string) => {
-      await reloadLoadedModuleFromSource(manager, loaderContext, moduleId);
+      await reloadLoadedModuleFromSource(
+        manager,
+        await loadContext(),
+        moduleId,
+      );
     },
   });
 }
@@ -378,7 +384,7 @@ export async function loadModuleEntriesForManager(
   const resolvedLoaderContext =
     loaderContext ?? (await createLoaderContext(config));
   if (runtimeInterface) {
-    await registerCoreModuleInterface(manager, resolvedLoaderContext);
+    registerCoreModuleInterface(manager, async () => resolvedLoaderContext);
   }
 
   await registerCoreInterfaces(manager);

--- a/src/core/runtime/runtime-bootstrap.ts
+++ b/src/core/runtime/runtime-bootstrap.ts
@@ -98,6 +98,24 @@ export function normalizeLoadedConfig(
   };
 }
 
+/**
+ * Load and normalize a project's configuration without applying any process
+ * level side effects, so callers stay in control of ordering.
+ */
+export async function loadProjectConfig(
+  projectFolder: string,
+  env: string,
+): Promise<ProjectRuntimeConfig> {
+  const fs = new NodeFileSystem();
+  const loader = new ConfigLoader(fs);
+  const loadedConfig = await loader.load(projectFolder, env);
+
+  return {
+    fs,
+    normalizedConfig: normalizeLoadedConfig(loadedConfig, projectFolder),
+  };
+}
+
 export async function loadProjectRuntimeConfig(
   projectFolder: string,
   env: string,
@@ -106,13 +124,10 @@ export async function loadProjectRuntimeConfig(
 ): Promise<ProjectRuntimeConfig> {
   setupProcessHandlers(shutdownManager);
 
-  const fs = new NodeFileSystem();
-  const loader = new ConfigLoader(fs);
-  const loadedConfig = await loader.load(projectFolder, env);
-  const normalizedConfig = normalizeLoadedConfig(loadedConfig, projectFolder);
+  const config = await loadProjectConfig(projectFolder, env);
 
-  setupAntelopeProjectLogging(loadedConfig.logging);
+  setupAntelopeProjectLogging(config.normalizedConfig.logging);
   applyVerboseChannels(options.verbose);
 
-  return { fs, normalizedConfig };
+  return config;
 }

--- a/src/core/runtime/runtime-types.ts
+++ b/src/core/runtime/runtime-types.ts
@@ -1,10 +1,12 @@
+import type { AntelopeLogging } from "@antelopejs/interface-core/config";
 import type { LoadedConfig } from "../config/config-loader";
 import type { ExpandedModuleConfig } from "../config/config-parser";
 import type { DownloaderRegistry } from "../downloaders/registry";
 import type { NodeFileSystem } from "../filesystem";
 import type { ModuleCache } from "../module-cache";
-import type { ModuleConfig } from "../module-manager";
+import type { ModuleConfig, ModuleManager } from "../module-manager";
 import type { ModuleManifest } from "../module-manifest";
+import type { ShutdownManager } from "../shutdown";
 
 export interface ModuleOverrideRef {
   module: string;
@@ -33,9 +35,48 @@ export interface ProjectRuntimeConfig {
   normalizedConfig: NormalizedLoadedConfig;
 }
 
+export interface LoaderConfig {
+  cacheFolder: string;
+  projectFolder: string;
+}
+
 export interface LoaderContext {
   fs: NodeFileSystem;
   cache: ModuleCache;
   registry: DownloaderRegistry;
   projectFolder: string;
+}
+
+/**
+ * Supplies a loader context on demand.
+ *
+ * Building a context creates the module cache directory on disk, so launch
+ * modes that never resolve modules must not trigger it merely by starting.
+ */
+export type LoaderContextProvider = () => Promise<LoaderContext>;
+
+/**
+ * Everything the shared launch sequence needs that differs between launching
+ * from live configuration and launching from a build artifact.
+ */
+export interface PreparedProject {
+  fs: NodeFileSystem;
+  dev: boolean;
+  logging?: AntelopeLogging;
+  loadContext: LoaderContextProvider;
+  verify: () => Promise<void>;
+  createEntries: () => Promise<ModuleManifestEntry[]>;
+}
+
+export type ProjectPreparer = (
+  projectFolder: string,
+  env: string,
+) => Promise<PreparedProject>;
+
+export interface StartedProject {
+  manager: ModuleManager;
+  dev: boolean;
+  loadContext: LoaderContextProvider;
+  fs: NodeFileSystem;
+  shutdownManager: ShutdownManager;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,41 +1,38 @@
 import { Writable } from "node:stream";
 import { Logging } from "@antelopejs/interface-core/logging";
 import { DEFAULT_ENV, tryFindConfigPath } from "./core/config/config-paths";
-import { NodeFileSystem } from "./core/filesystem";
+import type { NodeFileSystem } from "./core/filesystem";
 import { ModuleManager } from "./core/module-manager";
 import { ReplSession } from "./core/repl/repl-session";
+import { writeProjectBuildArtifact } from "./core/runtime/build-runtime";
 import {
-  ensureBuildModulesExist,
-  mapArtifactModuleEntries,
-  readBuildArtifactOrThrow,
-  warnIfBuildIsStale,
-  writeProjectBuildArtifact,
-} from "./core/runtime/build-runtime";
-import { registerCoreRuntimeInterface } from "./core/runtime/dev-server-registry";
+  prepareFromArtifact,
+  prepareFromConfig,
+  runLaunchSequence,
+} from "./core/runtime/launch-sequence";
 import {
-  constructAndStartModules,
-  createLoaderContext,
   ensureGraphIsValid,
   getWatchDirs,
   loadModuleEntriesForManager,
-  registerCoreInterfaces,
   reloadWatchedModule,
 } from "./core/runtime/module-loading";
 import {
-  applyVerboseChannels,
   loadProjectRuntimeConfig,
-  setupProcessHandlers,
   withRaisedMaxListeners,
 } from "./core/runtime/runtime-bootstrap";
-import type { BuildOptions, LoaderContext } from "./core/runtime/runtime-types";
-import { ShutdownManager } from "./core/shutdown";
+import type {
+  BuildOptions,
+  LoaderContext,
+  ProjectPreparer,
+  StartedProject,
+} from "./core/runtime/runtime-types";
+import type { ShutdownManager } from "./core/shutdown";
 import {
   checkOutdatedModules,
   warnOutdatedModules,
 } from "./core/version-checker";
 import { FileWatcher } from "./core/watch/file-watcher";
 import { HotReload } from "./core/watch/hot-reload";
-import { setupAntelopeProjectLogging } from "./logging";
 import type { LaunchOptions } from "./types";
 
 export { ConfigLoader } from "./core/config/config-loader";
@@ -56,15 +53,10 @@ const INTERACTIVE_PROMPT = "> ";
 const SHUTDOWN_PRIORITY_MODULES = 30;
 const SHUTDOWN_PRIORITY_RESOURCES = 20;
 const SHUTDOWN_PRIORITY_CLEANUP = 10;
+const UNSUPPORTED_ARTIFACT_OPTIONS_WARNING =
+  "Watch and interactive modes are only available when launching from configuration; ignoring them for this build artifact launch.";
 
 Writable.prototype.setMaxListeners(MAX_STREAM_LISTENERS);
-
-interface CoreInitialization {
-  manager: ModuleManager;
-  fs: NodeFileSystem;
-  shutdownManager: ShutdownManager;
-  loaderContext: LoaderContext;
-}
 
 let activeShutdownManager: ShutdownManager | undefined;
 
@@ -139,30 +131,33 @@ async function setupWatching(
 }
 
 async function setupPostLaunchFeatures(
-  manager: ModuleManager,
-  fs: NodeFileSystem,
+  started: StartedProject,
   projectFolder: string,
   env: string,
   options: LaunchOptions,
-  shutdownManager: ShutdownManager,
-  loaderContext: LoaderContext,
 ): Promise<void> {
+  const { manager, shutdownManager } = started;
+
   registerModuleShutdownHandler(shutdownManager, manager);
   registerShutdownCleanup(shutdownManager);
 
-  if (options.watch) {
+  if (!started.dev && (options.watch || options.interactive)) {
+    Logger.Warn(UNSUPPORTED_ARTIFACT_OPTIONS_WARNING);
+  }
+
+  if (started.dev && options.watch) {
     await setupWatching(
       manager,
-      fs,
+      started.fs,
       projectFolder,
       env,
       options,
       shutdownManager,
-      loaderContext,
+      await started.loadContext(),
     );
   }
 
-  if (options.interactive) {
+  if (started.dev && options.interactive) {
     const repl = new ReplSession({ moduleManager: manager });
     repl.start(INTERACTIVE_PROMPT);
 
@@ -174,52 +169,15 @@ async function setupPostLaunchFeatures(
   setActiveShutdownManager(shutdownManager);
 }
 
-async function initializeCore(
+async function startProject(
+  prepare: ProjectPreparer,
   projectFolder: string,
   env: string,
   options: LaunchOptions,
-): Promise<CoreInitialization> {
-  const shutdownManager = new ShutdownManager();
-  const runtimeConfig = await loadProjectRuntimeConfig(
-    projectFolder,
-    env,
-    options,
-    shutdownManager,
-  );
-  const outdated = await checkOutdatedModules(
-    runtimeConfig.normalizedConfig.modules,
-  );
-  warnOutdatedModules(outdated);
-  const loaderContext = await createLoaderContext(
-    runtimeConfig.normalizedConfig,
-  );
-  await registerCoreRuntimeInterface({
-    dev: true,
-    projectPath: projectFolder,
-    env,
-    fs: runtimeConfig.fs,
-    shutdownManager,
-  });
-
-  const manager = await withRaisedMaxListeners(async () => {
-    const moduleManager = new ModuleManager();
-    await loadModuleEntriesForManager(
-      moduleManager,
-      runtimeConfig.normalizedConfig,
-      true,
-      loaderContext,
-    );
-    ensureGraphIsValid(moduleManager);
-    await constructAndStartModules(moduleManager);
-    return moduleManager;
-  });
-
-  return {
-    manager,
-    fs: runtimeConfig.fs,
-    shutdownManager,
-    loaderContext,
-  };
+): Promise<ModuleManager> {
+  const started = await runLaunchSequence(prepare, projectFolder, env, options);
+  await setupPostLaunchFeatures(started, projectFolder, env, options);
+  return started.manager;
 }
 
 let isRestarting = false;
@@ -237,16 +195,7 @@ async function restartProject(
       await activeShutdownManager.shutdown();
     }
 
-    const initialized = await initializeCore(projectFolder, env, options);
-    await setupPostLaunchFeatures(
-      initialized.manager,
-      initialized.fs,
-      projectFolder,
-      env,
-      options,
-      initialized.shutdownManager,
-      initialized.loaderContext,
-    );
+    await startProject(prepareFromConfig, projectFolder, env, options);
   } finally {
     isRestarting = false;
   }
@@ -257,17 +206,7 @@ export async function launch(
   env: string = DEFAULT_ENV,
   options: LaunchOptions = {},
 ): Promise<ModuleManager> {
-  const initialized = await initializeCore(projectFolder, env, options);
-  await setupPostLaunchFeatures(
-    initialized.manager,
-    initialized.fs,
-    projectFolder,
-    env,
-    options,
-    initialized.shutdownManager,
-    initialized.loaderContext,
-  );
-  return initialized.manager;
+  return startProject(prepareFromConfig, projectFolder, env, options);
 }
 
 export async function build(
@@ -302,63 +241,17 @@ export async function build(
   });
 }
 
-function logEnvironmentMismatch(startEnv: string, buildEnv: string): void {
-  if (startEnv === buildEnv) {
-    return;
-  }
-  Logger.Info(
-    `Starting build created for environment '${buildEnv}' with runtime env '${startEnv}'`,
-  );
-}
-
-async function buildManagerFromArtifact(
-  manager: ModuleManager,
-  artifactEntries: ReturnType<typeof mapArtifactModuleEntries>,
-): Promise<void> {
-  await registerCoreInterfaces(manager);
-
-  manager.addModules(artifactEntries);
-  ensureGraphIsValid(manager);
-  await constructAndStartModules(manager);
-}
-
 export async function launchFromBuild(
   projectFolder: string = ".",
   env: string = DEFAULT_ENV,
   options: LaunchOptions = {},
 ): Promise<ModuleManager> {
-  const shutdownManager = new ShutdownManager();
-  setupProcessHandlers(shutdownManager);
-  const fs = new NodeFileSystem();
-  const artifact = await readBuildArtifactOrThrow(projectFolder, fs);
-
-  setupAntelopeProjectLogging(artifact.config.logging);
-  applyVerboseChannels(options.verbose);
-
-  const startEnv = env || DEFAULT_ENV;
-  logEnvironmentMismatch(startEnv, artifact.env);
-
-  await warnIfBuildIsStale(projectFolder, artifact, fs);
-  await ensureBuildModulesExist(artifact, fs);
-  await registerCoreRuntimeInterface({
-    dev: false,
-    projectPath: projectFolder,
-    env: startEnv,
-    fs,
-    shutdownManager,
-  });
-
-  const manager = await withRaisedMaxListeners(async () => {
-    const moduleManager = new ModuleManager();
-    const artifactEntries = mapArtifactModuleEntries(artifact);
-    await buildManagerFromArtifact(moduleManager, artifactEntries);
-    return moduleManager;
-  });
-
-  registerModuleShutdownHandler(shutdownManager, manager);
-  registerShutdownCleanup(shutdownManager);
-  setActiveShutdownManager(shutdownManager);
-  return manager;
+  return startProject(
+    prepareFromArtifact,
+    projectFolder,
+    env || DEFAULT_ENV,
+    options,
+  );
 }
 
 export default launch;

--- a/test/core/module-manager.test.ts
+++ b/test/core/module-manager.test.ts
@@ -115,6 +115,97 @@ describe("ModuleManager", () => {
     expect(tracked).to.deep.equal(["consumer", "provider"]);
   });
 
+  it("connects a provided optional dependency like a required one", async () => {
+    const fs = new InMemoryFileSystem();
+
+    await fs.writeFile(
+      "/provider/package.json",
+      JSON.stringify({ name: "provider", version: "1.0.0" }),
+    );
+    await fs.writeFile(
+      "/consumer/package.json",
+      JSON.stringify({
+        name: "consumer",
+        version: "1.0.0",
+        optionalDependencies: { "core@beta": "^1.0.0" },
+      }),
+    );
+
+    const providerSource: ModuleSourceLocal = {
+      type: "local",
+      path: "/provider",
+    };
+    const providerManifest = await ModuleManifest.create(
+      "/provider",
+      providerSource,
+      "provider",
+      fs,
+    );
+    providerManifest.implements = ["core@beta"];
+
+    const consumerSource: ModuleSourceLocal = {
+      type: "local",
+      path: "/consumer",
+    };
+    const consumerManifest = await ModuleManifest.create(
+      "/consumer",
+      consumerSource,
+      "consumer",
+      fs,
+    );
+
+    const resolver = new Resolver(new PathMapper(() => false));
+    const manager = new ModuleManager({ resolver });
+
+    manager.addModules([
+      { manifest: providerManifest },
+      { manifest: consumerManifest },
+    ]);
+
+    expect(manager.hasResolvedInterface("consumer", "core@beta")).to.equal(
+      true,
+    );
+    expect(
+      internal.interfaceConnections.consumer["core@beta"][0].path,
+    ).to.equal("core@beta");
+  });
+
+  it("does not connect an optional dependency that has no provider", async () => {
+    const fs = new InMemoryFileSystem();
+
+    await fs.writeFile(
+      "/consumer/package.json",
+      JSON.stringify({
+        name: "consumer",
+        version: "1.0.0",
+        optionalDependencies: { "core@beta": "^1.0.0" },
+      }),
+    );
+
+    const consumerSource: ModuleSourceLocal = {
+      type: "local",
+      path: "/consumer",
+    };
+    const consumerManifest = await ModuleManifest.create(
+      "/consumer",
+      consumerSource,
+      "consumer",
+      fs,
+    );
+
+    const resolver = new Resolver(new PathMapper(() => false));
+    const manager = new ModuleManager({ resolver });
+
+    manager.addModules([{ manifest: consumerManifest }]);
+
+    expect(manager.hasResolvedInterface("consumer", "core@beta")).to.equal(
+      false,
+    );
+    expect(internal.interfaceConnections.consumer?.["core@beta"]).to.equal(
+      undefined,
+    );
+  });
+
   it("returns modules by id and honors import overrides", async () => {
     const fs = new InMemoryFileSystem();
 

--- a/test/core/runtime/module-loading.test.ts
+++ b/test/core/runtime/module-loading.test.ts
@@ -284,7 +284,7 @@ describe("runtime module-loading", () => {
       },
     } as any;
 
-    await registerCoreModuleInterface(manager, loaderContext);
+    registerCoreModuleInterface(manager, async () => loaderContext);
 
     manager.getModuleEntry = sinon.stub().returns(undefined) as any;
     let infoError: unknown;

--- a/test/index.build-start.test.ts
+++ b/test/index.build-start.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { Logging } from "@antelopejs/interface-core/logging";
+import { ListModules } from "@antelopejs/interface-core/modules";
 import { expect } from "chai";
 import sinon from "sinon";
 import type { BuildArtifact } from "../src/core/build/build-artifact";
@@ -11,6 +12,23 @@ import { cleanupTempDir, makeTempDir, writeJson } from "./helpers/temp";
 interface ArtifactModuleInput {
   id: string;
   folder: string;
+}
+
+const PENDING = Symbol("pending");
+const PROXY_TIMEOUT_MS = 1000;
+
+function settlesOrPending<T>(
+  call: Promise<T>,
+  ms: number,
+): Promise<T | typeof PENDING> {
+  const timeout = new Promise<typeof PENDING>((resolve) =>
+    setTimeout(() => resolve(PENDING), ms).unref(),
+  );
+  return Promise.race([call, timeout]);
+}
+
+function detachProxy(fn: unknown): void {
+  (fn as { proxy?: { detach(): void } }).proxy?.detach();
 }
 
 function writeTsConfig(
@@ -66,6 +84,7 @@ describe("build and launchFromBuild", () => {
 
   afterEach(() => {
     sinon.restore();
+    detachProxy(ListModules);
     for (const dir of tempDirs.splice(0)) {
       cleanupTempDir(dir);
     }
@@ -137,6 +156,33 @@ describe("build and launchFromBuild", () => {
     expect(warnStub.firstCall.args.join(" ")).to.include(
       "Configuration has changed since last build",
     );
+  });
+
+  it("launchFromBuild implements the core modules interface", async () => {
+    const projectFolder = makeTempDir("antelope-start-modules-interface-");
+    tempDirs.push(projectFolder);
+
+    writeTsConfig(projectFolder, {
+      name: "sample",
+      modules: {},
+    });
+    const artifact = createArtifact(projectFolder, "abc123");
+    writeJson(
+      path.join(projectFolder, ".antelope", "build", "build.json"),
+      artifact,
+    );
+
+    detachProxy(ListModules);
+
+    await launchFromBuild(projectFolder);
+
+    const result = await settlesOrPending(ListModules(), PROXY_TIMEOUT_MS);
+
+    expect(result).to.not.equal(
+      PENDING,
+      "ListModules() never settled: no provider for @antelopejs/interface-core/modules",
+    );
+    expect(result).to.be.an("array");
   });
 
   it("launchFromBuild throws when a module folder is missing", async () => {


### PR DESCRIPTION
### 🔗 Linked issue

_None — found from a staging incident, see below._

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

#### The bug

`ajs project start` never implemented `@antelopejs/interface-core/modules`. `launchFromBuild` called `registerCoreInterfaces` but not `registerCoreModuleInterface`, which only the configuration path reached via `loadModuleEntriesForManager(..., runtimeInterface: true)`.

An unimplemented `AsyncProxy` queues the call and never settles (`proxies.ts`), so `await ListModules()` hangs forever without erroring. Module `start()` is fire-and-forget (`module.ts`, `start(): void`), so a module that awaits it never finishes starting while the boot still reports success. In the staging incident that surfaced this, the CMS's `detectSaasMode()` hung, leaving everything after it in `start()` unrun — schema registration, hooks, crons — and the only visible symptom hours later was `isSaasMode() called before detectSaasMode()`.

All seven module operations were affected, not just `ListModules`. `@antelopejs/interface-core`'s other provider-backed sub-interface, `/runtime`, was registered on both paths — only `/modules` was missed.

#### The fix

The two launch paths had drifted because each hand-transcribed its own boot order, so this extracts the sequence they share rather than patching one call site:

- **`runLaunchSequence()` owns the single order.** All variation moves into a `ProjectPreparer` (`prepareFromConfig` / `prepareFromArtifact`), so `launch()`, `launchFromBuild()` and `restartProject()` are one call each. `build()` and the test harness stop short of starting modules and keep their own shorter sequences.
- **The loader context is built lazily.** Only `LoadModule`/`ReloadModule` need one, and constructing it `mkdir`s the cache folder — so an eager context made `project start` create, or hard-fail on, the absolute `cacheFolder` baked in at build time. Artifact launches now root the loader on the *runtime* project folder and touch disk only if a module actually loads another module.
- **Watch and interactive modes are refused with a warning on artifact launches** instead of being silently dropped. Honouring them would let a config-file change restart a pinned artifact launch as a live-configuration launch, downloading modules in a process deliberately started from a build artifact.

Second, unrelated commit: `addDefaultAssociations` only matched interfaces under `dependencies`, so an interface declared as an optional dependency was never associated even when a provider was loaded. It now matches `optionalDependencies` too; an optional with no provider never appears in `interfaceSources`, so it stays unconnected and continues to be stubbed. This has been sitting uncommitted for a while and rides along here to avoid a second PR.

#### Verification

- `tsc` clean; `biome check` clean (2 pre-existing warnings in untouched files)
- **592 passing / 0 failing**
- The new test asserts against a timeout rather than plain-awaiting, because a regression *pends* instead of throwing and would otherwise hang the suite. Confirmed it fails when the fix is reverted.
- End-to-end: `ListModules()` resolves under both `project run` and `project start`; an artifact whose recorded build root differs from the runtime root starts cleanly with no stray directory (this case previously died with `ENOTDIR ... mkdir`).

#### Known, not addressed here

`envOverrides` are frozen at build time under `project start` — `applyEnvOverrides` reads `process.env` at config-load time, and nothing reads `artifact.config.envOverrides` back. Confirmed live: build with `X=a`, start with `X=b`, the module receives `a`. Harmless when build and start share a process environment, a real hazard when an image is built once and run per-environment. Left out because whether `start` should re-read `process.env` is a semantics decision between reproducible artifacts and runtime configuration, and it deserves its own change and test.

Also left alone: the `-c, --concurrency` option is threaded through both CLIs into `LaunchOptions` and consumed nowhere, and `project start`'s help text still claims it skips graph validation, which it does not.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [ ] I have run `ajs module exports generate` and committed any updated interface files.

<sub>Docs box left unticked deliberately: `project start`'s help text is inaccurate about graph validation, but it was inaccurate before this change too and is called out above rather than fixed here.</sub>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR unifies configuration and artifact startup under a shared launch sequence, lazily initializes module-loading state, registers the core modules interface for artifact launches, rejects unsupported artifact watch/interactive modes, and connects available optional interface providers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code-triggered failures identified.

The shared launch path preserves initialization and lifecycle responsibilities while ensuring artifact launches register the missing modules interface, and the lazy loader context avoids touching build-time cache paths unless dynamic module operations require it.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/runtime/launch-sequence.ts | Introduces preparation strategies and a shared, ordered startup sequence with lazy loader-context creation. |
| src/core/runtime/module-loading.ts | Changes the core modules interface to obtain loader state lazily for operations that require module loading. |
| src/index.ts | Routes configuration launches, artifact launches, and restarts through the shared sequence and explicitly warns about unsupported artifact options. |
| src/core/module-manager.ts | Extends default provider associations to interfaces declared through optional dependencies. |
| test/index.build-start.test.ts | Adds regression coverage proving that the core modules interface settles after launching a build artifact. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[launch] --> C[prepareFromConfig]
    B[launchFromBuild] --> D[prepareFromArtifact]
    C --> E[runLaunchSequence]
    D --> E
    E --> F[Verify project or artifact]
    F --> G[Register core runtime interface]
    G --> H[Register core modules and core interfaces]
    H --> I[Create module entries]
    I --> J[Validate dependency graph]
    J --> K[Construct and start modules]
    K --> L[Setup shutdown, watch, or REPL features]
```

<sub>Reviews (1): Last reviewed commit: ["fix(modules): connect optional dependenc..."](https://github.com/antelopejs/antelopejs/commit/79f561ef322e5dedc98a88d1952d1c40d912c3b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48350611)</sub>

<!-- /greptile_comment -->