### PR TITLE
fix(runtime): coordinate process-global ownership

### DIFF
--- a/src/core/interface-registry.ts
+++ b/src/core/interface-registry.ts
@@ -10,12 +10,19 @@ interface InterfaceConnectionEntry {
   id?: string;
 }
 
+type ModuleConnections = Record<string, InterfaceConnectionEntry[]>;
+
+const ownersByModule = new Map<string, Map<symbol, ModuleConnections>>();
+
 export class InterfaceRegistry {
+  private readonly owner = Symbol("interface-registry");
+  private readonly moduleIds = new Set<string>();
+
   setConnections(
     moduleId: string,
     connections: Map<string, InterfaceConnectionRef[]>,
   ): void {
-    const connectionIDs: Record<string, InterfaceConnectionEntry[]> = {};
+    const connectionIDs: ModuleConnections = {};
     for (const [interfaceName, modules] of connections) {
       connectionIDs[interfaceName] = modules.map(({ id }) => {
         const entry: InterfaceConnectionEntry = {
@@ -27,6 +34,47 @@ export class InterfaceRegistry {
         return entry;
       });
     }
+    const owners = this.getCurrentOwners(moduleId);
+    owners.set(this.owner, connectionIDs);
+    this.moduleIds.add(moduleId);
     internal.interfaceConnections[moduleId] = connectionIDs;
+  }
+
+  clear(): void {
+    for (const moduleId of this.moduleIds) {
+      this.removeOwner(moduleId);
+    }
+    this.moduleIds.clear();
+  }
+
+  private getCurrentOwners(moduleId: string): Map<symbol, ModuleConnections> {
+    const owners = ownersByModule.get(moduleId) ?? new Map();
+    const current = internal.interfaceConnections[moduleId];
+    if (current && [...owners.values()].includes(current)) {
+      return owners;
+    }
+    owners.clear();
+    ownersByModule.set(moduleId, owners);
+    return owners;
+  }
+
+  private removeOwner(moduleId: string): void {
+    const owners = ownersByModule.get(moduleId);
+    if (!owners) {
+      return;
+    }
+    const current = internal.interfaceConnections[moduleId];
+    if (!current || ![...owners.values()].includes(current)) {
+      ownersByModule.delete(moduleId);
+      return;
+    }
+    owners.delete(this.owner);
+    const remaining = [...owners.values()].at(-1);
+    if (remaining) {
+      internal.interfaceConnections[moduleId] = remaining;
+      return;
+    }
+    delete internal.interfaceConnections[moduleId];
+    ownersByModule.delete(moduleId);
   }
 }

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -245,9 +245,9 @@ export class ModuleManager {
   }
 
   async constructAll(): Promise<void> {
-    this.resolverDetour.attach();
-    this.applyInterfaceStubs();
+    const leaseAcquired = this.resolverDetour.attach();
     try {
+      this.applyInterfaceStubs();
       await Promise.all(
         [...this.loaded.values()].map(({ module, config }) =>
           module.construct(config.config).catch((err) => {
@@ -260,25 +260,34 @@ export class ModuleManager {
         ),
       );
     } catch (err) {
-      this.resolverDetour.detach();
+      if (leaseAcquired) {
+        this.releaseRuntimeState();
+      }
       throw err;
     }
   }
 
   async constructModules(modules: ManagedModule[]): Promise<void> {
-    this.resolverDetour.attach();
-    this.applyInterfaceStubs();
-    await Promise.all(
-      modules.map(({ module, config }) =>
-        module.construct(config.config).catch((err) => {
-          Logger.Error(`Failed to construct module:`);
-          Logger.Error(`  - ID: ${module.id}`);
-          Logger.Error(`  - Version: ${module.version}`);
-          Logger.Error("  - Error:", err);
-          throw err;
-        }),
-      ),
-    );
+    const leaseAcquired = this.resolverDetour.attach();
+    try {
+      this.applyInterfaceStubs();
+      await Promise.all(
+        modules.map(({ module, config }) =>
+          module.construct(config.config).catch((err) => {
+            Logger.Error(`Failed to construct module:`);
+            Logger.Error(`  - ID: ${module.id}`);
+            Logger.Error(`  - Version: ${module.version}`);
+            Logger.Error("  - Error:", err);
+            throw err;
+          }),
+        ),
+      );
+    } catch (err) {
+      if (leaseAcquired) {
+        this.releaseRuntimeState();
+      }
+      throw err;
+    }
   }
 
   async startAll(): Promise<void> {
@@ -334,10 +343,16 @@ export class ModuleManager {
       }
     } finally {
       this.startupOrder = [];
-      this.stubbedInterfacePaths.clear();
-      clearStubInterfaceWarnings();
-      this.resolverDetour.detach();
+      this.releaseRuntimeState();
     }
+  }
+
+  private releaseRuntimeState(): void {
+    this.stubbedInterfacePaths.clear();
+    clearStubInterfaceWarnings();
+    this.moduleTracker.clear();
+    this.interfaceRegistry.clear();
+    this.resolverDetour.detach();
   }
 
   private trackModuleStart(moduleId: string): void {
@@ -356,6 +371,7 @@ export class ModuleManager {
     this.resolver.interfacePackages.clear();
     this.resolvedAssociations.clear();
     this.moduleTracker.clear();
+    this.interfaceRegistry.clear();
 
     const interfaceSources = new Map<string, Module>();
     for (const { module, config } of this.loaded.values()) {

--- a/src/core/module-tracker.ts
+++ b/src/core/module-tracker.ts
@@ -7,11 +7,22 @@ export interface ModuleFolderEntry {
 }
 
 export class ModuleTracker {
+  private readonly entries = new Set<ModuleFolderEntry>();
+
   add(entry: ModuleFolderEntry): void {
+    this.entries.add(entry);
     internal.moduleByFolder.push(entry);
   }
 
   clear(): void {
-    internal.moduleByFolder.splice(0, internal.moduleByFolder.length);
+    const retained = internal.moduleByFolder.filter(
+      (entry) => !this.entries.has(entry),
+    );
+    internal.moduleByFolder.splice(
+      0,
+      internal.moduleByFolder.length,
+      ...retained,
+    );
+    this.entries.clear();
   }
 }

--- a/src/core/resolution/resolver-detour.ts
+++ b/src/core/resolution/resolver-detour.ts
@@ -9,45 +9,102 @@ type ModuleResolver = (
   options: any,
 ) => string;
 
-export class ResolverDetour {
-  private oldResolver?: ModuleResolver;
+interface ResolverLease {
+  owner: symbol;
+  resolver: Resolver;
+}
 
-  constructor(private resolver: Resolver) {}
+class ResolverDetourCoordinator {
+  private readonly leases: ResolverLease[] = [];
+  private originalResolver?: ModuleResolver;
+  private installedResolver?: ModuleResolver;
 
-  attach(): void {
-    if (!this.oldResolver) {
-      this.oldResolver = (Module as any)._resolveFilename;
-      (Module as any)._resolveFilename = (
-        request: string,
-        parent: any,
-        isMain: boolean,
-        options: any,
-      ) => {
-        const result = this.resolver.resolve(request, parent);
-        if (!result) {
-          return this.oldResolver?.(request, parent, isMain, options);
-        }
-        if (result.resolveFrom) {
-          const contextParent = {
-            ...parent,
-            filename: path.join(result.resolveFrom, "_"),
-          };
-          return this.oldResolver?.(
-            result.resolvedPath,
-            contextParent,
-            isMain,
-            options,
-          );
-        }
-        return this.oldResolver?.(result.resolvedPath, parent, isMain, options);
-      };
+  attach(owner: symbol, resolver: Resolver): boolean {
+    if (this.leases.some((lease) => lease.owner === owner)) {
+      return false;
+    }
+    this.ensureInstalled();
+    this.leases.push({ owner, resolver });
+    return true;
+  }
+
+  detach(owner: symbol): void {
+    const leaseIndex = this.leases.findIndex((lease) => lease.owner === owner);
+    if (leaseIndex === -1) {
+      return;
+    }
+    this.leases.splice(leaseIndex, 1);
+    if ((Module as any)._resolveFilename !== this.installedResolver) {
+      if (this.leases.length === 0) {
+        this.originalResolver = undefined;
+        this.installedResolver = undefined;
+      }
+      throw new Error("Node module resolver hook was replaced externally");
+    }
+    if (this.leases.length === 0) {
+      (Module as any)._resolveFilename = this.originalResolver;
+      this.originalResolver = undefined;
+      this.installedResolver = undefined;
     }
   }
 
-  detach(): void {
-    if (this.oldResolver) {
-      (Module as any)._resolveFilename = this.oldResolver;
-      this.oldResolver = undefined;
+  private ensureInstalled(): void {
+    if (this.installedResolver) {
+      this.ensureHookOwnership();
+      return;
     }
+    this.originalResolver = (Module as any)._resolveFilename;
+    this.installedResolver = (request, parent, isMain, options) =>
+      this.resolve(request, parent, isMain, options);
+    (Module as any)._resolveFilename = this.installedResolver;
+  }
+
+  private ensureHookOwnership(): void {
+    if ((Module as any)._resolveFilename !== this.installedResolver) {
+      throw new Error("Node module resolver hook was replaced externally");
+    }
+  }
+
+  private resolve(
+    request: string,
+    parent: any,
+    isMain: boolean,
+    options: any,
+  ): string {
+    const activeResolver = this.leases.at(-1)?.resolver;
+    const result = activeResolver?.resolve(request, parent);
+    if (!result) {
+      return this.originalResolver?.(
+        request,
+        parent,
+        isMain,
+        options,
+      ) as string;
+    }
+    const contextParent = result.resolveFrom
+      ? { ...parent, filename: path.join(result.resolveFrom, "_") }
+      : parent;
+    return this.originalResolver?.(
+      result.resolvedPath,
+      contextParent,
+      isMain,
+      options,
+    ) as string;
+  }
+}
+
+const coordinator = new ResolverDetourCoordinator();
+
+export class ResolverDetour {
+  private readonly owner = Symbol("resolver-detour");
+
+  constructor(private resolver: Resolver) {}
+
+  attach(): boolean {
+    return coordinator.attach(this.owner, this.resolver);
+  }
+
+  detach(): void {
+    coordinator.detach(this.owner);
   }
 }

--- a/src/core/runtime/launch-sequence.ts
+++ b/src/core/runtime/launch-sequence.ts
@@ -17,6 +17,7 @@ import {
   buildModuleConfigs,
   constructAndStartModules,
   createLoaderContext,
+  destroyModulesAfterFailure,
   ensureGraphIsValid,
   registerCoreInterfaces,
   registerCoreModuleInterface,
@@ -208,8 +209,7 @@ async function startProjectModules(
       await constructAndStartModules(moduleManager);
       return moduleManager;
     } catch (error) {
-      await moduleManager.destroyAll();
-      throw error;
+      return destroyModulesAfterFailure(moduleManager, error);
     }
   });
 }

--- a/src/core/runtime/launch-sequence.ts
+++ b/src/core/runtime/launch-sequence.ts
@@ -24,6 +24,7 @@ import {
 import {
   applyVerboseChannels,
   loadProjectConfig,
+  releaseProcessShutdownManager,
   setupProcessHandlers,
   withRaisedMaxListeners,
 } from "./runtime-bootstrap";
@@ -31,6 +32,7 @@ import type {
   LoaderConfig,
   LoaderContext,
   LoaderContextProvider,
+  PreparedProject,
   ProjectPreparer,
   StartedProject,
 } from "./runtime-types";
@@ -143,6 +145,27 @@ export async function runLaunchSequence(
   const shutdownManager = new ShutdownManager();
   setupProcessHandlers(shutdownManager);
 
+  try {
+    return await completeLaunchSequence(
+      prepare,
+      projectFolder,
+      env,
+      options,
+      shutdownManager,
+    );
+  } catch (error) {
+    releaseProcessShutdownManager(shutdownManager);
+    throw error;
+  }
+}
+
+async function completeLaunchSequence(
+  prepare: ProjectPreparer,
+  projectFolder: string,
+  env: string,
+  options: LaunchOptions,
+  shutdownManager: ShutdownManager,
+): Promise<StartedProject> {
   const project = await prepare(projectFolder, env);
 
   setupAntelopeProjectLogging(project.logging);
@@ -158,18 +181,7 @@ export async function runLaunchSequence(
     shutdownManager,
   });
 
-  const manager = await withRaisedMaxListeners(async () => {
-    const moduleManager = new ModuleManager();
-
-    registerCoreModuleInterface(moduleManager, project.loadContext);
-    await registerCoreInterfaces(moduleManager);
-
-    moduleManager.addModules(await project.createEntries());
-
-    ensureGraphIsValid(moduleManager);
-    await constructAndStartModules(moduleManager);
-    return moduleManager;
-  });
+  const manager = await startProjectModules(project);
 
   return {
     manager,
@@ -178,4 +190,26 @@ export async function runLaunchSequence(
     fs: project.fs,
     shutdownManager,
   };
+}
+
+async function startProjectModules(
+  project: PreparedProject,
+): Promise<ModuleManager> {
+  return withRaisedMaxListeners(async () => {
+    const moduleManager = new ModuleManager();
+
+    try {
+      registerCoreModuleInterface(moduleManager, project.loadContext);
+      await registerCoreInterfaces(moduleManager);
+
+      moduleManager.addModules(await project.createEntries());
+
+      ensureGraphIsValid(moduleManager);
+      await constructAndStartModules(moduleManager);
+      return moduleManager;
+    } catch (error) {
+      await moduleManager.destroyAll();
+      throw error;
+    }
+  });
 }

--- a/src/core/runtime/module-loading.ts
+++ b/src/core/runtime/module-loading.ts
@@ -407,7 +407,19 @@ export async function constructAndStartModules(
   }
 
   await terminalDisplay.stopSpinner(`Done loading`);
-  await manager.startAll();
+  try {
+    await manager.startAll();
+  } catch (error) {
+    try {
+      await manager.destroyAll();
+    } catch (cleanupError) {
+      Logger.Error(
+        "Failed to clean up modules after startup failure:",
+        cleanupError,
+      );
+    }
+    throw error;
+  }
 }
 
 export function ensureGraphIsValid(manager: ModuleManager): void {

--- a/src/core/runtime/module-loading.ts
+++ b/src/core/runtime/module-loading.ts
@@ -412,6 +412,21 @@ export async function constructAndStartModules(
   await manager.startAll();
 }
 
+export async function destroyModulesAfterFailure(
+  manager: ModuleManager,
+  error: unknown,
+): Promise<never> {
+  try {
+    await manager.destroyAll();
+  } catch (cleanupError) {
+    Logger.Error(
+      "Failed to clean up modules after startup failure:",
+      cleanupError,
+    );
+  }
+  throw error;
+}
+
 export function ensureGraphIsValid(manager: ModuleManager): void {
   const allModules = manager.getAllManagedModules();
   const loadedModules = [...manager.getLoadedModules()];

--- a/src/core/runtime/module-loading.ts
+++ b/src/core/runtime/module-loading.ts
@@ -407,19 +407,7 @@ export async function constructAndStartModules(
   }
 
   await terminalDisplay.stopSpinner(`Done loading`);
-  try {
-    await manager.startAll();
-  } catch (error) {
-    try {
-      await manager.destroyAll();
-    } catch (cleanupError) {
-      Logger.Error(
-        "Failed to clean up modules after startup failure:",
-        cleanupError,
-      );
-    }
-    throw error;
-  }
+  await manager.startAll();
 }
 
 export function ensureGraphIsValid(manager: ModuleManager): void {

--- a/src/core/runtime/runtime-bootstrap.ts
+++ b/src/core/runtime/runtime-bootstrap.ts
@@ -15,9 +15,10 @@ import type {
 const EXIT_CODE_ERROR = 1;
 const DEFAULT_MAX_EVENT_LISTENERS = 50;
 let processHandlersReady = false;
-let activeShutdownManager: ShutdownManager | undefined;
+const shutdownManagers: ShutdownManager[] = [];
 
 function shutdownProcess(exitCode: number): void {
+  const activeShutdownManager = shutdownManagers.at(-1);
   if (activeShutdownManager) {
     void activeShutdownManager.shutdown(exitCode);
     return;
@@ -28,7 +29,8 @@ function shutdownProcess(exitCode: number): void {
 
 export function setupProcessHandlers(shutdownManager?: ShutdownManager): void {
   if (shutdownManager) {
-    activeShutdownManager = shutdownManager;
+    releaseProcessShutdownManager(shutdownManager);
+    shutdownManagers.push(shutdownManager);
   }
 
   if (processHandlersReady) {
@@ -54,6 +56,15 @@ export function setupProcessHandlers(shutdownManager?: ShutdownManager): void {
   process.on("warning", (warning: Error) => {
     Logging.Warn("Warning:", warning);
   });
+}
+
+export function releaseProcessShutdownManager(
+  shutdownManager: ShutdownManager,
+): void {
+  const index = shutdownManagers.indexOf(shutdownManager);
+  if (index !== -1) {
+    shutdownManagers.splice(index, 1);
+  }
 }
 
 export async function withRaisedMaxListeners<T>(

--- a/src/core/test/test-module.ts
+++ b/src/core/test/test-module.ts
@@ -14,6 +14,7 @@ import { ModuleManager } from "../module-manager";
 import { registerCoreRuntimeInterface } from "../runtime/dev-server-registry";
 import {
   constructAndStartModules,
+  destroyModulesAfterFailure,
   ensureGraphIsValid,
   loadModuleEntriesForManager,
 } from "../runtime/module-loading";
@@ -132,8 +133,7 @@ export async function setupTestEnvironment(
       registerTestDir(path.resolve(moduleRoot), manager);
       return manager;
     } catch (error) {
-      await manager.destroyAll();
-      throw error;
+      return destroyModulesAfterFailure(manager, error);
     }
   });
 }

--- a/src/core/test/test-module.ts
+++ b/src/core/test/test-module.ts
@@ -117,19 +117,24 @@ export async function setupTestEnvironment(
 
   return withRaisedMaxListeners(async () => {
     const manager = new ModuleManager();
-    manager.resolver.stubModulePath = STUB_INTERFACE_PATH;
-    await loadModuleEntriesForManager(manager, normalizedConfig, true);
-    ensureGraphIsValid(manager);
-    await registerCoreRuntimeInterface({
-      dev: false,
-      projectPath: moduleRoot,
-      env: DEFAULT_ENV,
-      fs,
-    });
-    await constructAndStartModules(manager);
-    internal.testStubMode = true;
-    registerTestDir(path.resolve(moduleRoot), manager);
-    return manager;
+    try {
+      manager.resolver.stubModulePath = STUB_INTERFACE_PATH;
+      await loadModuleEntriesForManager(manager, normalizedConfig, true);
+      ensureGraphIsValid(manager);
+      await registerCoreRuntimeInterface({
+        dev: false,
+        projectPath: moduleRoot,
+        env: DEFAULT_ENV,
+        fs,
+      });
+      await constructAndStartModules(manager);
+      internal.testStubMode = true;
+      registerTestDir(path.resolve(moduleRoot), manager);
+      return manager;
+    } catch (error) {
+      await manager.destroyAll();
+      throw error;
+    }
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,11 @@ async function setupWatching(
     loadedSignatures.set(moduleId, signature);
   });
 
+  shutdownManager.register(async () => {
+    hotReload.clear();
+    watcher.stopWatching();
+  }, SHUTDOWN_PRIORITY_RESOURCES);
+
   for (const { module } of manager.getLoadedModules()) {
     if (module.manifest?.source?.type === "local") {
       const watchDirs = getWatchDirs(module.manifest.source);
@@ -136,11 +141,6 @@ async function setupWatching(
 
   watcher.onModuleChanged((id) => hotReload.queue(id));
   watcher.startWatching();
-
-  shutdownManager.register(async () => {
-    hotReload.clear();
-    watcher.stopWatching();
-  }, SHUTDOWN_PRIORITY_RESOURCES);
 }
 
 async function setupPostLaunchFeatures(
@@ -172,11 +172,10 @@ async function setupPostLaunchFeatures(
 
   if (started.dev && options.interactive) {
     const repl = new ReplSession({ moduleManager: manager });
-    repl.start(INTERACTIVE_PROMPT);
-
     shutdownManager.register(async () => {
       repl.close();
     }, SHUTDOWN_PRIORITY_RESOURCES);
+    repl.start(INTERACTIVE_PROMPT);
   }
 
   setActiveShutdownManager(shutdownManager);
@@ -189,8 +188,13 @@ async function startProject(
   options: LaunchOptions,
 ): Promise<ModuleManager> {
   const started = await runLaunchSequence(prepare, projectFolder, env, options);
-  await setupPostLaunchFeatures(started, projectFolder, env, options);
-  return started.manager;
+  try {
+    await setupPostLaunchFeatures(started, projectFolder, env, options);
+    return started.manager;
+  } catch (error) {
+    await started.shutdownManager.shutdown();
+    throw error;
+  }
 }
 
 let isRestarting = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
 } from "./core/runtime/module-loading";
 import {
   loadProjectRuntimeConfig,
+  releaseProcessShutdownManager,
   withRaisedMaxListeners,
 } from "./core/runtime/runtime-bootstrap";
 import type {
@@ -58,12 +59,26 @@ const UNSUPPORTED_ARTIFACT_OPTIONS_WARNING =
 
 Writable.prototype.setMaxListeners(MAX_STREAM_LISTENERS);
 
-let activeShutdownManager: ShutdownManager | undefined;
+const activeShutdownManagers: ShutdownManager[] = [];
 
 function setActiveShutdownManager(shutdownManager: ShutdownManager): void {
-  activeShutdownManager?.removeSignalHandlers();
-  activeShutdownManager = shutdownManager;
+  releaseActiveShutdownManager(shutdownManager);
+  activeShutdownManagers.at(-1)?.removeSignalHandlers();
+  activeShutdownManagers.push(shutdownManager);
   shutdownManager.setupSignalHandlers();
+}
+
+function releaseActiveShutdownManager(shutdownManager: ShutdownManager): void {
+  const index = activeShutdownManagers.indexOf(shutdownManager);
+  if (index === -1) {
+    return;
+  }
+  const wasActive = index === activeShutdownManagers.length - 1;
+  activeShutdownManagers.splice(index, 1);
+  shutdownManager.removeSignalHandlers();
+  if (wasActive) {
+    activeShutdownManagers.at(-1)?.setupSignalHandlers();
+  }
 }
 
 function registerModuleShutdownHandler(
@@ -78,10 +93,8 @@ function registerModuleShutdownHandler(
 
 function registerShutdownCleanup(shutdownManager: ShutdownManager): void {
   shutdownManager.register(async () => {
-    shutdownManager.removeSignalHandlers();
-    if (activeShutdownManager === shutdownManager) {
-      activeShutdownManager = undefined;
-    }
+    releaseActiveShutdownManager(shutdownManager);
+    releaseProcessShutdownManager(shutdownManager);
   }, SHUTDOWN_PRIORITY_CLEANUP);
 }
 
@@ -191,6 +204,7 @@ async function restartProject(
   isRestarting = true;
 
   try {
+    const activeShutdownManager = activeShutdownManagers.at(-1);
     if (activeShutdownManager) {
       await activeShutdownManager.shutdown();
     }
@@ -226,18 +240,22 @@ export async function build(
 
   await withRaisedMaxListeners(async () => {
     const manager = new ModuleManager();
-    const entries = await loadModuleEntriesForManager(
-      manager,
-      runtimeConfig.normalizedConfig,
-      false,
-    );
-    ensureGraphIsValid(manager);
-    await writeProjectBuildArtifact(
-      runtimeConfig.normalizedConfig,
-      env,
-      entries,
-      runtimeConfig.fs,
-    );
+    try {
+      const entries = await loadModuleEntriesForManager(
+        manager,
+        runtimeConfig.normalizedConfig,
+        false,
+      );
+      ensureGraphIsValid(manager);
+      await writeProjectBuildArtifact(
+        runtimeConfig.normalizedConfig,
+        env,
+        entries,
+        runtimeConfig.fs,
+      );
+    } finally {
+      await manager.destroyAll();
+    }
   });
 }
 

--- a/test/core/core-interface.test.ts
+++ b/test/core/core-interface.test.ts
@@ -83,7 +83,7 @@ describe("core/beta module interface", () => {
     sinon.stub(Module.prototype, "construct").resolves();
     sinon.stub(Module.prototype, "start").resolves();
 
-    await launch("/project", "default", {});
+    const manager = await launch("/project", "default", {});
     startStub.resetHistory();
 
     const list = await moduleInterfaceBeta.ListModules();
@@ -123,5 +123,6 @@ describe("core/beta module interface", () => {
       error = err;
     }
     expect(error).to.be.instanceOf(Error);
+    await manager.destroyAll();
   });
 });

--- a/test/core/interface-registry.test.ts
+++ b/test/core/interface-registry.test.ts
@@ -27,5 +27,38 @@ describe("InterfaceRegistry", () => {
       { path: "core@beta" },
       { path: "core@beta", id: "x" },
     ]);
+    registry.clear();
+  });
+
+  it("restores duplicate module IDs when the newer owner clears first", () => {
+    const first = new InterfaceRegistry();
+    const second = new InterfaceRegistry();
+    const firstConnections = new Map([["first", [{ module: "provider" }]]]);
+    const secondConnections = new Map([["second", [{ module: "provider" }]]]);
+
+    first.setConnections("duplicate", firstConnections);
+    second.setConnections("duplicate", secondConnections);
+    second.clear();
+
+    expect(internal.interfaceConnections.duplicate).to.have.key("first");
+
+    first.clear();
+    expect(internal.interfaceConnections.duplicate).to.equal(undefined);
+  });
+
+  it("preserves duplicate module IDs when the older owner clears first", () => {
+    const first = new InterfaceRegistry();
+    const second = new InterfaceRegistry();
+    const firstConnections = new Map([["first", [{ module: "provider" }]]]);
+    const secondConnections = new Map([["second", [{ module: "provider" }]]]);
+
+    first.setConnections("duplicate", firstConnections);
+    second.setConnections("duplicate", secondConnections);
+    first.clear();
+
+    expect(internal.interfaceConnections.duplicate).to.have.key("second");
+
+    second.clear();
+    expect(internal.interfaceConnections.duplicate).to.equal(undefined);
   });
 });

--- a/test/core/module-manager.test.ts
+++ b/test/core/module-manager.test.ts
@@ -632,4 +632,79 @@ describe("ModuleManager", () => {
       }
     }
   });
+
+  it("releases the resolver lease when partial construction fails", async () => {
+    const originalResolver = (Module as any)._resolveFilename;
+    const manager = new ModuleManager();
+    const moduleEntry = {
+      module: {
+        id: "failing",
+        version: "1.0.0",
+        construct: sinon.stub().rejects(new Error("construct failed")),
+      },
+      config: {},
+    };
+
+    let constructionError: unknown;
+    try {
+      await manager.constructModules([moduleEntry as any]);
+    } catch (error) {
+      constructionError = error;
+    }
+
+    expect(constructionError).to.be.instanceOf(Error);
+    expect((Module as any)._resolveFilename).to.equal(originalResolver);
+  });
+
+  it("keeps manager-owned global state isolated during rebuild and destroy", async () => {
+    const first = new ModuleManager();
+    const second = new ModuleManager();
+    const firstManifest = {
+      name: "duplicate",
+      version: "1.0.0",
+      main: "/first/index.js",
+      folder: "/first",
+      manifest: { name: "duplicate", version: "1.0.0" },
+      source: { type: "local", path: "/first" },
+    } as any;
+    const secondManifest = {
+      ...firstManifest,
+      main: "/second/index.js",
+      folder: "/second",
+      source: { type: "local", path: "/second" },
+    } as any;
+
+    first.addModules([{ manifest: firstManifest }]);
+    second.addModules([{ manifest: secondManifest }]);
+    first.refreshAssociations();
+
+    expect(
+      internal.moduleByFolder.map((entry) => entry.dir).sort(),
+    ).to.deep.equal(["/first", "/second"]);
+
+    await first.destroyAll();
+    expect(internal.moduleByFolder.map((entry) => entry.dir)).to.deep.equal([
+      "/second",
+    ]);
+    expect(internal.interfaceConnections.duplicate).to.not.equal(undefined);
+
+    await second.destroyAll();
+    expect(internal.moduleByFolder).to.have.length(0);
+    expect(internal.interfaceConnections.duplicate).to.equal(undefined);
+  });
+
+  it("does not leak leases or global state across repeated destruction", async () => {
+    const originalResolver = (Module as any)._resolveFilename;
+    const manager = new ModuleManager();
+
+    await manager.constructAll();
+    await manager.destroyAll();
+    await manager.destroyAll();
+    await manager.constructAll();
+    await manager.destroyAll();
+
+    expect((Module as any)._resolveFilename).to.equal(originalResolver);
+    expect(internal.moduleByFolder).to.have.length(0);
+    expect(internal.interfaceConnections).to.deep.equal({});
+  });
 });

--- a/test/core/module-tracker.test.ts
+++ b/test/core/module-tracker.test.ts
@@ -25,6 +25,38 @@ describe("ModuleTracker", () => {
     expect(internal.moduleByFolder).to.have.length(0);
   });
 
+  it("clears only entries owned by the tracker", () => {
+    const first = new ModuleTracker();
+    const second = new ModuleTracker();
+
+    first.add({ id: "shared", dir: "/first" });
+    second.add({ id: "shared", dir: "/second" });
+
+    first.clear();
+    expect(internal.moduleByFolder).to.deep.equal([
+      { id: "shared", dir: "/second" },
+    ]);
+
+    second.clear();
+    expect(internal.moduleByFolder).to.have.length(0);
+  });
+
+  it("supports clearing owners in reverse order", () => {
+    const first = new ModuleTracker();
+    const second = new ModuleTracker();
+
+    first.add({ id: "first", dir: "/first" });
+    second.add({ id: "second", dir: "/second" });
+
+    second.clear();
+    expect(internal.moduleByFolder.map((entry) => entry.id)).to.deep.equal([
+      "first",
+    ]);
+
+    first.clear();
+    expect(internal.moduleByFolder).to.have.length(0);
+  });
+
   it("should preserve the isImplementor flag on added entries", () => {
     const tracker = new ModuleTracker();
 

--- a/test/core/resolution/resolver-detour.test.ts
+++ b/test/core/resolution/resolver-detour.test.ts
@@ -4,33 +4,94 @@ import { PathMapper } from "../../../src/core/resolution/path-mapper";
 import { Resolver } from "../../../src/core/resolution/resolver";
 import { ResolverDetour } from "../../../src/core/resolution/resolver-detour";
 
-describe("ResolverDetour", () => {
-  it("should attach and detach from Node resolver", () => {
-    const original = (Module as any)._resolveFilename;
-    let lastRequest = "";
-    const stubResolver = (request: string) => {
-      lastRequest = request;
-      return request;
-    };
-    (Module as any)._resolveFilename = stubResolver;
+type ModuleResolver = (request: string) => string;
 
-    const resolver = new Resolver(new PathMapper(() => false));
-    const detour = new ResolverDetour(resolver);
+function createResolver(resolvedPath?: string): Resolver {
+  const resolver = new Resolver(new PathMapper(() => false));
+  if (resolvedPath) {
+    resolver.resolve = () => ({ resolvedPath });
+  }
+  return resolver;
+}
+
+function resolveRequest(): string {
+  return (Module as any)._resolveFilename(
+    "request",
+    { filename: "/module/index.js" },
+    false,
+    {},
+  );
+}
+
+describe("ResolverDetour", () => {
+  const processResolver = (Module as any)._resolveFilename;
+  let originalResolver: ModuleResolver;
+
+  beforeEach(() => {
+    originalResolver = (request) => request;
+    (Module as any)._resolveFilename = originalResolver;
+  });
+
+  afterEach(() => {
+    (Module as any)._resolveFilename = processResolver;
+  });
+
+  it("uses one process hook and preserves the newer lease", () => {
+    const first = new ResolverDetour(createResolver("first"));
+    const second = new ResolverDetour(createResolver("second"));
+
+    first.attach();
+    const processHook = (Module as any)._resolveFilename;
+    second.attach();
+
+    expect((Module as any)._resolveFilename).to.equal(processHook);
+    expect(resolveRequest()).to.equal("second");
+
+    first.detach();
+    expect((Module as any)._resolveFilename).to.equal(processHook);
+    expect(resolveRequest()).to.equal("second");
+
+    second.detach();
+    expect((Module as any)._resolveFilename).to.equal(originalResolver);
+  });
+
+  it("restores the older lease when the newer lease detaches first", () => {
+    const first = new ResolverDetour(createResolver("first"));
+    const second = new ResolverDetour(createResolver("second"));
+
+    first.attach();
+    second.attach();
+    second.detach();
+
+    expect(resolveRequest()).to.equal("first");
+
+    first.detach();
+    expect((Module as any)._resolveFilename).to.equal(originalResolver);
+  });
+
+  it("attaches and detaches each lease idempotently", () => {
+    const detour = new ResolverDetour(createResolver());
 
     detour.attach();
-    const result = (Module as any)._resolveFilename(
-      "test",
-      { filename: "/modA/src/index.js" },
-      false,
-      {},
-    );
-
-    expect(result).to.equal("test");
-    expect(lastRequest).to.equal("test");
+    const processHook = (Module as any)._resolveFilename;
+    detour.attach();
+    expect((Module as any)._resolveFilename).to.equal(processHook);
 
     detour.detach();
-    expect((Module as any)._resolveFilename).to.equal(stubResolver);
+    detour.detach();
+    expect((Module as any)._resolveFilename).to.equal(originalResolver);
+  });
 
-    (Module as any)._resolveFilename = original;
+  it("detects an externally replaced process hook without overwriting it", () => {
+    const detour = new ResolverDetour(createResolver());
+    const externalResolver = (request: string) => `external:${request}`;
+
+    detour.attach();
+    (Module as any)._resolveFilename = externalResolver;
+
+    expect(() => detour.detach()).to.throw(
+      "Node module resolver hook was replaced externally",
+    );
+    expect((Module as any)._resolveFilename).to.equal(externalResolver);
   });
 });

--- a/test/core/runtime/module-loading.test.ts
+++ b/test/core/runtime/module-loading.test.ts
@@ -246,6 +246,23 @@ describe("runtime module-loading", () => {
       true,
     );
     expect(failingManager.startAll.called).to.equal(false);
+
+    const startupFailure = new Error("start failed");
+    const startFailingManager = {
+      constructAll: sinon.stub().resolves(),
+      startAll: sinon.stub().rejects(startupFailure),
+      destroyAll: sinon.stub().resolves(),
+    } as any;
+
+    thrown = undefined;
+    try {
+      await constructAndStartModules(startFailingManager);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.equal(startupFailure);
+    expect(startFailingManager.destroyAll.calledOnce).to.equal(true);
   });
 
   it("resolves only after async start hooks settle", async () => {

--- a/test/core/runtime/module-loading.test.ts
+++ b/test/core/runtime/module-loading.test.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../../src/core/module-manager";
 import {
   constructAndStartModules,
+  destroyModulesAfterFailure,
   ensureGraphIsValid,
   getWatchDirs,
   registerCoreModuleInterface,
@@ -353,6 +354,23 @@ describe("runtime module-loading", () => {
     await pending;
     expect(startSettled).to.equal(true);
     expect(resolved).to.equal(true);
+  });
+
+  it("preserves startup errors when cleanup also fails", async () => {
+    const startupFailure = new Error("start failed");
+    const manager = {
+      destroyAll: sinon.stub().rejects(new Error("destroy failed")),
+    } as any;
+
+    let thrown: unknown;
+    try {
+      await destroyModulesAfterFailure(manager, startupFailure);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.equal(startupFailure);
+    expect(manager.destroyAll.calledOnce).to.equal(true);
   });
 
   it("handles module interface operations and error branches", async () => {

--- a/test/core/runtime/module-loading.test.ts
+++ b/test/core/runtime/module-loading.test.ts
@@ -251,7 +251,6 @@ describe("runtime module-loading", () => {
     const startFailingManager = {
       constructAll: sinon.stub().resolves(),
       startAll: sinon.stub().rejects(startupFailure),
-      destroyAll: sinon.stub().resolves(),
     } as any;
 
     thrown = undefined;
@@ -262,7 +261,6 @@ describe("runtime module-loading", () => {
     }
 
     expect(thrown).to.equal(startupFailure);
-    expect(startFailingManager.destroyAll.calledOnce).to.equal(true);
   });
 
   it("resolves only after async start hooks settle", async () => {

--- a/test/core/runtime/runtime-bootstrap.test.ts
+++ b/test/core/runtime/runtime-bootstrap.test.ts
@@ -128,6 +128,36 @@ describe("runtime runtime-bootstrap", () => {
     }
   });
 
+  it("restores the previous process shutdown manager on release", () => {
+    const originalListeners = snapshotProcessListeners();
+    const bootstrap = loadBootstrapModule();
+    const first = new ShutdownManager();
+    const second = new ShutdownManager();
+    const firstShutdown = sinon.stub(first, "shutdown").resolves();
+    const secondShutdown = sinon.stub(second, "shutdown").resolves();
+    const exitStub = sinon.stub(process, "exit");
+
+    try {
+      bootstrap.setupProcessHandlers(first);
+      bootstrap.setupProcessHandlers(second);
+      bootstrap.releaseProcessShutdownManager(second);
+
+      const current = snapshotProcessListeners();
+      const uncaught = current.uncaughtException[
+        current.uncaughtException.length - 1
+      ] as (error: Error) => void;
+      uncaught(new Error("boom"));
+
+      expect(firstShutdown.calledOnceWith(1)).to.equal(true);
+      expect(secondShutdown.called).to.equal(false);
+      expect(exitStub.called).to.equal(false);
+      bootstrap.releaseProcessShutdownManager(first);
+    } finally {
+      restoreProcessListeners(originalListeners);
+      exitStub.restore();
+    }
+  });
+
   it("allows late wiring of shutdown manager after handlers are registered", () => {
     const originalListeners = snapshotProcessListeners();
     const bootstrap = loadBootstrapModule();

--- a/test/core/test/test-module.test.ts
+++ b/test/core/test/test-module.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { expect } from "chai";
 import sinon from "sinon";
 import { ConfigLoader } from "../../../src/core/config/config-loader";
+import { ModuleManager } from "../../../src/core/module-manager";
 import * as testModule from "../../../src/core/test/test-module";
 import { InMemoryFileSystem } from "../../helpers/in-memory-filesystem";
 
@@ -475,6 +476,33 @@ describe("test-module", () => {
   });
 
   describe("setupTestEnvironment", () => {
+    it("destroys the manager when startup fails", async () => {
+      const moduleLoading = require("../../../src/core/runtime/module-loading");
+      const startupFailure = new Error("start failed");
+      sinon.stub(moduleLoading, "loadModuleEntriesForManager").resolves([]);
+      sinon
+        .stub(moduleLoading, "constructAndStartModules")
+        .rejects(startupFailure);
+      const destroyStub = sinon
+        .stub(ModuleManager.prototype, "destroyAll")
+        .resolves();
+
+      let thrown: unknown;
+      try {
+        await testModule.setupTestEnvironment("/module", {
+          name: "test",
+          cacheFolder: ".antelope/cache",
+          modules: {},
+          envOverrides: {},
+        } as any);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).to.equal(startupFailure);
+      expect(destroyStub.calledOnce).to.equal(true);
+    });
+
     it("enables auto-stub on the module manager resolver", async () => {
       const { internal } = await import("@antelopejs/interface-core/internal");
       const moduleLoading = require("../../../src/core/runtime/module-loading");

--- a/test/core/test/test-module.test.ts
+++ b/test/core/test/test-module.test.ts
@@ -503,6 +503,33 @@ describe("test-module", () => {
       expect(destroyStub.calledOnce).to.equal(true);
     });
 
+    it("preserves startup errors when test-runtime cleanup fails", async () => {
+      const moduleLoading = require("../../../src/core/runtime/module-loading");
+      const startupFailure = new Error("start failed");
+      sinon.stub(moduleLoading, "loadModuleEntriesForManager").resolves([]);
+      sinon
+        .stub(moduleLoading, "constructAndStartModules")
+        .rejects(startupFailure);
+      const destroyStub = sinon
+        .stub(ModuleManager.prototype, "destroyAll")
+        .rejects(new Error("destroy failed"));
+
+      let thrown: unknown;
+      try {
+        await testModule.setupTestEnvironment("/module", {
+          name: "test",
+          cacheFolder: ".antelope/cache",
+          modules: {},
+          envOverrides: {},
+        } as any);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).to.equal(startupFailure);
+      expect(destroyStub.calledOnce).to.equal(true);
+    });
+
     it("enables auto-stub on the module manager resolver", async () => {
       const { internal } = await import("@antelopejs/interface-core/internal");
       const moduleLoading = require("../../../src/core/runtime/module-loading");

--- a/test/index.launch.test.ts
+++ b/test/index.launch.test.ts
@@ -177,4 +177,76 @@ describe("launch", () => {
     expect(scanStub.called).to.equal(false);
     expect(startWatchingStub.calledOnce).to.equal(true);
   });
+
+  it("cleans up once when post-launch watch setup fails", async () => {
+    const setupFailure = new Error("scan failed");
+    sinon.stub(ConfigLoader.prototype, "load").resolves({
+      cacheFolder: "/abs/cache",
+      projectFolder: "/project",
+      modules: {
+        modA: { source: { type: "local", path: "/mods/modA" } },
+      },
+    } as any);
+    sinon.stub(ModuleCache.prototype, "load").resolves();
+    sinon.stub(DownloaderRegistry.prototype, "load").resolves([
+      {
+        name: "modA",
+        version: "1.0.0",
+        main: __filename,
+        folder: "/mods/modA",
+        manifest: { name: "modA", version: "1.0.0" },
+        source: { type: "local", path: "/mods/modA" },
+      } as any,
+    ]);
+    sinon.stub(ModuleManager.prototype, "constructAll").resolves();
+    sinon.stub(ModuleManager.prototype, "startAll").resolves();
+    const stopStub = sinon.stub(ModuleManager.prototype, "stopAll").resolves();
+    const destroyStub = sinon
+      .stub(ModuleManager.prototype, "destroyAll")
+      .resolves();
+    sinon.stub(FileWatcher.prototype, "scanModule").rejects(setupFailure);
+    const stopWatchingStub = sinon.stub(FileWatcher.prototype, "stopWatching");
+
+    let thrown: unknown;
+    try {
+      await launch("/project", "default", { watch: true });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.equal(setupFailure);
+    expect(stopStub.calledOnce).to.equal(true);
+    expect(destroyStub.calledOnce).to.equal(true);
+    expect(stopWatchingStub.calledOnce).to.equal(true);
+  });
+
+  it("closes the REPL and cleans up once when interactive setup fails", async () => {
+    const setupFailure = new Error("repl failed");
+    sinon.stub(ConfigLoader.prototype, "load").resolves({
+      cacheFolder: "/abs/cache",
+      projectFolder: "/project",
+      modules: {},
+    } as any);
+    sinon.stub(ModuleCache.prototype, "load").resolves();
+    sinon.stub(ModuleManager.prototype, "constructAll").resolves();
+    sinon.stub(ModuleManager.prototype, "startAll").resolves();
+    const stopStub = sinon.stub(ModuleManager.prototype, "stopAll").resolves();
+    const destroyStub = sinon
+      .stub(ModuleManager.prototype, "destroyAll")
+      .resolves();
+    sinon.stub(ReplSession.prototype, "start").throws(setupFailure);
+    const closeStub = sinon.stub(ReplSession.prototype, "close");
+
+    let thrown: unknown;
+    try {
+      await launch("/project", "default", { interactive: true });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.equal(setupFailure);
+    expect(stopStub.calledOnce).to.equal(true);
+    expect(destroyStub.calledOnce).to.equal(true);
+    expect(closeStub.calledOnce).to.equal(true);
+  });
 });


### PR DESCRIPTION
## Summary
- replace per-manager resolver wrapper stacking with one process hook and ordered, idempotent leases
- preserve active resolver and shutdown ownership across either release order while detecting external hook replacement
- isolate each manager's module-folder and interface-connection registrations, including duplicate module IDs
- clean up leases and global ownership on construction, startup, build, launch failure, and repeated destroy paths

## Verification
- `pnpm test` (611 unit tests plus all playground phases)
- `pnpm test:coverage` (96.33% lines/statements, 93% branches, 96.24% functions)
- `pnpm build`
- `pnpm lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR coordinates process-global resolver, shutdown, module-folder, and interface-registration ownership across concurrent managers while making failure cleanup ordered and idempotent.
- Introduces process-wide resolver leases that preserve the active owner across either release order.
- Isolates module-folder and interface-connection registrations by manager ownership.
- Centralizes startup-failure cleanup while preserving the initiating error.
- Cleans up started projects when post-launch watch or REPL setup fails.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the prior duplicate-cleanup, error-masking, and post-launch ownership-leak findings are addressed by the current code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/runtime/launch-sequence.ts | Centralizes launch-failure cleanup so each failed manager is destroyed once and the original startup error is preserved. |
| src/core/runtime/module-loading.ts | Adds a cleanup helper that logs destruction failures without replacing the initiating startup exception. |
| src/index.ts | Fixes post-launch ownership leaks by shutting down started projects after watch or interactive setup failures. |
| src/core/resolution/resolver-detour.ts | Replaces stacked resolver wrappers with an ordered process-wide lease coordinator. |
| src/core/runtime/runtime-bootstrap.ts | Tracks multiple shutdown managers and restores the preceding owner when the active manager is released. |
| src/core/interface-registry.ts | Tracks interface registrations by owner and restores surviving registrations for duplicate module IDs. |
| src/core/module-manager.ts | Releases manager-owned resolver, tracker, and interface state across construction failures, rebuilds, and destruction. |
| src/core/module-tracker.ts | Restricts cleanup to folder entries owned by the current tracker. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant A as Manager A
    participant C as Global coordinator
    participant B as Manager B
    participant P as Process hooks/state
    A->>C: acquire lease
    C->>P: install shared ownership
    B->>C: acquire lease
    C->>P: select Manager B
    B->>C: release lease
    C->>P: restore Manager A
    A->>C: release lease
    C->>P: restore original state
```

<sub>Reviews (6): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/antelopejs/antelopejs/commit/58cc953d8645db604a621fdf1e279a384cb2b348) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54581457)</sub>

<!-- /greptile_comment -->