### PR TITLE
fix(core): neutralize RegisteringProxy on stubbed optional interfaces and settle async start() before test stub mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test:coverage": "c8 --check-coverage --lines 90 --functions 90 --branches 90 --statements 90 mocha --require ts-node/register --require test/setup.ts 'test/**/*.test.ts' --exit"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.6",
+    "@antelopejs/interface-core": "^0.0.8",
     "@types/proper-lockfile": "^4.1.4",
     "boxen": "^8.0.1",
     "chalk": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.6
-        version: 0.0.6
+        specifier: ^0.0.8
+        version: 0.0.8
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
@@ -105,8 +105,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.6':
-    resolution: {integrity: sha512-OMna86iT/ylL6wJl6FCPw9ieddULXGs4jTmeiDBNEXYQ9acnVXjS/+SaN0UR0h7oY7WTD9VwKXVwG95qjNIA1w==}
+  '@antelopejs/interface-core@0.0.8':
+    resolution: {integrity: sha512-9VjKxKXoGRM0Ux/qbZXGiC6Ot5QJVQq4ayjU1J0jcO+8vHeZDolbPGUKTAABQ/o9xoL/RxVTyNMwxyiQW0roZg==}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -1762,7 +1762,7 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.6':
+  '@antelopejs/interface-core@0.0.8':
     dependencies:
       reflect-metadata: 0.2.2
 

--- a/src/core/module-lifecycle.ts
+++ b/src/core/module-lifecycle.ts
@@ -4,6 +4,7 @@ import { type ModuleCallbacks, ModuleState } from "../types";
 export class ModuleLifecycle {
   private callbacks?: ModuleCallbacks;
   private _state: ModuleState = ModuleState.Loaded;
+  private starting?: Promise<void>;
 
   constructor(private moduleId: string) {}
 
@@ -29,16 +30,43 @@ export class ModuleLifecycle {
   }
 
   async start(): Promise<void> {
+    if (this.starting) {
+      return this.starting;
+    }
+
     if (this._state !== ModuleState.Constructed) {
       return;
     }
 
-    await this.callbacks?.start?.();
-    Events.ModuleStarted.emit(this.moduleId);
-    this._state = ModuleState.Active;
+    this.starting = this.runStart();
+    return this.starting;
+  }
+
+  private async runStart(): Promise<void> {
+    try {
+      await this.callbacks?.start?.();
+      Events.ModuleStarted.emit(this.moduleId);
+      this._state = ModuleState.Active;
+    } finally {
+      this.starting = undefined;
+    }
+  }
+
+  /**
+   * An async start hook leaves the state on `Constructed` until it settles, so
+   * guards below must wait for it instead of reading a state that is still in
+   * transition - otherwise a stop racing a pending start silently no-ops and
+   * the module ends up active anyway.
+   */
+  private async settleStart(): Promise<void> {
+    if (this.starting) {
+      await this.starting.catch(() => undefined);
+    }
   }
 
   async stop(): Promise<void> {
+    await this.settleStart();
+
     if (this._state !== ModuleState.Active) {
       return;
     }
@@ -51,6 +79,8 @@ export class ModuleLifecycle {
   }
 
   async destroy(): Promise<void> {
+    await this.settleStart();
+
     if (this._state === ModuleState.Loaded) {
       return;
     }

--- a/src/core/module-lifecycle.ts
+++ b/src/core/module-lifecycle.ts
@@ -28,12 +28,12 @@ export class ModuleLifecycle {
     this._state = ModuleState.Constructed;
   }
 
-  start(): void {
+  async start(): Promise<void> {
     if (this._state !== ModuleState.Constructed) {
       return;
     }
 
-    this.callbacks?.start?.();
+    await this.callbacks?.start?.();
     Events.ModuleStarted.emit(this.moduleId);
     this._state = ModuleState.Active;
   }

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -281,18 +281,17 @@ export class ModuleManager {
     );
   }
 
-  startAll(): void {
-    for (const { module } of this.loaded.values()) {
-      module.start();
-      this.trackModuleStart(module.id);
-    }
+  async startAll(): Promise<void> {
+    await this.startModules([...this.loaded.values()]);
   }
 
-  startModules(modules: ManagedModule[]): void {
+  async startModules(modules: ManagedModule[]): Promise<void> {
+    const starting: Promise<void>[] = [];
     for (const { module } of modules) {
-      module.start();
+      starting.push(module.start());
       this.trackModuleStart(module.id);
     }
+    await Promise.all(starting);
   }
 
   async stopAll(): Promise<void> {

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -60,8 +60,8 @@ export class Module {
     await this.lifecycle.construct(config);
   }
 
-  start(): void {
-    this.lifecycle.start();
+  start(): Promise<void> {
+    return this.lifecycle.start();
   }
 
   async stop(): Promise<void> {

--- a/src/core/resolution/stub-interface-runtime.ts
+++ b/src/core/resolution/stub-interface-runtime.ts
@@ -23,6 +23,18 @@ function neutralizeAsyncProxy(proxy: AsyncProxy, interfaceName: string): void {
   proxy.onCall(() => makeRejection(interfaceName), true);
 }
 
+function neutralizeRegisteringProxy(
+  proxy: RegisteringProxy,
+  interfaceName: string,
+): void {
+  proxy.onRegister((id) => {
+    Logger.Trace(
+      `Interface '${interfaceName}' has no provider; registration '${String(id)}' recorded but inert.`,
+    );
+  }, true);
+  proxy.onUnregister(() => {});
+}
+
 function walk(
   value: unknown,
   interfaceName: string,
@@ -50,7 +62,13 @@ function walk(
     neutralizeAsyncProxy(value, interfaceName);
     return;
   }
-  if (value instanceof RegisteringProxy || value instanceof EventProxy) {
+  if (value instanceof RegisteringProxy) {
+    neutralizeRegisteringProxy(value, interfaceName);
+    return;
+  }
+  // EventProxy needs no neutralization: register() never requires a provider
+  // and emit() with no handlers is already a no-op.
+  if (value instanceof EventProxy) {
     return;
   }
 

--- a/src/core/runtime/module-loading.ts
+++ b/src/core/runtime/module-loading.ts
@@ -163,12 +163,12 @@ export function registerCoreModuleInterface(
       );
       await manager.constructModules(created);
       if (autostart) {
-        manager.startModules(created);
+        await manager.startModules(created);
       }
       return created.map(({ module }) => module.id);
     },
     StartModule: async (moduleId: string) => {
-      manager.getModule(moduleId)?.start();
+      await manager.getModule(moduleId)?.start();
     },
     StopModule: async (moduleId: string) => {
       await manager.getModule(moduleId)?.stop();
@@ -364,7 +364,7 @@ async function reloadLoadedModuleFromSource(
   manager.replaceLoadedModule(moduleId, replacement);
   manager.refreshAssociations();
   await replacement.construct(entry.config.config);
-  replacement.start();
+  await replacement.start();
 }
 
 export async function reloadWatchedModule(
@@ -407,7 +407,7 @@ export async function constructAndStartModules(
   }
 
   await terminalDisplay.stopSpinner(`Done loading`);
-  manager.startAll();
+  await manager.startAll();
 }
 
 export function ensureGraphIsValid(manager: ModuleManager): void {

--- a/src/core/test/test-context.ts
+++ b/src/core/test/test-context.ts
@@ -1,6 +1,6 @@
 export interface ModuleManagerLifecycle {
   constructAll(): Promise<void>;
-  startAll(): void;
+  startAll(): Promise<void> | void;
   destroyAll(): Promise<void>;
 }
 
@@ -29,7 +29,7 @@ export class TestContext {
 
     if (this.moduleManager) {
       await this.moduleManager.constructAll();
-      this.moduleManager.startAll();
+      await this.moduleManager.startAll();
     }
   }
 

--- a/src/types/module.types.ts
+++ b/src/types/module.types.ts
@@ -7,6 +7,6 @@ export enum ModuleState {
 export interface ModuleCallbacks {
   construct?(config: unknown): Promise<void> | void;
   destroy?(): Promise<void> | void;
-  start?(): void;
+  start?(): Promise<void> | void;
   stop?(): Promise<void> | void;
 }

--- a/test/core/core-interface.test.ts
+++ b/test/core/core-interface.test.ts
@@ -84,6 +84,7 @@ describe("core/beta module interface", () => {
     sinon.stub(Module.prototype, "start").resolves();
 
     await launch("/project", "default", {});
+    startStub.resetHistory();
 
     const list = await moduleInterfaceBeta.ListModules();
     expect(list).to.deep.equal(["modA", "modB"]);

--- a/test/core/core-interface.test.ts
+++ b/test/core/core-interface.test.ts
@@ -81,7 +81,7 @@ describe("core/beta module interface", () => {
     );
 
     sinon.stub(Module.prototype, "construct").resolves();
-    sinon.stub(Module.prototype, "start").returns();
+    sinon.stub(Module.prototype, "start").resolves();
 
     await launch("/project", "default", {});
 

--- a/test/core/module-lifecycle.test.ts
+++ b/test/core/module-lifecycle.test.ts
@@ -28,7 +28,7 @@ describe("ModuleLifecycle", () => {
     await lifecycle.construct({});
     expect(lifecycle.state).to.equal(ModuleState.Constructed);
 
-    lifecycle.start();
+    await lifecycle.start();
     expect(lifecycle.state).to.equal(ModuleState.Active);
 
     await lifecycle.stop();
@@ -48,7 +48,7 @@ describe("ModuleLifecycle", () => {
     const lifecycle = new ModuleLifecycle("mod");
     lifecycle.setCallbacks(callbacks);
 
-    lifecycle.start();
+    await lifecycle.start();
     await lifecycle.stop();
 
     expect(callbacks.start.called).to.equal(false);
@@ -77,7 +77,7 @@ describe("ModuleLifecycle", () => {
     lifecycle.setCallbacks(callbacks);
 
     await lifecycle.construct({});
-    lifecycle.start();
+    await lifecycle.start();
     await lifecycle.destroy();
 
     expect(callbacks.stop.calledOnce).to.equal(true);
@@ -94,6 +94,28 @@ describe("ModuleLifecycle", () => {
 
     expect(callbacks.destroy.called).to.equal(false);
     expect(lifecycle.state).to.equal(ModuleState.Loaded);
+  });
+
+  it("should await async start callback before becoming active", async () => {
+    const calls: string[] = [];
+    const lifecycle = new ModuleLifecycle("mod");
+
+    lifecycle.setCallbacks({
+      start: async () => {
+        await new Promise((resolve) => {
+          setImmediate(resolve);
+        });
+        calls.push("start");
+      },
+    });
+
+    await lifecycle.construct({});
+    const starting = lifecycle.start();
+    expect(lifecycle.state).to.equal(ModuleState.Constructed);
+
+    await starting;
+    expect(calls).to.deep.equal(["start"]);
+    expect(lifecycle.state).to.equal(ModuleState.Active);
   });
 
   it("should await async stop callback", async () => {
@@ -119,7 +141,7 @@ describe("ModuleLifecycle", () => {
     });
 
     await lifecycle.construct({});
-    lifecycle.start();
+    await lifecycle.start();
     await lifecycle.stop();
     await lifecycle.destroy();
 

--- a/test/core/module-lifecycle.test.ts
+++ b/test/core/module-lifecycle.test.ts
@@ -118,6 +118,95 @@ describe("ModuleLifecycle", () => {
     expect(lifecycle.state).to.equal(ModuleState.Active);
   });
 
+  it("should run the start callback once when starts overlap", async () => {
+    const start = sinon.stub().callsFake(
+      () =>
+        new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        }),
+    );
+    const lifecycle = new ModuleLifecycle("mod");
+    lifecycle.setCallbacks({ start });
+
+    await lifecycle.construct({});
+    await Promise.all([lifecycle.start(), lifecycle.start()]);
+
+    expect(start.calledOnce).to.equal(true);
+    expect(lifecycle.state).to.equal(ModuleState.Active);
+  });
+
+  it("should stop a module whose start is still pending", async () => {
+    const calls: string[] = [];
+    const lifecycle = new ModuleLifecycle("mod");
+
+    lifecycle.setCallbacks({
+      start: async () => {
+        await new Promise((resolve) => {
+          setImmediate(resolve);
+        });
+        calls.push("start");
+      },
+      stop: () => {
+        calls.push("stop");
+      },
+    });
+
+    await lifecycle.construct({});
+    const starting = lifecycle.start();
+    await Promise.all([lifecycle.stop(), starting]);
+
+    expect(calls).to.deep.equal(["start", "stop"]);
+    expect(lifecycle.state).to.equal(ModuleState.Constructed);
+  });
+
+  it("should destroy a module whose start is still pending", async () => {
+    const calls: string[] = [];
+    const lifecycle = new ModuleLifecycle("mod");
+
+    lifecycle.setCallbacks({
+      start: async () => {
+        await new Promise((resolve) => {
+          setImmediate(resolve);
+        });
+        calls.push("start");
+      },
+      stop: () => {
+        calls.push("stop");
+      },
+      destroy: () => {
+        calls.push("destroy");
+      },
+    });
+
+    await lifecycle.construct({});
+    const starting = lifecycle.start();
+    await Promise.all([lifecycle.destroy(), starting]);
+
+    expect(calls).to.deep.equal(["start", "stop", "destroy"]);
+    expect(lifecycle.state).to.equal(ModuleState.Loaded);
+  });
+
+  it("should stay startable after a failed start", async () => {
+    const start = sinon
+      .stub()
+      .onFirstCall()
+      .rejects(new Error("boom"))
+      .onSecondCall()
+      .resolves();
+    const lifecycle = new ModuleLifecycle("mod");
+    lifecycle.setCallbacks({ start });
+
+    await lifecycle.construct({});
+    await lifecycle.start().then(
+      () => expect.fail("start should have rejected"),
+      (err: Error) => expect(err.message).to.equal("boom"),
+    );
+    expect(lifecycle.state).to.equal(ModuleState.Constructed);
+
+    await lifecycle.start();
+    expect(lifecycle.state).to.equal(ModuleState.Active);
+  });
+
   it("should await async stop callback", async () => {
     const calls: string[] = [];
     const lifecycle = new ModuleLifecycle("mod");

--- a/test/core/module-manager.test.ts
+++ b/test/core/module-manager.test.ts
@@ -403,7 +403,7 @@ describe("ModuleManager", () => {
     expect(attachStub.calledOnce).to.equal(true);
     expect(constructStub.calledWith({ flag: true })).to.equal(true);
 
-    manager.startModules([moduleEntry as any]);
+    await manager.startModules([moduleEntry as any]);
     expect(startStub.calledOnce).to.equal(true);
   });
 
@@ -440,7 +440,7 @@ describe("ModuleManager", () => {
     (manager as any).loaded.set("modB", { module: modB, config: {} });
     (manager as any).loaded.set("modC", { module: modC, config: {} });
 
-    manager.startAll();
+    await manager.startAll();
     calls.length = 0;
 
     await manager.stopAll();
@@ -521,7 +521,7 @@ describe("ModuleManager", () => {
       config: {},
     });
 
-    manager.startAll();
+    await manager.startAll();
 
     await manager.stopAll();
 

--- a/test/core/module.test.ts
+++ b/test/core/module.test.ts
@@ -27,7 +27,7 @@ describe("Module", () => {
     const mod = new Module(manifest, loader);
 
     await mod.construct({ foo: "bar" });
-    mod.start();
+    await mod.start();
     await mod.stop();
     await mod.destroy();
 
@@ -105,7 +105,7 @@ describe("Module", () => {
     const mod = new Module(manifest, loader);
 
     await mod.construct({});
-    mod.start();
+    await mod.start();
 
     try {
       await mod.destroy();
@@ -130,7 +130,7 @@ describe("Module", () => {
     const mod = new Module(manifest, loader);
 
     await mod.construct({});
-    mod.start();
+    await mod.start();
     await mod.stop();
 
     expect(stopResolved).to.equal(true);

--- a/test/core/resolution/stub-interface-runtime.test.ts
+++ b/test/core/resolution/stub-interface-runtime.test.ts
@@ -4,8 +4,11 @@ import {
   InterfaceFunction,
   RegisteringProxy,
 } from "@antelopejs/interface-core";
+import { internal } from "@antelopejs/interface-core/internal";
 import { expect } from "chai";
+import { ModuleLifecycle } from "../../../src/core/module-lifecycle";
 import { neutralizeInterfaceAsyncProxies } from "../../../src/core/resolution/stub-interface-runtime";
+import { ModuleState } from "../../../src/types";
 
 describe("neutralizeInterfaceAsyncProxies", () => {
   it("makes AsyncProxy-backed calls reject instead of queuing forever", async () => {
@@ -44,17 +47,53 @@ describe("neutralizeInterfaceAsyncProxies", () => {
     expect(rejected).to.equal(true);
   });
 
-  it("leaves RegisteringProxy untouched", () => {
+  it("makes RegisteringProxy.register() a no-op in test stub mode", () => {
     const reg = new RegisteringProxy<(id: string) => void>();
     const iface = { reg };
     neutralizeInterfaceAsyncProxies(iface, "reg-iface");
 
-    let called = false;
-    reg.onRegister(() => {
-      called = true;
-    }, true);
+    internal.testStubMode = true;
+    try {
+      expect(() => reg.register("id-1")).to.not.throw();
+      expect(() => reg.unregister("id-1")).to.not.throw();
+    } finally {
+      internal.testStubMode = false;
+    }
+  });
+
+  it("replays registrations recorded while neutralized to a later provider", () => {
+    const reg = new RegisteringProxy<(id: string) => void>();
+    neutralizeInterfaceAsyncProxies({ reg }, "reg-iface");
     reg.register("id-1");
-    expect(called).to.equal(true);
+
+    const received: string[] = [];
+    reg.onRegister((id) => received.push(id), true);
+    expect(received).to.deep.equal(["id-1"]);
+  });
+
+  it("boots a module whose async start() registers into a stubbed optional interface", async () => {
+    const reg = new RegisteringProxy<(id: string) => void>();
+    neutralizeInterfaceAsyncProxies({ reg }, "optional-iface");
+
+    const lifecycle = new ModuleLifecycle("mod-async-start");
+    lifecycle.setCallbacks({
+      start: async () => {
+        await new Promise((resolve) => {
+          setImmediate(resolve);
+        });
+        reg.register("trigger-1");
+      },
+    });
+
+    await lifecycle.construct({});
+    await lifecycle.start();
+    internal.testStubMode = true;
+    try {
+      expect(lifecycle.state).to.equal(ModuleState.Active);
+      expect(() => reg.register("trigger-2")).to.not.throw();
+    } finally {
+      internal.testStubMode = false;
+    }
   });
 
   it("leaves EventProxy untouched", () => {

--- a/test/core/runtime/module-loading.test.ts
+++ b/test/core/runtime/module-loading.test.ts
@@ -248,6 +248,42 @@ describe("runtime module-loading", () => {
     expect(failingManager.startAll.called).to.equal(false);
   });
 
+  it("resolves only after async start hooks settle", async () => {
+    sinon.stub(terminalDisplay, "startSpinner").resolves();
+    sinon.stub(terminalDisplay, "stopSpinner").resolves();
+
+    let settleStart: () => void = () => undefined;
+    let startSettled = false;
+    const manager = {
+      constructAll: sinon.stub().resolves(),
+      startAll: sinon.stub().callsFake(
+        () =>
+          new Promise<void>((resolve) => {
+            settleStart = () => {
+              startSettled = true;
+              resolve();
+            };
+          }),
+      ),
+    } as any;
+
+    let resolved = false;
+    const pending = constructAndStartModules(manager).then(() => {
+      resolved = true;
+    });
+
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(manager.startAll.calledOnce).to.equal(true);
+    expect(resolved).to.equal(false);
+
+    settleStart();
+    await pending;
+    expect(startSettled).to.equal(true);
+    expect(resolved).to.equal(true);
+  });
+
   it("handles module interface operations and error branches", async () => {
     const listModulesStub = sinon.stub().returns(["alpha"]);
     const getModuleEntryStub = sinon.stub();


### PR DESCRIPTION
## Summary

Closes #93.

### 1. Stub neutralization now covers `RegisteringProxy`

`neutralizeInterfacePackage()` walks a stubbed optional interface's exports and now attaches no-op register/unregister callbacks to every `RegisteringProxy` (mirroring the existing `AsyncProxy` treatment) with a `Trace` log per ignored registration. `register()` against a stubbed optional interface becomes an inert recorded call instead of throwing under `internal.testStubMode` — and because entries are still recorded, they replay correctly if a real provider attaches later (e.g. hot-loading the module).

`EventProxy` was evaluated and needs no treatment: its `register()` never requires a provider and `emit()` with no handlers is already a no-op. A comment in the walk documents this.

Non-optional missing interfaces are untouched: their proxies are never neutralized, so they still throw in test stub mode.

### 2. Async `start()` hooks settle before `testStubMode` flips

The start path is awaitable end to end:
- `ModuleCallbacks.start?(): Promise<void> | void`
- `ModuleLifecycle.start()` / `Module.start()` await the hook before emitting `ModuleStarted` and marking the module `Active`
- `ModuleManager.startAll()`/`startModules()` initiate all starts in order (startup-order tracking unchanged) then settle them via `Promise.all`
- All call sites await: `constructAndStartModules`, the core `LoadModule`/`StartModule` interface handlers, module reload, `TestContext`

`setupTestEnvironment` already ran `await constructAndStartModules(manager)` before setting `internal.testStubMode = true`; that await is now meaningful, so the flag only flips after every async `start()` has settled. Outside tests this also removes the race between startup work and anything running after `constructAndStartModules()` resolves.

## Acceptance criteria from #93

- [x] `register()`/`unregister()` on a stubbed optional interface no-ops in test stub mode
- [x] `EventProxy` behavior reviewed and documented (no change needed)
- [x] Non-optional missing interfaces still throw (stub-interface tests unchanged and green)
- [x] Async `start()` hooks settled before `testStubMode` is enabled
- [x] Regression test: module with an async `start()` registering into a stubbed optional interface boots cleanly

## Test plan

- `pnpm run test:unit` — green (Node 20, as CI). New tests: RegisteringProxy no-op + replay-to-later-provider, async-start regression scenario, `ModuleLifecycle` awaits async start before `Active`, `constructAndStartModules` resolves only after start hooks settle.
- `pnpm run test:playground` — all 3 phases pass (launch, build, launch-from-build).
- `pnpm run lint` — no new issues (2 pre-existing warnings in untouched files).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR neutralizes registering proxies for missing optional interfaces and makes module startup await asynchronous hooks before reporting modules as active.

- Adds inert register/unregister handling while preserving registration replay for later providers.
- Propagates asynchronous start completion through lifecycle, manager, runtime loading, reload, and test-context paths.
- Extends lifecycle and stub-interface regression coverage.

<h3>Confidence Score: 4/5</h3>

The lifecycle concurrency defect should be fixed before merging because overlapping runtime lifecycle requests can duplicate startup or leave a supposedly stopped module active.

Awaiting the start hook leaves the module in Constructed state, so concurrent start and stop requests pass incompatible state guards and produce duplicate or stale lifecycle outcomes.

**Files Needing Attention:** src/core/module-lifecycle.ts, src/core/runtime/module-loading.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/module-lifecycle.ts | Awaits asynchronous start hooks before activation, but the pending Constructed state permits duplicate starts and ineffective overlapping stops. |
| src/core/module-manager.ts | Collects module start promises and waits for all initiated starts while preserving deterministic startup tracking. |
| src/core/resolution/stub-interface-runtime.ts | Adds inert RegisteringProxy callbacks for stubbed optional interfaces and documents why EventProxy requires no treatment. |
| src/core/runtime/module-loading.ts | Awaits startup across load, explicit start, reload, and initial construction paths, exposing concurrent lifecycle requests to the in-flight-state issue. |
| src/core/test/test-context.ts | Updates test setup to await module-manager startup completion. |
| src/types/module.types.ts | Expands the public start callback contract to support asynchronous completion. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[StartModule request] --> B{State is Constructed?}
  B -- Yes --> C[Await asynchronous start hook]
  C --> D[Emit ModuleStarted]
  D --> E[Set state Active]
  C -. pending window .-> F[Overlapping StartModule or StopModule]
  F --> B
  F --> G{Stop sees Active?}
  G -- No --> H[Stop returns without action]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/core/module-lifecycle.ts:36
**Pending start breaks lifecycle guards**

If two lifecycle requests overlap while an asynchronous `start` hook is pending, the module remains `Constructed`, so another start invokes the hook and emits `ModuleStarted` again, while a stop returns without action and allows the pending start to mark the module `Active` afterward.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): neutralize RegisteringProxy o..."](https://github.com/antelopejs/antelopejs/commit/cce9dbfd5b9c70f136943e9f296da7356be86697) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50789823)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
