### PR TITLE
fix(core): make interface package resolution deterministic

### DIFF
--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import { Logging } from "@antelopejs/interface-core/logging";
+import { satisfies, validRange } from "semver";
 import {
   type InterfaceConnectionRef,
   InterfaceRegistry,
@@ -9,6 +10,12 @@ import type { ModuleManifest } from "./module-manifest";
 import { ModuleRegistry } from "./module-registry";
 import { ModuleTracker } from "./module-tracker";
 import type { UnresolvedInterface } from "./resolution/interface-resolution";
+import {
+  isPathWithin,
+  type ResolvedPackage,
+  resolvePackage,
+  resolvePackageAtRoot,
+} from "./resolution/package-resolution";
 import { PathMapper } from "./resolution/path-mapper";
 import { Resolver } from "./resolution/resolver";
 import { ResolverDetour } from "./resolution/resolver-detour";
@@ -38,6 +45,17 @@ interface ModuleManagerDeps {
   moduleTracker?: ModuleTracker;
 }
 
+interface InterfacePackageConsumer {
+  moduleId: string;
+  range: string;
+  resolvedPackage?: ResolvedPackage;
+}
+
+interface InterfacePackagePlan {
+  canonicalPackage: ResolvedPackage;
+  consumers: InterfacePackageConsumer[];
+}
+
 export class ModuleManager {
   public readonly registry: ModuleRegistry;
   public readonly resolver: Resolver;
@@ -47,7 +65,14 @@ export class ModuleManager {
   private readonly resolvedAssociations = new Map<string, Set<string>>();
   private readonly staticModules: ManagedModule[] = [];
   private readonly loaded = new Map<string, ManagedModule>();
-  private readonly stubbedInterfacePaths = new Map<string, string>();
+  private readonly stubbedInterfacePackages = new Map<
+    string,
+    ResolvedPackage
+  >();
+  private readonly interfacePackagePlans = new Map<
+    string,
+    InterfacePackagePlan
+  >();
   private startupOrder: string[] = [];
 
   constructor(deps: ModuleManagerDeps = {}) {
@@ -179,48 +204,51 @@ export class ModuleManager {
   }
 
   registerStubbedInterfaces(stubbed: UnresolvedInterface[]): void {
-    for (const { moduleId, interfacePackage, standalone } of stubbed) {
-      if (this.stubbedInterfacePaths.has(interfacePackage)) {
-        continue;
-      }
-      const consumerFolder = this.loaded.get(moduleId)?.module.manifest.folder;
-      if (!consumerFolder) {
-        continue;
-      }
-      const pkgRoot = this.resolveInterfacePackageRoot(
-        interfacePackage,
-        consumerFolder,
+    const packageNames = new Set(
+      stubbed.map((entry) => entry.interfacePackage),
+    );
+    for (const packageName of packageNames) {
+      const entries = stubbed.filter(
+        (entry) => entry.interfacePackage === packageName,
       );
-      if (!pkgRoot) {
-        continue;
-      }
-      this.stubbedInterfacePaths.set(interfacePackage, pkgRoot);
-      this.resolver.interfacePackages.set(interfacePackage, pkgRoot);
-      logStubInterfaceWarningOnce(interfacePackage, standalone);
+      this.registerStubbedInterfacePackage(packageName, entries);
     }
   }
 
-  private resolveInterfacePackageRoot(
-    ifacePkg: string,
-    fromFolder: string,
-  ): string | undefined {
-    try {
-      const mainPath = require.resolve(ifacePkg, { paths: [fromFolder] });
-      return extractPackageRoot(mainPath, ifacePkg);
-    } catch {
-      return undefined;
+  private registerStubbedInterfacePackage(
+    packageName: string,
+    entries: UnresolvedInterface[],
+  ): void {
+    const consumers = this.collectInterfacePackageConsumers(packageName);
+    const canonicalPackage = consumers.find(
+      (consumer) => consumer.resolvedPackage,
+    )?.resolvedPackage;
+    if (!canonicalPackage) {
+      return;
     }
+    this.stubbedInterfacePackages.set(packageName, canonicalPackage);
+    this.interfacePackagePlans.set(packageName, {
+      canonicalPackage,
+      consumers,
+    });
+    this.registerInterfacePackage(packageName, canonicalPackage);
+    logStubInterfaceWarningOnce(
+      packageName,
+      entries.some((entry) => entry.standalone),
+    );
   }
 
   private applyInterfaceStubs(): void {
     const implemented = this.collectImplementedInterfaces();
-    for (const [interfaceName, pkgRoot] of [...this.stubbedInterfacePaths]) {
+    for (const [interfaceName, resolvedPackage] of [
+      ...this.stubbedInterfacePackages,
+    ]) {
       if (implemented.has(interfaceName)) {
-        this.stubbedInterfacePaths.delete(interfaceName);
+        this.stubbedInterfacePackages.delete(interfaceName);
         continue;
       }
       if (!this.resolver.interfacePackages.has(interfaceName)) {
-        this.resolver.interfacePackages.set(interfaceName, pkgRoot);
+        this.registerInterfacePackage(interfaceName, resolvedPackage);
       }
       try {
         require(interfaceName);
@@ -228,7 +256,7 @@ export class ModuleManager {
         Logger.Error(`Failed to load interface '${interfaceName}':`, err);
         continue;
       }
-      neutralizeInterfacePackage(pkgRoot, interfaceName);
+      neutralizeInterfacePackage(resolvedPackage.root, interfaceName);
     }
   }
 
@@ -245,6 +273,7 @@ export class ModuleManager {
   }
 
   async constructAll(): Promise<void> {
+    this.validateInterfacePackages();
     this.resolverDetour.attach();
     this.applyInterfaceStubs();
     try {
@@ -266,6 +295,7 @@ export class ModuleManager {
   }
 
   async constructModules(modules: ManagedModule[]): Promise<void> {
+    this.validateInterfacePackages();
     this.resolverDetour.attach();
     this.applyInterfaceStubs();
     await Promise.all(
@@ -334,7 +364,7 @@ export class ModuleManager {
       }
     } finally {
       this.startupOrder = [];
-      this.stubbedInterfacePaths.clear();
+      this.stubbedInterfacePackages.clear();
       clearStubInterfaceWarnings();
       this.resolverDetour.detach();
     }
@@ -354,6 +384,9 @@ export class ModuleManager {
     this.resolver.moduleByFolder.clear();
     this.resolver.modulesById.clear();
     this.resolver.interfacePackages.clear();
+    this.resolver.interfacePackageEntries.clear();
+    this.resolver.interfacePackageResolveFrom.clear();
+    this.interfacePackagePlans.clear();
     this.resolvedAssociations.clear();
     this.moduleTracker.clear();
 
@@ -392,23 +425,134 @@ export class ModuleManager {
     interfaceSources: Map<string, Module>,
   ): void {
     for (const [ifacePkg, module] of interfaceSources) {
-      // If the module implements its own package, use its folder directly
-      if (module.manifest.manifest.name === ifacePkg) {
-        this.resolver.interfacePackages.set(ifacePkg, module.manifest.folder);
+      const canonicalPackage = this.resolveImplementedPackage(ifacePkg, module);
+      if (!canonicalPackage) {
         continue;
       }
-      try {
-        const mainPath = require.resolve(ifacePkg, {
-          paths: [module.manifest.folder],
-        });
-        const pkgRoot = extractPackageRoot(mainPath, ifacePkg);
-        if (pkgRoot) {
-          this.resolver.interfacePackages.set(ifacePkg, pkgRoot);
-        }
-      } catch {
-        // Not an installable npm package (old-style name like "greeter@v1") — skip
-      }
+      this.interfacePackagePlans.set(ifacePkg, {
+        canonicalPackage,
+        consumers: this.collectInterfacePackageConsumers(ifacePkg),
+      });
+      this.registerInterfacePackage(ifacePkg, canonicalPackage);
     }
+    for (const [packageName, canonicalPackage] of this
+      .stubbedInterfacePackages) {
+      if (interfaceSources.has(packageName)) {
+        continue;
+      }
+      this.interfacePackagePlans.set(packageName, {
+        canonicalPackage,
+        consumers: this.collectInterfacePackageConsumers(packageName),
+      });
+      this.registerInterfacePackage(packageName, canonicalPackage);
+    }
+  }
+
+  private resolveImplementedPackage(
+    packageName: string,
+    module: Module,
+  ): ResolvedPackage | undefined {
+    const resolvedPackage = resolvePackage(packageName, module.manifest.folder);
+    if (resolvedPackage) {
+      return resolvedPackage;
+    }
+    if (module.manifest.manifest.name !== packageName) {
+      return undefined;
+    }
+    return resolvePackageAtRoot(
+      packageName,
+      module.manifest.folder,
+      module.manifest.version,
+    );
+  }
+
+  private collectInterfacePackageConsumers(
+    packageName: string,
+  ): InterfacePackageConsumer[] {
+    const consumers: InterfacePackageConsumer[] = [];
+    for (const { module } of this.loaded.values()) {
+      const manifest = module.manifest.manifest;
+      const range =
+        manifest.dependencies?.[packageName] ??
+        manifest.optionalDependencies?.[packageName];
+      if (!range) {
+        continue;
+      }
+      consumers.push({
+        moduleId: module.id,
+        range,
+        resolvedPackage: resolvePackage(packageName, module.manifest.folder),
+      });
+    }
+    return consumers;
+  }
+
+  private registerInterfacePackage(
+    packageName: string,
+    resolvedPackage: ResolvedPackage,
+  ): void {
+    this.resolver.interfacePackages.set(packageName, resolvedPackage.root);
+    this.resolver.interfacePackageEntries.set(
+      packageName,
+      resolvedPackage.entry,
+    );
+    this.resolver.interfacePackageResolveFrom.set(
+      packageName,
+      resolvedPackage.resolveFrom,
+    );
+  }
+
+  private validateInterfacePackages(): void {
+    const errors = [...this.interfacePackagePlans].flatMap(([name, plan]) => [
+      ...this.findVersionErrors(name, plan),
+      ...this.findPreloadedCopyErrors(name, plan),
+    ]);
+    if (errors.length === 0) {
+      return;
+    }
+    throw new Error(
+      `Incompatible interface package resolution:\n${errors.join("\n")}`,
+    );
+  }
+
+  private findVersionErrors(
+    packageName: string,
+    plan: InterfacePackagePlan,
+  ): string[] {
+    return plan.consumers.flatMap((consumer) => {
+      const range = validRange(consumer.range);
+      if (!range || satisfies(plan.canonicalPackage.version, range)) {
+        return [];
+      }
+      const installed = consumer.resolvedPackage
+        ? `${consumer.resolvedPackage.version} at ${consumer.resolvedPackage.root}`
+        : "not installed from the consumer";
+      return [
+        `  - ${consumer.moduleId} requires ${packageName}@${consumer.range}, but the canonical package is ${plan.canonicalPackage.version} at ${plan.canonicalPackage.root} (consumer copy: ${installed})`,
+      ];
+    });
+  }
+
+  private findPreloadedCopyErrors(
+    packageName: string,
+    plan: InterfacePackagePlan,
+  ): string[] {
+    const canonicalRoot = plan.canonicalPackage.realRoot;
+    const copies = plan.consumers
+      .map((consumer) => consumer.resolvedPackage)
+      .filter((resolvedPackage): resolvedPackage is ResolvedPackage =>
+        Boolean(resolvedPackage && resolvedPackage.realRoot !== canonicalRoot),
+      );
+    return copies.flatMap((copy) => {
+      const loadedFile = Object.keys(require.cache).find((filePath) =>
+        isPathWithin(filePath, copy.root),
+      );
+      return loadedFile
+        ? [
+            `  - ${packageName}@${copy.version} was loaded from ${copy.root} before the canonical copy at ${plan.canonicalPackage.root}; preloaded interface copies cannot be redirected (${loadedFile})`,
+          ]
+        : [];
+    });
   }
 
   private buildModuleAssociations(interfaceSources: Map<string, Module>): void {
@@ -471,23 +615,6 @@ export class ModuleManager {
   }
 
   private isPathWithin(filePath: string, dirPath: string): boolean {
-    const normalizedDir = path.resolve(dirPath);
-    const normalizedFile = path.resolve(filePath);
-    if (normalizedFile === normalizedDir) {
-      return true;
-    }
-    return normalizedFile.startsWith(normalizedDir + path.sep);
+    return isPathWithin(filePath, dirPath);
   }
-}
-
-function extractPackageRoot(
-  mainPath: string,
-  ifacePkg: string,
-): string | undefined {
-  const marker = `${path.sep}${ifacePkg.replace("/", path.sep)}${path.sep}`;
-  const scopeIndex = mainPath.indexOf(marker);
-  if (scopeIndex === -1) {
-    return undefined;
-  }
-  return mainPath.substring(0, scopeIndex + marker.length - 1);
 }

--- a/src/core/resolution/interface-resolution.ts
+++ b/src/core/resolution/interface-resolution.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { resolvePackage } from "./package-resolution";
 
 export interface InterfaceProvider {
   implements: string[];
@@ -37,19 +37,14 @@ function readInterfacePackageInfo(
   dep: string,
   consumerFolder: string,
 ): InterfacePackageInfo {
-  try {
-    const pkgJsonPath = require.resolve(`${dep}/package.json`, {
-      paths: [consumerFolder],
-    });
-    const depPkg = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
-    const antelopeJs = depPkg.antelopeJs;
-    return {
-      isInterface: Boolean(antelopeJs),
-      standalone: Boolean(antelopeJs?.standalone),
-    };
-  } catch {
+  const resolvedPackage = resolvePackage(dep, consumerFolder);
+  if (!resolvedPackage) {
     return { isInterface: false, standalone: false };
   }
+  return {
+    isInterface: Boolean(resolvedPackage.antelopeJs),
+    standalone: Boolean(resolvedPackage.antelopeJs?.standalone),
+  };
 }
 
 export function findUnresolvedInterfaces(

--- a/src/core/resolution/package-resolution.ts
+++ b/src/core/resolution/package-resolution.ts
@@ -1,0 +1,129 @@
+import { readFileSync, realpathSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+export interface ResolvedPackage {
+  name: string;
+  version: string;
+  root: string;
+  realRoot: string;
+  entry: string;
+  resolveFrom: string;
+  antelopeJs?: Record<string, unknown>;
+}
+
+interface PackageJson {
+  name?: string;
+  version?: string;
+  antelopeJs?: Record<string, unknown>;
+}
+
+function normalizeExistingPath(filePath: string): string {
+  const resolvedPath = path.resolve(filePath);
+  try {
+    return realpathSync.native(resolvedPath);
+  } catch {
+    return resolvedPath;
+  }
+}
+
+export function getPathVariants(filePath: string): string[] {
+  const logicalPath = path.resolve(filePath);
+  const realPath = normalizeExistingPath(logicalPath);
+  return logicalPath === realPath ? [logicalPath] : [logicalPath, realPath];
+}
+
+export function isPathWithin(filePath: string, folderPath: string): boolean {
+  return getPathVariants(filePath).some((fileVariant) =>
+    getPathVariants(folderPath).some((folderVariant) => {
+      const relativePath = path.relative(folderVariant, fileVariant);
+      return (
+        relativePath === "" ||
+        (!relativePath.startsWith(`..${path.sep}`) &&
+          relativePath !== ".." &&
+          !path.isAbsolute(relativePath))
+      );
+    }),
+  );
+}
+
+function readPackageJson(packageRoot: string): PackageJson | undefined {
+  try {
+    return JSON.parse(
+      readFileSync(path.join(packageRoot, "package.json"), "utf8"),
+    ) as PackageJson;
+  } catch {
+    return undefined;
+  }
+}
+
+function createResolvedPackage(
+  packageRoot: string,
+  entry: string,
+  resolveFrom: string,
+  manifest: PackageJson,
+): ResolvedPackage | undefined {
+  if (!manifest.name || !manifest.version) {
+    return undefined;
+  }
+  return {
+    name: manifest.name,
+    version: manifest.version,
+    root: path.resolve(packageRoot),
+    realRoot: normalizeExistingPath(packageRoot),
+    entry: path.resolve(entry),
+    resolveFrom: path.resolve(resolveFrom),
+    antelopeJs: manifest.antelopeJs,
+  };
+}
+
+export function findPackageFromEntry(
+  entry: string,
+  packageName: string,
+  resolveFrom: string,
+): ResolvedPackage | undefined {
+  let currentFolder = statSync(entry).isDirectory()
+    ? entry
+    : path.dirname(entry);
+  while (true) {
+    const manifest = readPackageJson(currentFolder);
+    if (manifest?.name === packageName) {
+      return createResolvedPackage(currentFolder, entry, resolveFrom, manifest);
+    }
+    const parentFolder = path.dirname(currentFolder);
+    if (parentFolder === currentFolder) {
+      return undefined;
+    }
+    currentFolder = parentFolder;
+  }
+}
+
+export function resolvePackage(
+  packageName: string,
+  fromFolder: string,
+): ResolvedPackage | undefined {
+  try {
+    const entry = createRequire(
+      path.join(path.resolve(fromFolder), "__antelope_resolver__.js"),
+    ).resolve(packageName);
+    return findPackageFromEntry(entry, packageName, fromFolder);
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolvePackageAtRoot(
+  packageName: string,
+  packageRoot: string,
+  version: string,
+): ResolvedPackage {
+  const root = path.resolve(packageRoot);
+  return {
+    name: packageName,
+    version,
+    root,
+    realRoot: normalizeExistingPath(root),
+    entry: root,
+    resolveFrom: root,
+  };
+}

--- a/src/core/resolution/path-mapper.ts
+++ b/src/core/resolution/path-mapper.ts
@@ -19,7 +19,7 @@ export class PathMapper {
   resolve(request: string, manifest: ModuleManifest): string | undefined {
     if (manifest.srcAliases) {
       for (const { alias, replace } of manifest.srcAliases) {
-        if (request.startsWith(alias)) {
+        if (request === alias || request.startsWith(`${alias}/`)) {
           return request.length > alias.length
             ? path.join(replace, request.substring(alias.length))
             : replace;

--- a/src/core/resolution/resolver.ts
+++ b/src/core/resolution/resolver.ts
@@ -1,5 +1,5 @@
-import path from "node:path";
 import type { ModuleManifest } from "../module-manifest";
+import { isPathWithin, resolvePackage } from "./package-resolution";
 import type { PathMapper } from "./path-mapper";
 
 export interface ModuleRef {
@@ -13,14 +13,16 @@ export interface ResolveResult {
 }
 
 const CORE_PKG = "@antelopejs/interface-core";
-const CORE_RESOLVE_FROM = path.dirname(
-  require.resolve(`${CORE_PKG}/package.json`),
-);
+const CORE_PACKAGE = resolvePackage(CORE_PKG, __dirname);
+const CORE_RESOLVE_FROM = CORE_PACKAGE?.root ?? __dirname;
+const CORE_ENTRY = CORE_PACKAGE?.entry ?? CORE_PKG;
 
 export class Resolver {
   public readonly moduleByFolder = new Map<string, ModuleRef>();
   public readonly modulesById = new Map<string, ModuleRef>();
   public readonly interfacePackages = new Map<string, string>();
+  public readonly interfacePackageEntries = new Map<string, string>();
+  public readonly interfacePackageResolveFrom = new Map<string, string>();
   public stubModulePath?: string;
 
   constructor(private pathMapper: PathMapper) {}
@@ -52,7 +54,7 @@ export class Resolver {
 
   private resolveInterfaceCore(request: string): ResolveResult | undefined {
     if (request === CORE_PKG) {
-      return { resolvedPath: CORE_RESOLVE_FROM };
+      return { resolvedPath: CORE_ENTRY };
     }
     if (request.startsWith(`${CORE_PKG}/`)) {
       return { resolvedPath: request, resolveFrom: CORE_RESOLVE_FROM };
@@ -63,10 +65,15 @@ export class Resolver {
   private resolveInterfacePackage(request: string): ResolveResult | undefined {
     for (const [pkg, rootDir] of this.interfacePackages) {
       if (request === pkg) {
-        return { resolvedPath: rootDir };
+        return {
+          resolvedPath: this.interfacePackageEntries.get(pkg) ?? rootDir,
+        };
       }
       if (request.startsWith(`${pkg}/`)) {
-        return { resolvedPath: request, resolveFrom: rootDir };
+        return {
+          resolvedPath: request,
+          resolveFrom: this.interfacePackageResolveFrom.get(pkg) ?? rootDir,
+        };
       }
     }
     return undefined;
@@ -80,7 +87,7 @@ export class Resolver {
     let matchingModule: ModuleRef | undefined;
     for (const [folder, module] of this.moduleByFolder) {
       if (
-        fileName.startsWith(folder) &&
+        isPathWithin(fileName, folder) &&
         folder.length > matchingFolder.length
       ) {
         matchingFolder = folder;

--- a/src/core/runtime/module-loading.ts
+++ b/src/core/runtime/module-loading.ts
@@ -363,7 +363,9 @@ async function reloadLoadedModuleFromSource(
   ensureReloadedModuleId(replacement, moduleId);
   manager.replaceLoadedModule(moduleId, replacement);
   manager.refreshAssociations();
-  await replacement.construct(entry.config.config);
+  await manager.constructModules([
+    { module: replacement, config: entry.config },
+  ]);
   await replacement.start();
 }
 

--- a/test/core/module-manager.test.ts
+++ b/test/core/module-manager.test.ts
@@ -48,6 +48,126 @@ async function createTempModuleWithInterfacePkg(): Promise<{
   return { root, modulePath, interfacePkg, interfacePkgDir };
 }
 
+interface ResolutionFixture {
+  root: string;
+  providerPath: string;
+  consumerPath: string;
+  packageName: string;
+  providerPackageRoot: string;
+  consumerPackageRoot: string;
+}
+
+interface ResolutionFixtureVersions {
+  provider: string;
+  consumer: string;
+  range: string;
+}
+
+async function writeInterfacePackage(
+  packageRoot: string,
+  packageName: string,
+  version: string,
+): Promise<void> {
+  await mkdir(path.join(packageRoot, "dist"), { recursive: true });
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      name: packageName,
+      version,
+      exports: { ".": "./dist/index.js" },
+      antelopeJs: {},
+    }),
+  );
+  await writeFile(
+    path.join(packageRoot, "dist", "index.js"),
+    `module.exports = ${JSON.stringify(version)};`,
+  );
+}
+
+async function createResolutionFixture(
+  versions: ResolutionFixtureVersions,
+): Promise<ResolutionFixture> {
+  const root = await mkdtemp(path.join(tmpdir(), "ajs-interface-resolution-"));
+  const providerPath = path.join(root, "provider");
+  const consumerPath = path.join(root, "consumer");
+  const packageName = "interface-shared";
+  const providerPackageRoot = path.join(
+    providerPath,
+    "node_modules",
+    packageName,
+  );
+  const consumerPackageRoot = path.join(
+    consumerPath,
+    "node_modules",
+    packageName,
+  );
+  await mkdir(providerPath, { recursive: true });
+  await mkdir(consumerPath, { recursive: true });
+  await writeFile(
+    path.join(providerPath, "package.json"),
+    JSON.stringify({ name: "provider", version: "1.0.0" }),
+  );
+  await writeFile(
+    path.join(consumerPath, "package.json"),
+    JSON.stringify({
+      name: "consumer",
+      version: "1.0.0",
+      dependencies: { [packageName]: versions.range },
+    }),
+  );
+  await writeInterfacePackage(
+    providerPackageRoot,
+    packageName,
+    versions.provider,
+  );
+  await writeInterfacePackage(
+    consumerPackageRoot,
+    packageName,
+    versions.consumer,
+  );
+  return {
+    root,
+    providerPath,
+    consumerPath,
+    packageName,
+    providerPackageRoot,
+    consumerPackageRoot,
+  };
+}
+
+async function createResolutionManager(
+  fixture: ResolutionFixture,
+): Promise<ModuleManager> {
+  const providerSource: ModuleSourceLocal = {
+    type: "local",
+    path: fixture.providerPath,
+  };
+  const providerManifest = await ModuleManifest.create(
+    fixture.providerPath,
+    providerSource,
+    "provider",
+  );
+  providerManifest.implements = [fixture.packageName];
+  const consumerSource: ModuleSourceLocal = {
+    type: "local",
+    path: fixture.consumerPath,
+  };
+  const consumerManifest = await ModuleManifest.create(
+    fixture.consumerPath,
+    consumerSource,
+    "consumer",
+  );
+  const manager = new ModuleManager();
+  const modules = manager.addModules([
+    { manifest: providerManifest },
+    { manifest: consumerManifest },
+  ]);
+  modules.forEach(({ module }) => {
+    sinon.stub(module, "construct").resolves();
+  });
+  return manager;
+}
+
 describe("ModuleManager", () => {
   beforeEach(() => {
     internal.moduleByFolder.splice(0, internal.moduleByFolder.length);
@@ -552,6 +672,86 @@ describe("ModuleManager", () => {
       );
     } finally {
       await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("canonicalizes compatible physical package copies before construction", async () => {
+    const fixture = await createResolutionFixture({
+      provider: "1.4.0",
+      consumer: "1.2.0",
+      range: "^1.0.0",
+    });
+    try {
+      const manager = await createResolutionManager(fixture);
+
+      await manager.constructAll();
+
+      expect(
+        manager.resolver.interfacePackages.get(fixture.packageName),
+      ).to.equal(fixture.providerPackageRoot);
+      expect(
+        manager.resolver.interfacePackageEntries.get(fixture.packageName),
+      ).to.equal(path.join(fixture.providerPackageRoot, "dist", "index.js"));
+      await manager.destroyAll();
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a canonical v2 package for a consumer requiring v1", async () => {
+    const fixture = await createResolutionFixture({
+      provider: "2.0.0",
+      consumer: "1.8.0",
+      range: "^1.0.0",
+    });
+    try {
+      const manager = await createResolutionManager(fixture);
+      let error: Error | undefined;
+
+      try {
+        await manager.constructAll();
+      } catch (caught) {
+        error = caught as Error;
+      }
+
+      expect(error?.message).to.include(
+        "consumer requires interface-shared@^1.0.0, but the canonical package is 2.0.0",
+      );
+      const consumer = manager.getModule("consumer") as any;
+      expect(consumer.construct.called).to.equal(false);
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an incompatible interface copy loaded before construction", async () => {
+    const fixture = await createResolutionFixture({
+      provider: "1.4.0",
+      consumer: "1.2.0",
+      range: "^1.0.0",
+    });
+    const consumerRequire = Module.createRequire(
+      path.join(fixture.consumerPath, "index.js"),
+    );
+    const loadedEntry = consumerRequire.resolve(fixture.packageName);
+    try {
+      consumerRequire(fixture.packageName);
+      const manager = await createResolutionManager(fixture);
+      let error: Error | undefined;
+
+      try {
+        await manager.constructAll();
+      } catch (caught) {
+        error = caught as Error;
+      }
+
+      expect(error?.message).to.include("was loaded from");
+      expect(error?.message).to.include(
+        "preloaded interface copies cannot be redirected",
+      );
+    } finally {
+      delete require.cache[loadedEntry];
+      await rm(fixture.root, { recursive: true, force: true });
     }
   });
 

--- a/test/core/resolution/interface-resolution.test.ts
+++ b/test/core/resolution/interface-resolution.test.ts
@@ -143,7 +143,12 @@ describe("findUnresolvedInterfaces (standalone interfaces)", () => {
     mkdirSync(dir, { recursive: true });
     writeFileSync(
       path.join(dir, "package.json"),
-      JSON.stringify({ name, version: "1.0.0", main: "index.js", antelopeJs }),
+      JSON.stringify({
+        name,
+        version: "1.0.0",
+        exports: { ".": "./index.js" },
+        antelopeJs,
+      }),
     );
     writeFileSync(path.join(dir, "index.js"), "module.exports = {};");
   }

--- a/test/core/resolution/package-resolution.test.ts
+++ b/test/core/resolution/package-resolution.test.ts
@@ -1,0 +1,104 @@
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { expect } from "chai";
+import {
+  findPackageFromEntry,
+  isPathWithin,
+  resolvePackage,
+} from "../../../src/core/resolution/package-resolution";
+import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
+
+interface SymlinkPackageFixture {
+  root: string;
+  consumer: string;
+  packageRoot: string;
+  packageLink: string;
+  entry: string;
+}
+
+function createSymlinkPackage(packageName: string): SymlinkPackageFixture {
+  const root = makeTempDir("ajs-package-resolution-");
+  const consumer = path.join(root, "consumer");
+  const packageRoot = path.join(root, "workspace", ...packageName.split("/"));
+  const packageLink = path.join(
+    consumer,
+    "node_modules",
+    ...packageName.split("/"),
+  );
+  const entry = path.join(packageRoot, "dist", "index.js");
+  mkdirSync(path.dirname(entry), { recursive: true });
+  mkdirSync(path.dirname(packageLink), { recursive: true });
+  writeFileSync(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      name: packageName,
+      version: "1.2.3",
+      exports: { ".": "./dist/index.js" },
+      antelopeJs: {},
+    }),
+  );
+  writeFileSync(entry, "module.exports = {};");
+  symlinkSync(packageRoot, packageLink, "dir");
+  return { root, consumer, packageRoot, packageLink, entry };
+}
+
+describe("package resolution", () => {
+  for (const packageName of ["interface-plain", "@scope/interface-scoped"]) {
+    it(`discovers ${packageName} through a workspace symlink and hidden manifest`, () => {
+      const fixture = createSymlinkPackage(packageName);
+      try {
+        const resolvedPackage = resolvePackage(packageName, fixture.consumer);
+
+        expect(resolvedPackage?.name).to.equal(packageName);
+        expect(resolvedPackage?.version).to.equal("1.2.3");
+        expect(resolvedPackage?.realRoot).to.equal(fixture.packageRoot);
+        expect(resolvedPackage?.entry).to.equal(fixture.entry);
+      } finally {
+        cleanupTempDir(fixture.root);
+      }
+    });
+  }
+
+  it("preserves a logical package root when the resolved entry is not canonicalized", () => {
+    const fixture = createSymlinkPackage("@scope/interface-logical");
+    try {
+      const logicalEntry = path.join(fixture.packageLink, "dist", "index.js");
+      const resolvedPackage = findPackageFromEntry(
+        logicalEntry,
+        "@scope/interface-logical",
+        fixture.consumer,
+      );
+
+      expect(resolvedPackage?.root).to.equal(fixture.packageLink);
+      expect(resolvedPackage?.realRoot).to.equal(fixture.packageRoot);
+      expect(isPathWithin(fixture.entry, fixture.packageLink)).to.equal(true);
+      expect(isPathWithin(logicalEntry, fixture.packageRoot)).to.equal(true);
+    } finally {
+      cleanupTempDir(fixture.root);
+    }
+  });
+
+  it("resolves an exported package from inside its own workspace root", () => {
+    const fixture = createSymlinkPackage("@scope/interface-self");
+    try {
+      const resolvedPackage = resolvePackage(
+        "@scope/interface-self",
+        fixture.packageRoot,
+      );
+
+      expect(resolvedPackage?.root).to.equal(fixture.packageRoot);
+      expect(resolvedPackage?.entry).to.equal(fixture.entry);
+    } finally {
+      cleanupTempDir(fixture.root);
+    }
+  });
+
+  it("uses path boundaries for module ownership", () => {
+    expect(isPathWithin("/modules/mod-a/index.js", "/modules/mod-a")).to.equal(
+      true,
+    );
+    expect(isPathWithin("/modules/mod-a2/index.js", "/modules/mod-a")).to.equal(
+      false,
+    );
+  });
+});

--- a/test/core/resolution/path-mapper.test.ts
+++ b/test/core/resolution/path-mapper.test.ts
@@ -29,6 +29,14 @@ describe("PathMapper", () => {
     expect(result).to.equal("/mod/src");
   });
 
+  it("does not resolve aliases that only share a prefix", () => {
+    const mapper = new PathMapper(() => false);
+
+    const result = mapper.resolve("@src-extra/utils", manifest);
+
+    expect(result).to.equal(undefined);
+  });
+
   it("should resolve mapped paths when target exists", () => {
     const existing = new Set<string>(["/mod/src/lib/util.js"]);
     const mapper = new PathMapper((p) => existing.has(p));

--- a/test/core/resolution/resolver.test.ts
+++ b/test/core/resolution/resolver.test.ts
@@ -4,6 +4,7 @@ import { PathMapper } from "../../../src/core/resolution/path-mapper";
 import { Resolver } from "../../../src/core/resolution/resolver";
 
 const CORE_PKG = "@antelopejs/interface-core";
+const CORE_CANONICAL_ENTRY = require.resolve(CORE_PKG);
 const CORE_CANONICAL_DIR = path.dirname(
   require.resolve(`${CORE_PKG}/package.json`),
 );
@@ -83,6 +84,17 @@ describe("Resolver", () => {
     expect(result?.resolvedPath).to.equal("/modA/src/utils");
   });
 
+  it("does not assign sibling folders that only share a prefix", () => {
+    const resolver = new Resolver(new PathMapper(() => false));
+    resolver.moduleByFolder.set("/modules/mod-a", moduleA);
+
+    const result = resolver.resolve("@src/utils", {
+      filename: "/modules/mod-a2/index.js",
+    } as any);
+
+    expect(result).to.equal(undefined);
+  });
+
   it("resolves interface package to canonical path", () => {
     const resolver = new Resolver(new PathMapper(() => false));
     resolver.interfacePackages.set(
@@ -130,7 +142,7 @@ describe("Resolver", () => {
 
     const result = resolver.resolve(CORE_PKG);
 
-    expect(result?.resolvedPath).to.equal(CORE_CANONICAL_DIR);
+    expect(result?.resolvedPath).to.equal(CORE_CANONICAL_ENTRY);
     expect(result?.resolveFrom).to.equal(undefined);
   });
 
@@ -149,7 +161,7 @@ describe("Resolver", () => {
 
     const result = resolver.resolve(CORE_PKG);
 
-    expect(result?.resolvedPath).to.equal(CORE_CANONICAL_DIR);
+    expect(result?.resolvedPath).to.equal(CORE_CANONICAL_ENTRY);
   });
 
   it("does not redirect packages that merely share the interface-core prefix", () => {

--- a/test/core/runtime/module-loading.test.ts
+++ b/test/core/runtime/module-loading.test.ts
@@ -2,7 +2,10 @@ import * as moduleInterfaceBeta from "@antelopejs/interface-core/modules";
 import { expect } from "chai";
 import sinon from "sinon";
 import { terminalDisplay } from "../../../src/core/cli/terminal-display";
-import type { ModuleManager } from "../../../src/core/module-manager";
+import type {
+  ManagedModule,
+  ModuleManager,
+} from "../../../src/core/module-manager";
 import {
   constructAndStartModules,
   ensureGraphIsValid,
@@ -10,6 +13,14 @@ import {
   registerCoreModuleInterface,
   reloadWatchedModule,
 } from "../../../src/core/runtime/module-loading";
+
+async function constructManagedModules(
+  entries: ManagedModule[],
+): Promise<void> {
+  await Promise.all(
+    entries.map(({ module, config }) => module.construct(config.config)),
+  );
+}
 
 describe("runtime module-loading", () => {
   afterEach(() => {
@@ -80,6 +91,7 @@ describe("runtime module-loading", () => {
       unrequireModuleFiles: sinon.stub(),
       replaceLoadedModule: replaceLoadedModuleStub,
       refreshAssociations: refreshAssociationsStub,
+      constructModules: sinon.stub().callsFake(constructManagedModules),
     } as any;
 
     const manifest = {
@@ -112,6 +124,49 @@ describe("runtime module-loading", () => {
     ).to.equal(true);
     expect(replaceLoadedModuleStub.calledOnce).to.equal(true);
     expect(refreshAssociationsStub.calledOnce).to.equal(true);
+    expect(manager.constructModules.calledOnce).to.equal(true);
+  });
+
+  it("propagates interface compatibility validation during reload", async () => {
+    const entry = {
+      module: {
+        manifest: { source: { type: "local", path: "/mods/alpha" } },
+        destroy: sinon.stub().resolves(),
+      },
+      config: { config: {} },
+    };
+    const compatibilityError = new Error(
+      "Incompatible interface package resolution",
+    );
+    const manager = {
+      getLoadedModuleEntry: sinon.stub().returns(entry),
+      unrequireModuleFiles: sinon.stub(),
+      replaceLoadedModule: sinon.stub(),
+      refreshAssociations: sinon.stub(),
+      constructModules: sinon.stub().rejects(compatibilityError),
+    } as any;
+    const manifest = {
+      name: "alpha",
+      version: "1.0.0",
+      main: __filename,
+      folder: "/mods/alpha",
+      source: { type: "local", path: "/mods/alpha" },
+    } as any;
+    const loaderContext = {
+      cache: {},
+      projectFolder: "/project",
+      registry: { load: sinon.stub().resolves([manifest]) },
+    } as any;
+
+    let thrown: unknown;
+    try {
+      await reloadWatchedModule(manager, "alpha", loaderContext);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.equal(compatibilityError);
+    expect(manager.constructModules.calledOnce).to.equal(true);
   });
 
   it("propagates error when registry.load fails during reload", async () => {
@@ -172,6 +227,7 @@ describe("runtime module-loading", () => {
       unrequireModuleFiles: sinon.stub(),
       replaceLoadedModule: replaceLoadedModuleStub,
       refreshAssociations: refreshAssociationsStub,
+      constructModules: sinon.stub().callsFake(constructManagedModules),
     } as any;
 
     const manifest = {


### PR DESCRIPTION
## Summary
- discover interface package roots from resolved entries and matching package manifests, including hidden manifests, exports, scoped packages, and workspace symlinks
- canonicalize logical/real paths with boundary-safe ownership checks and exact alias boundaries
- collect interface package versions, roots, and consumer ranges before construction, rejecting semver conflicts and preloaded noncanonical copies
- preserve canonical entry and resolution context so exported package entry points and subpaths resolve correctly

## Compatibility
- compatible physical duplicates remain canonicalized to the provider's package copy
- incompatible consumer ranges fail before any module construction with package versions and roots in the diagnostic
- no dependency on unpublished interface-core APIs and no multi-provider dispatch changes

## Verification
- `pnpm test:unit` (610 passing)
- `pnpm test:playground` (all phases passed; includes build)
- `pnpm test:coverage` (coverage thresholds passed)
- `pnpm run lint` (passes with two existing warnings and one existing info diagnostic in unrelated files)
- targeted Biome check for all changed files (clean)
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes interface-package discovery and canonical resolution deterministic and extends compatibility validation to hot reloads. The reload fix currently validates only after committing destructive lifecycle and registry changes.
- Resolves package roots through entries and matching manifests, including exports and symlinked packages.
- Canonicalizes interface package copies and validates consumer semver ranges before construction.
- Routes reload construction through ModuleManager compatibility validation.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a rejected reload can destroy the working module and leave an unconstructed replacement registered.

Compatibility validation now covers reloads, but it runs only after the active module has been destroyed and manager state has been switched to the replacement, with no rollback when validation fails.

**Files Needing Attention:** src/core/runtime/module-loading.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/module-manager.ts | Adds canonical interface-package plans, semver validation, preloaded-copy checks, and deterministic resolver registration; its validation correctly detects the previously missed reload incompatibility. |
| src/core/runtime/module-loading.ts | Routes reloads through compatibility validation, but does so after destroying and replacing the active module, leaving broken runtime state when validation rejects. |
| src/core/resolution/package-resolution.ts | Introduces package-root discovery and logical/real-path ownership helpers used by deterministic interface resolution. |
| src/core/resolution/resolver.ts | Preserves canonical package entries and resolution contexts for package roots and exported subpaths. |
| test/core/runtime/module-loading.test.ts | Covers propagation of compatibility errors during reload but not the resulting manager, registry, or lifecycle state. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Watcher
    participant Reload
    participant Manager
    participant Old as Active module
    participant New as Replacement
    Watcher->>Reload: reload module
    Reload->>Old: destroy()
    Reload->>Manager: replaceLoadedModule(New)
    Reload->>Manager: refreshAssociations()
    Reload->>Manager: constructModules(New)
    Manager->>Manager: validateInterfacePackages()
    Manager-->>Reload: throw incompatibility
    Note over Manager,New: Registry and graph retain an unconstructed replacement
    Note over Old: Previous working module is already destroyed
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/core/runtime/module-loading.ts:366-368
**Failed reload replaces working module**

When a reloaded manifest requires an incompatible interface range, the active module has already been destroyed and the replacement registered before `constructModules` rejects it, leaving the runtime graph pointing to a replacement that was never constructed or started.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(runtime): validate interfaces during..."](https://github.com/antelopejs/antelopejs/commit/e0bd4c55d0d265b660da4ac2bcfb466deea74e61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54580799)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->