### PR TITLE
fix(cli): honor declared package manager versions

### DIFF
--- a/src/core/cli/commands/module/init.ts
+++ b/src/core/cli/commands/module/init.ts
@@ -198,7 +198,12 @@ export async function moduleInitCommand(
     // Execute install command
     const installSpinner = new Spinner("Installing dependencies");
     await installSpinner.start();
-    const installCmd = await getInstallCommand(packageJsonPath, false);
+    const installCmd = await getInstallCommand(
+      packageJsonPath,
+      false,
+      undefined,
+      "update",
+    );
     await ExecuteCMD(installCmd, { cwd: packageJsonPath });
     await installSpinner.succeed("Dependencies installed");
 

--- a/src/core/cli/package-manager.ts
+++ b/src/core/cli/package-manager.ts
@@ -10,6 +10,12 @@ const VALID_PACKAGE_MANAGERS = ["npm", "yarn", "pnpm"] as const;
 type PackageManagerName = (typeof VALID_PACKAGE_MANAGERS)[number];
 
 const DEFAULT_PACKAGE_MANAGER: PackageManagerName = "npm";
+const PACKAGE_MANAGER_PATTERN = /^(npm|yarn|pnpm)@([0-9A-Za-z._+-]+)$/;
+const LOCKFILES: Record<PackageManagerName, string[]> = {
+  npm: ["npm-shrinkwrap.json", "package-lock.json"],
+  yarn: ["yarn.lock"],
+  pnpm: ["pnpm-lock.yaml"],
+};
 
 const FALLBACK_VERSIONS: Record<PackageManagerName, string> = {
   npm: "npm@10.2.4",
@@ -18,12 +24,20 @@ const FALLBACK_VERSIONS: Record<PackageManagerName, string> = {
 };
 
 interface InstallPackagesParams {
+  executable: string;
   packageList: string;
   isDev: boolean;
 }
 
 interface InstallDependenciesParams {
+  executable: string;
+  hasLockfile: boolean;
   isProduction: boolean;
+}
+
+interface PackageManager {
+  executable: string;
+  name: PackageManagerName;
 }
 
 type InstallPackagesCommandBuilder = (params: InstallPackagesParams) => string;
@@ -31,27 +45,44 @@ type InstallDependenciesCommandBuilder = (
   params: InstallDependenciesParams,
 ) => string;
 
+function compactCommand(command: string): string {
+  return command.replace(/\s+/g, " ").trim();
+}
+
 const INSTALL_COMMANDS: Record<
   PackageManagerName,
   InstallPackagesCommandBuilder
 > = {
-  pnpm: ({ packageList, isDev }) =>
-    `pnpm install ${isDev ? "-D" : ""} ${packageList} -C . --lockfile-dir .`.trim(),
-  yarn: ({ packageList, isDev }) =>
-    `yarn add ${isDev ? "-D" : ""} ${packageList} -C . --lockfile-dir .`.trim(),
-  npm: ({ packageList, isDev }) =>
-    `npm install ${isDev ? "--save-dev" : "--save"} ${packageList} -C . --lockfile-dir .`.trim(),
+  pnpm: ({ executable, packageList, isDev }) =>
+    compactCommand(
+      `${executable} install ${isDev ? "-D" : ""} ${packageList} -C . --lockfile-dir .`,
+    ),
+  yarn: ({ executable, packageList, isDev }) =>
+    compactCommand(
+      `${executable} add ${isDev ? "-D" : ""} ${packageList} -C . --lockfile-dir .`,
+    ),
+  npm: ({ executable, packageList, isDev }) =>
+    compactCommand(
+      `${executable} install ${isDev ? "--save-dev" : "--save"} ${packageList} -C . --lockfile-dir .`,
+    ),
 };
 
 const UNINSTALL_COMMANDS: Record<
   PackageManagerName,
   InstallDependenciesCommandBuilder
 > = {
-  pnpm: ({ isProduction }) =>
-    `pnpm install ${isProduction ? "--prod" : ""} --ignore-workspace`,
-  yarn: ({ isProduction }) =>
-    `yarn install ${isProduction ? "--production" : ""}`,
-  npm: ({ isProduction }) => `npm install ${isProduction ? "--omit=dev" : ""}`,
+  pnpm: ({ executable, hasLockfile, isProduction }) =>
+    compactCommand(
+      `${executable} install ${isProduction ? "--prod" : ""} --ignore-workspace${hasLockfile ? " --frozen-lockfile --prefer-offline" : ""}`,
+    ),
+  yarn: ({ executable, hasLockfile, isProduction }) =>
+    compactCommand(
+      `${executable} install ${isProduction ? "--production" : ""}${hasLockfile ? " --frozen-lockfile --prefer-offline" : ""}`,
+    ),
+  npm: ({ executable, hasLockfile, isProduction }) =>
+    compactCommand(
+      `${executable} ${hasLockfile ? "ci --prefer-offline" : "install"} ${isProduction ? "--omit=dev" : ""}`,
+    ),
 };
 
 function normalizePackageManager(packageManager?: string): PackageManagerName {
@@ -61,6 +92,37 @@ function normalizePackageManager(packageManager?: string): PackageManagerName {
   return VALID_PACKAGE_MANAGERS.includes(packageManager as PackageManagerName)
     ? (packageManager as PackageManagerName)
     : DEFAULT_PACKAGE_MANAGER;
+}
+
+function hasCorepack(): boolean {
+  try {
+    execSync("corepack --version", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolvePackageManager(packageManager?: string): PackageManager {
+  const match = packageManager?.match(PACKAGE_MANAGER_PATTERN);
+  const name = normalizePackageManager(match?.[1] ?? packageManager);
+  const executable =
+    match && hasCorepack() ? `corepack ${packageManager}` : name;
+  return { executable, name };
+}
+
+async function hasPackageManagerLockfile(
+  directory: string,
+  packageManager: PackageManagerName,
+  fileSystem: IFileSystem,
+): Promise<boolean> {
+  const lockfiles = LOCKFILES[packageManager];
+  const matches = await Promise.all(
+    lockfiles.map((lockfile) =>
+      fileSystem.exists(path.join(directory, lockfile)),
+    ),
+  );
+  return matches.includes(true);
 }
 
 export async function getModulePackageManager(
@@ -78,9 +140,9 @@ export async function getModulePackageManager(
     if (!packageJson.packageManager) {
       return undefined;
     }
-    const pmName = packageJson.packageManager.split("@")[0];
-    return VALID_PACKAGE_MANAGERS.includes(pmName as PackageManagerName)
-      ? pmName
+    return PACKAGE_MANAGER_PATTERN.test(packageJson.packageManager) ||
+      VALID_PACKAGE_MANAGERS.includes(packageJson.packageManager)
+      ? packageJson.packageManager
       : undefined;
   } catch {
     return undefined;
@@ -139,10 +201,11 @@ export async function getInstallPackagesCommand(
   directory: string = ".",
   fileSystem: IFileSystem = new NodeFileSystem(),
 ): Promise<string> {
-  const packageManager = normalizePackageManager(
+  const packageManager = resolvePackageManager(
     await getModulePackageManager(directory, fileSystem),
   );
-  return INSTALL_COMMANDS[packageManager]({
+  return INSTALL_COMMANDS[packageManager.name]({
+    executable: packageManager.executable,
     packageList: packages.join(" "),
     isDev,
   });
@@ -153,10 +216,19 @@ export async function getInstallCommand(
   isProduction = true,
   fileSystem: IFileSystem = new NodeFileSystem(),
 ): Promise<string> {
-  const packageManager = normalizePackageManager(
+  const packageManager = resolvePackageManager(
     await getModulePackageManager(directory, fileSystem),
   );
-  return UNINSTALL_COMMANDS[packageManager]({ isProduction });
+  const hasLockfile = await hasPackageManagerLockfile(
+    directory,
+    packageManager.name,
+    fileSystem,
+  );
+  return UNINSTALL_COMMANDS[packageManager.name]({
+    executable: packageManager.executable,
+    hasLockfile,
+    isProduction,
+  });
 }
 
 export function parsePackageInfoOutput(output: string): string {

--- a/src/core/cli/package-manager.ts
+++ b/src/core/cli/package-manager.ts
@@ -32,6 +32,7 @@ interface InstallPackagesParams {
 interface InstallDependenciesParams {
   executable: string;
   hasLockfile: boolean;
+  isLockfileFrozen: boolean;
   isProduction: boolean;
 }
 
@@ -39,6 +40,8 @@ interface PackageManager {
   executable: string;
   name: PackageManagerName;
 }
+
+type LockfileMode = "frozen" | "update";
 
 type InstallPackagesCommandBuilder = (params: InstallPackagesParams) => string;
 type InstallDependenciesCommandBuilder = (
@@ -71,17 +74,17 @@ const UNINSTALL_COMMANDS: Record<
   PackageManagerName,
   InstallDependenciesCommandBuilder
 > = {
-  pnpm: ({ executable, hasLockfile, isProduction }) =>
+  pnpm: ({ executable, hasLockfile, isLockfileFrozen, isProduction }) =>
     compactCommand(
-      `${executable} install ${isProduction ? "--prod" : ""} --ignore-workspace${hasLockfile ? " --frozen-lockfile --prefer-offline" : ""}`,
+      `${executable} install ${isProduction ? "--prod" : ""} --ignore-workspace${isLockfileFrozen ? " --frozen-lockfile" : ""}${hasLockfile ? " --prefer-offline" : ""}`,
     ),
-  yarn: ({ executable, hasLockfile, isProduction }) =>
+  yarn: ({ executable, hasLockfile, isLockfileFrozen, isProduction }) =>
     compactCommand(
-      `${executable} install ${isProduction ? "--production" : ""}${hasLockfile ? " --frozen-lockfile --prefer-offline" : ""}`,
+      `${executable} install ${isProduction ? "--production" : ""}${isLockfileFrozen ? " --frozen-lockfile" : ""}${hasLockfile ? " --prefer-offline" : ""}`,
     ),
-  npm: ({ executable, hasLockfile, isProduction }) =>
+  npm: ({ executable, hasLockfile, isLockfileFrozen, isProduction }) =>
     compactCommand(
-      `${executable} ${hasLockfile ? "ci --prefer-offline" : "install"} ${isProduction ? "--omit=dev" : ""}`,
+      `${executable} ${isLockfileFrozen ? "ci --prefer-offline" : `install${hasLockfile ? " --prefer-offline" : ""}`} ${isProduction ? "--omit=dev" : ""}`,
     ),
 };
 
@@ -215,6 +218,7 @@ export async function getInstallCommand(
   directory: string = ".",
   isProduction = true,
   fileSystem: IFileSystem = new NodeFileSystem(),
+  lockfileMode: LockfileMode = "frozen",
 ): Promise<string> {
   const packageManager = resolvePackageManager(
     await getModulePackageManager(directory, fileSystem),
@@ -227,6 +231,7 @@ export async function getInstallCommand(
   return UNINSTALL_COMMANDS[packageManager.name]({
     executable: packageManager.executable,
     hasLockfile,
+    isLockfileFrozen: hasLockfile && lockfileMode === "frozen",
     isProduction,
   });
 }

--- a/test/core/cli/commands/module/init.behavior.test.ts
+++ b/test/core/cli/commands/module/init.behavior.test.ts
@@ -42,7 +42,9 @@ describe("module init behavior", () => {
       promptStub.onCall(2).resolves({ initGit: false });
 
       sinon.stub(pkgManager, "savePackageManagerToPackageJson").returns();
-      sinon.stub(pkgManager, "getInstallCommand").resolves("npm install");
+      const getInstallCommandStub = sinon
+        .stub(pkgManager, "getInstallCommand")
+        .resolves("npm install");
       const execStub = sinon
         .stub(command, "ExecuteCMD")
         .resolves({ code: 0, stdout: "", stderr: "" });
@@ -58,6 +60,9 @@ describe("module init behavior", () => {
 
       await moduleInitCommand(moduleDir, {}, false);
 
+      expect(
+        getInstallCommandStub.calledWith(moduleDir, false, undefined, "update"),
+      ).to.equal(true);
       expect(execStub.calledWith("npm install", { cwd: moduleDir })).to.equal(
         true,
       );

--- a/test/core/cli/package-manager.test.ts
+++ b/test/core/cli/package-manager.test.ts
@@ -18,21 +18,27 @@ describe("Package Manager Utils", () => {
       const fs = new InMemoryFileSystem();
       await fs.writeFile(
         "/project/package.json",
-        JSON.stringify({ packageManager: "pnpm@10.6.5" }),
+        JSON.stringify({ packageManager: "pnpm@10.6.5+sha256.47c8bca4" }),
       );
-      expect(await getModulePackageManager("/project", fs)).to.equal("pnpm");
+      expect(await getModulePackageManager("/project", fs)).to.equal(
+        "pnpm@10.6.5+sha256.47c8bca4",
+      );
 
       await fs.writeFile(
         "/project/package.json",
         JSON.stringify({ packageManager: "yarn@1.22.21" }),
       );
-      expect(await getModulePackageManager("/project", fs)).to.equal("yarn");
+      expect(await getModulePackageManager("/project", fs)).to.equal(
+        "yarn@1.22.21",
+      );
 
       await fs.writeFile(
         "/project/package.json",
         JSON.stringify({ packageManager: "npm@10.2.4" }),
       );
-      expect(await getModulePackageManager("/project", fs)).to.equal("npm");
+      expect(await getModulePackageManager("/project", fs)).to.equal(
+        "npm@10.2.4",
+      );
     });
 
     it("returns undefined for invalid content", async () => {
@@ -48,7 +54,10 @@ describe("Package Manager Utils", () => {
   });
 
   describe("install command builders", () => {
+    afterEach(() => sinon.restore());
+
     it("builds install commands for each package manager", async () => {
+      sinon.stub(require("node:child_process"), "execSync").returns("0.20.0");
       const fs = new InMemoryFileSystem();
 
       await fs.writeFile(
@@ -56,7 +65,7 @@ describe("Package Manager Utils", () => {
         JSON.stringify({ packageManager: "pnpm@10.6.5" }),
       );
       expect(await getInstallCommand("/project", true, fs)).to.include(
-        "pnpm install",
+        "corepack pnpm@10.6.5 install",
       );
       expect(
         await getInstallPackagesCommand(["a"], true, "/project", fs),
@@ -67,18 +76,18 @@ describe("Package Manager Utils", () => {
         JSON.stringify({ packageManager: "yarn@1.22.21" }),
       );
       expect(await getInstallCommand("/project", true, fs)).to.include(
-        "--production",
+        "corepack yarn@1.22.21 install --production",
       );
       expect(
         await getInstallPackagesCommand(["a"], false, "/project", fs),
-      ).to.include("yarn add");
+      ).to.include("corepack yarn@1.22.21 add");
 
       await fs.writeFile(
         "/project/package.json",
         JSON.stringify({ packageManager: "npm@10.2.4" }),
       );
       expect(await getInstallCommand("/project", true, fs)).to.include(
-        "--omit=dev",
+        "corepack npm@10.2.4 install --omit=dev",
       );
       expect(
         await getInstallPackagesCommand(["a"], true, "/project", fs),
@@ -108,6 +117,70 @@ describe("Package Manager Utils", () => {
       expect(
         await getInstallPackagesCommand(["a"], false, "/project", fs),
       ).to.include("npm install");
+    });
+
+    it("uses global binaries when Corepack is unavailable", async () => {
+      sinon
+        .stub(require("node:child_process"), "execSync")
+        .throws(new Error("corepack not found"));
+      const fs = new InMemoryFileSystem();
+      await fs.writeFile(
+        "/project/package.json",
+        JSON.stringify({ packageManager: "pnpm@10.6.5" }),
+      );
+
+      expect(await getInstallCommand("/project", false, fs)).to.equal(
+        "pnpm install --ignore-workspace",
+      );
+    });
+
+    it("uses frozen lockfiles and prefers the local cache", async () => {
+      sinon.stub(require("node:child_process"), "execSync").returns("0.20.0");
+      const fs = new InMemoryFileSystem();
+      const cases = [
+        {
+          command:
+            "corepack pnpm@10.6.5 install --prod --ignore-workspace --frozen-lockfile --prefer-offline",
+          lockfile: "pnpm-lock.yaml",
+          packageManager: "pnpm@10.6.5",
+        },
+        {
+          command:
+            "corepack yarn@1.22.21 install --production --frozen-lockfile --prefer-offline",
+          lockfile: "yarn.lock",
+          packageManager: "yarn@1.22.21",
+        },
+        {
+          command: "corepack npm@10.2.4 ci --prefer-offline --omit=dev",
+          lockfile: "package-lock.json",
+          packageManager: "npm@10.2.4",
+        },
+      ];
+
+      for (const testCase of cases) {
+        await fs.writeFile(
+          "/project/package.json",
+          JSON.stringify({ packageManager: testCase.packageManager }),
+        );
+        await fs.writeFile(`/project/${testCase.lockfile}`, "lock");
+        expect(await getInstallCommand("/project", true, fs)).to.equal(
+          testCase.command,
+        );
+        await fs.rm(`/project/${testCase.lockfile}`);
+      }
+    });
+
+    it("ignores malformed versions", async () => {
+      const fs = new InMemoryFileSystem();
+      await fs.writeFile(
+        "/project/package.json",
+        JSON.stringify({ packageManager: "pnpm@10.6.5; echo unsafe" }),
+      );
+
+      expect(await getModulePackageManager("/project", fs)).to.equal(undefined);
+      expect(await getInstallCommand("/project", false, fs)).to.include(
+        "npm install",
+      );
     });
   });
 

--- a/test/core/cli/package-manager.test.ts
+++ b/test/core/cli/package-manager.test.ts
@@ -170,6 +170,44 @@ describe("Package Manager Utils", () => {
       }
     });
 
+    it("updates copied lockfiles during project initialization", async () => {
+      sinon.stub(require("node:child_process"), "execSync").returns("0.20.0");
+      const fs = new InMemoryFileSystem();
+      const cases = [
+        {
+          command:
+            "corepack pnpm@10.6.5 install --ignore-workspace --prefer-offline",
+          lockfile: "pnpm-lock.yaml",
+          packageManager: "pnpm@10.6.5",
+        },
+        {
+          command: "corepack yarn@1.22.21 install --prefer-offline",
+          lockfile: "yarn.lock",
+          packageManager: "yarn@1.22.21",
+        },
+        {
+          command: "corepack npm@10.2.4 install --prefer-offline",
+          lockfile: "package-lock.json",
+          packageManager: "npm@10.2.4",
+        },
+      ];
+
+      for (const testCase of cases) {
+        await fs.writeFile(
+          "/project/package.json",
+          JSON.stringify({
+            dependencies: { "selected-interface": "latest" },
+            packageManager: testCase.packageManager,
+          }),
+        );
+        await fs.writeFile(`/project/${testCase.lockfile}`, "copied-template");
+        expect(
+          await getInstallCommand("/project", false, fs, "update"),
+        ).to.equal(testCase.command);
+        await fs.rm(`/project/${testCase.lockfile}`);
+      }
+    });
+
     it("ignores malformed versions", async () => {
       const fs = new InMemoryFileSystem();
       await fs.writeFile(


### PR DESCRIPTION
## Summary

- preserve the complete `packageManager` declaration instead of dropping its version
- execute declared npm, Yarn, and pnpm versions through Corepack when available
- retain global-binary compatibility for projects without a declaration and environments without Corepack
- keep downloaded-package installs frozen while allowing module initialization to refresh copied template lockfiles after adding interfaces

## Rebase status

Rebased onto `origin/main` at `b507915de42ae37bea694c99078fefdbf302d6c9` (runtime PRs #97, #98, #100, and #101). Current head: `572979ade79142df9fc8c18da82d78eaaf17ce29`.

`git range-diff` reports both PR commits patch-identical across the rebase. The incremental PR diff contains only:

- `src/core/cli/package-manager.ts`
- `src/core/cli/commands/module/init.ts`
- their two focused test files

The rebased frozen install resolved published `@antelopejs/interface-core@0.0.11` from the new base.

## Deterministic-success matrix

Environment: Node 20.9.0, Corepack 0.20.0, globally installed pnpm 11.22.0. Timings are single-run sanity measurements.

| Scenario | Resolved command/version | Result |
| --- | --- | --- |
| Original failure: declared pnpm 10.6.5, incompatible global pnpm 11 | global `pnpm install` | **0/1 succeeded** (`node:sqlite`) |
| Rebased root install | `corepack pnpm@10.6.5 install --frozen-lockfile` | succeeded; lockfile unchanged; interface-core 0.0.11 installed |
| Stale npm lock, frozen contract | `corepack npm@10.2.4 ci --prefer-offline` | failed as intended (`EUSAGE`) in 408 ms; lock unchanged |
| Stale npm lock, init/update contract | `corepack npm@10.2.4 install --prefer-offline` | succeeded in 526 ms; lock refreshed |
| Stale pnpm lock, frozen contract | `corepack pnpm@10.6.5 install --ignore-workspace --frozen-lockfile --prefer-offline` | failed as intended (`ERR_PNPM_OUTDATED_LOCKFILE`) in 417 ms; lock unchanged |
| Stale pnpm lock, init/update contract | `corepack pnpm@10.6.5 install --ignore-workspace --prefer-offline` | succeeded in 640 ms; lock refreshed |

## Call-site contract

There are two production call sites for `getInstallCommand`:

| Call site | Contract | Lockfile mode |
| --- | --- | --- |
| package downloader | immutable published package installed into cache | frozen by default |
| module initialization | copied template may receive selected interfaces | explicit `update` |

All three official module templates currently contain a `pnpm-lock.yaml`, so initialization must be able to refresh copied locks. Package downloads remain strict.

## Command/compatibility matrix

| Manifest | Frozen download/build | Mutable initialization | Real Corepack resolution |
| --- | --- | --- | --- |
| `pnpm@10.6.5` | frozen + prefer-offline | update + prefer-offline | 10.6.5 |
| `yarn@1.22.21` | frozen + prefer-offline | update + prefer-offline | 1.22.21 |
| `npm@10.2.4` | ci + prefer-offline | install + prefer-offline | 10.2.4 |
| no field / unsupported field | global npm fallback | global npm fallback | unchanged compatibility |
| declared version, Corepack absent | matching global binary fallback | matching global binary fallback | version cannot be guaranteed |

## Validation on rebased head

- frozen root install: passed; `@antelopejs/interface-core` resolved to **0.0.11**
- `pnpm build`: passed
- `pnpm test`: passed with pinned pnpm shim
  - unit suite: **660 passing**
  - package consumer added by #101: **passed**
  - playground: all 3 phases **passed**
- `pnpm test:coverage`: passed — **94.56% statements/lines, 92.28% branches, 91.98% functions**
- `pnpm lint`: passed with 2 pre-existing warnings and 1 pre-existing informational diagnostic
- stale-lock npm and pnpm reproductions: frozen failed without mutation; init/update succeeded and refreshed locks
- declared-version probes: npm 10.2.4, pnpm 10.6.5, Yarn 1.22.21 resolved exactly

## Environment limitation

This orb's global pnpm 11.22.0 requires a newer Node version than Node 20.9.0. Repository scripts contain nested bare `pnpm` calls, and the #101 package-consumer fixture intentionally has no `packageManager`; without a pinned shim those nested calls select pnpm 11 and fail before exercising repository code. Validation therefore prepended a temporary `pnpm` wrapper that delegates to `corepack pnpm@10.6.5`. No wrapper or environment-specific change is committed.

The earlier Greptile P1 was addressed in the second commit; its review thread remains resolved. This PR must not be merged as part of this update.
