### PR TITLE
fix(runtime): support native ESM modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,19 @@ on:
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['20', '22', '24']
     env:
       COREPACK_DEFAULT_TO_LATEST: 0
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node-version }}
       - run: npm i -g --force corepack && corepack enable
       - run: npm i -g @antelopejs/core
-      - run: pnpm install
+      - run: pnpm install --engine-strict
       - run: pnpm prepack
       - run: pnpm lint
       - run: pnpm test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/docs/2.concepts/2.modules.md
+++ b/docs/2.concepts/2.modules.md
@@ -49,6 +49,12 @@ export async function destroy(): Promise<void> {
 }
 ```
 
+Entry points may use CommonJS or native ESM. Native ESM modules must set `"type": "module"` in `package.json` or use an `.mjs` entry point. Top-level await and standard ESM imports are supported.
+
+::warning
+Native ESM modules cannot import AntelopeJS interface packages yet. The current interface resolver canonicalizes CommonJS module identities, while Node's native ESM loader has an independent cache and resolution pipeline. AntelopeJS fails startup with an explicit error for this combination until the companion runtime-identity work provides equivalent ESM canonicalization.
+::
+
 The `construct` function receives the module's configuration object. Use it to set up database connections, register interface implementations, and prepare internal state. The `start` function runs after all modules have been constructed and interfaces are resolved.
 
 ## Lifecycle States

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=20.6.0"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "url": "git+https://github.com/AntelopeJS/antelopejs.git"
   },
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/playground/antelope.config.ts
+++ b/playground/antelope.config.ts
@@ -19,5 +19,12 @@ export default defineConfig({
       },
       config: { target: "World" },
     },
+    "module-esm": {
+      source: {
+        type: "local",
+        path: "./modules/module-esm",
+      },
+      config: { message: "Native ESM" },
+    },
   },
 });

--- a/playground/modules/module-esm/index.mjs
+++ b/playground/modules/module-esm/index.mjs
@@ -1,0 +1,20 @@
+import { formatMessage } from "./message.mjs";
+
+const ready = await Promise.resolve(true);
+let config;
+
+export function construct(moduleConfig) {
+  config = moduleConfig;
+}
+
+export function start() {
+  if (ready) {
+    console.log(formatMessage(config.message));
+  }
+}
+
+export function stop() {}
+
+export function destroy() {
+  config = undefined;
+}

--- a/playground/modules/module-esm/message.mjs
+++ b/playground/modules/module-esm/message.mjs
@@ -1,0 +1,1 @@
+export const formatMessage = (message) => `[module-esm] ${message}`;

--- a/playground/modules/module-esm/package.json
+++ b/playground/modules/module-esm/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "module-esm",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs",
+  "exports": "./index.mjs"
+}

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -19,6 +19,8 @@ import {
 } from "./resolution/stub-interface-runtime";
 
 const Logger = new Logging.Channel("loader");
+const CORE_INTERFACE_PACKAGE = "@antelopejs/interface-core";
+const ESM_EXTENSIONS = new Set([".mjs", ".mts"]);
 
 export interface ModuleConfig {
   config?: unknown;
@@ -232,6 +234,41 @@ export class ModuleManager {
     }
   }
 
+  private validateNativeEsmModules(): void {
+    for (const { module } of this.loaded.values()) {
+      if (!this.isNativeEsmModule(module)) {
+        continue;
+      }
+      const interfaceImports = this.getInterfaceImports(module);
+      if (interfaceImports.length === 0) {
+        continue;
+      }
+      throw new Error(
+        `Native ESM module '${module.id}' imports unsupported AntelopeJS interfaces: ${interfaceImports.join(", ")}. Native ESM interface imports require the companion runtime-identity support before they can be enabled safely.`,
+      );
+    }
+  }
+
+  private isNativeEsmModule(module: Module): boolean {
+    return (
+      module.manifest.manifest.type === "module" ||
+      ESM_EXTENSIONS.has(path.extname(module.manifest.main))
+    );
+  }
+
+  private getInterfaceImports(module: Module): string[] {
+    const manifest = module.manifest.manifest;
+    const dependencies = {
+      ...manifest.dependencies,
+      ...manifest.optionalDependencies,
+    };
+    return Object.keys(dependencies).filter(
+      (dependency) =>
+        dependency === CORE_INTERFACE_PACKAGE ||
+        this.resolver.interfacePackages.has(dependency),
+    );
+  }
+
   private collectImplementedInterfaces(): Set<string> {
     const implemented = new Set<string>();
     for (const { module, config } of this.getAllManagedModules()) {
@@ -248,6 +285,7 @@ export class ModuleManager {
     this.resolverDetour.attach();
     this.applyInterfaceStubs();
     try {
+      this.validateNativeEsmModules();
       await Promise.all(
         [...this.loaded.values()].map(({ module, config }) =>
           module.construct(config.config).catch((err) => {
@@ -268,6 +306,7 @@ export class ModuleManager {
   async constructModules(modules: ManagedModule[]): Promise<void> {
     this.resolverDetour.attach();
     this.applyInterfaceStubs();
+    this.validateNativeEsmModules();
     await Promise.all(
       modules.map(({ module, config }) =>
         module.construct(config.config).catch((err) => {

--- a/src/core/module-manifest.ts
+++ b/src/core/module-manifest.ts
@@ -11,6 +11,7 @@ import { NodeFileSystem } from "./filesystem";
 export interface ModulePackageJson {
   name: string;
   version: string;
+  type?: "commonjs" | "module";
   description?: string;
   author?: string | string[];
 

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -1,3 +1,4 @@
+import { register } from "node:module";
 import { pathToFileURL } from "node:url";
 import { Logging } from "@antelopejs/interface-core/logging";
 import { type ModuleCallbacks, ModuleState } from "../types";
@@ -8,11 +9,25 @@ export type ModuleLoader = (mainPath: string) => Promise<ModuleCallbacks>;
 
 const Logger = new Logging.Channel("loader.module");
 const IMPORT_GENERATION_PARAM = "antelopeImportGeneration";
+const ESM_RESOLVE_HOOK = `
+export async function resolve(specifier, context, nextResolve) {
+  const resolved = await nextResolve(specifier, context);
+  if (!context.parentURL || !specifier.startsWith(".")) return resolved;
+  const parentUrl = new URL(context.parentURL);
+  const generation = parentUrl.searchParams.get("${IMPORT_GENERATION_PARAM}");
+  if (generation === null || !resolved.url.startsWith("file:")) return resolved;
+  const resolvedUrl = new URL(resolved.url);
+  resolvedUrl.searchParams.set("${IMPORT_GENERATION_PARAM}", generation);
+  return { ...resolved, url: resolvedUrl.href };
+}
+`;
 const nativeImport = new Function(
   "specifier",
   "return import(specifier)",
 ) as ModuleLoader;
 let importGeneration = 0;
+
+register(`data:text/javascript,${encodeURIComponent(ESM_RESOLVE_HOOK)}`);
 
 function createImportUrl(mainPath: string): string {
   const resolvedPath = require.resolve(mainPath);

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from "node:url";
 import { Logging } from "@antelopejs/interface-core/logging";
 import { type ModuleCallbacks, ModuleState } from "../types";
 import { ModuleLifecycle } from "./module-lifecycle";
@@ -6,10 +7,23 @@ import type { ModuleManifest } from "./module-manifest";
 export type ModuleLoader = (mainPath: string) => Promise<ModuleCallbacks>;
 
 const Logger = new Logging.Channel("loader.module");
+const IMPORT_GENERATION_PARAM = "antelopeImportGeneration";
+const nativeImport = new Function(
+  "specifier",
+  "return import(specifier)",
+) as ModuleLoader;
+let importGeneration = 0;
+
+function createImportUrl(mainPath: string): string {
+  const resolvedPath = require.resolve(mainPath);
+  const importUrl = pathToFileURL(resolvedPath);
+  importUrl.searchParams.set(IMPORT_GENERATION_PARAM, String(importGeneration));
+  importGeneration += 1;
+  return importUrl.href;
+}
 
 async function defaultLoader(mainPath: string): Promise<ModuleCallbacks> {
-  const mod = await import(mainPath);
-  return mod as ModuleCallbacks;
+  return nativeImport(createImportUrl(mainPath));
 }
 
 export class Module {

--- a/test/core/module.test.ts
+++ b/test/core/module.test.ts
@@ -237,7 +237,7 @@ exports.start = () => fs.writeFileSync(config.markerPath, "commonjs");
     }
   });
 
-  it("uses a fresh native ESM generation after source changes", async () => {
+  it("uses a fresh native ESM generation for child imports", async () => {
     const folder = await fs.mkdtemp(path.join(os.tmpdir(), "ajs-esm-fresh-"));
     const markerPath = path.join(folder, "marker.txt");
     try {
@@ -247,22 +247,25 @@ exports.start = () => fs.writeFileSync(config.markerPath, "commonjs");
       );
       await fs.writeFile(
         path.join(folder, "value.js"),
-        'export const importedValue = "value";\n',
+        'export const importedValue = "v1";\n',
       );
       const entryPath = path.join(folder, "index.js");
-      await fs.writeFile(entryPath, esmSource("v1"));
+      await fs.writeFile(entryPath, esmSource("entry"));
 
       const first = new Module(createManifest(folder));
       await first.construct({ markerPath } satisfies NativeModuleConfig);
       await first.start();
       await first.destroy();
-      await fs.writeFile(entryPath, esmSource("v2"));
+      await fs.writeFile(
+        path.join(folder, "value.js"),
+        'export const importedValue = "v2";\n',
+      );
 
       const second = new Module(createManifest(folder));
       await second.construct({ markerPath } satisfies NativeModuleConfig);
       await second.start();
 
-      expect(await fs.readFile(markerPath, "utf-8")).to.equal("value:v2");
+      expect(await fs.readFile(markerPath, "utf-8")).to.equal("v2:entry");
     } finally {
       await fs.rm(folder, { recursive: true, force: true });
     }

--- a/test/core/module.test.ts
+++ b/test/core/module.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { expect } from "chai";
 import sinon from "sinon";
 import { Module } from "../../src/core/module";
@@ -8,6 +11,32 @@ const manifest = {
   version: "1.0.0",
   main: "/mod/index.js",
 } as any;
+
+interface NativeModuleConfig {
+  markerPath: string;
+}
+
+function createManifest(main: string) {
+  return {
+    name: "native-module",
+    version: "1.0.0",
+    main,
+  } as any;
+}
+
+function esmSource(value: string): string {
+  return `import fs from "node:fs/promises";
+import { importedValue } from "./value.js";
+const topLevelValue = await Promise.resolve("${value}");
+let config;
+export function construct(moduleConfig) { config = moduleConfig; }
+export async function start() {
+  await fs.writeFile(config.markerPath, importedValue + ":" + topLevelValue);
+}
+export function stop() {}
+export function destroy() {}
+`;
+}
 
 describe("Module", () => {
   it("exposes current state", () => {
@@ -134,5 +163,108 @@ describe("Module", () => {
     await mod.stop();
 
     expect(stopResolved).to.equal(true);
+  });
+
+  it("loads native ESM imports, top-level await, and lifecycle exports", async () => {
+    const folder = await fs.mkdtemp(path.join(os.tmpdir(), "ajs esm module "));
+    const markerPath = path.join(folder, "marker.txt");
+    try {
+      await fs.writeFile(
+        path.join(folder, "package.json"),
+        JSON.stringify({ type: "module" }),
+      );
+      await fs.writeFile(
+        path.join(folder, "value.js"),
+        'export const importedValue = "imported";\n',
+      );
+      await fs.writeFile(path.join(folder, "index.js"), esmSource("awaited"));
+
+      const mod = new Module(createManifest(folder));
+      await mod.construct({ markerPath } satisfies NativeModuleConfig);
+      await mod.start();
+
+      expect(await fs.readFile(markerPath, "utf-8")).to.equal(
+        "imported:awaited",
+      );
+    } finally {
+      await fs.rm(folder, { recursive: true, force: true });
+    }
+  });
+
+  it("continues to load CommonJS lifecycle exports", async () => {
+    const folder = await fs.mkdtemp(path.join(os.tmpdir(), "ajs-cjs-module-"));
+    const markerPath = path.join(folder, "marker.txt");
+    try {
+      await fs.writeFile(
+        path.join(folder, "index.js"),
+        `const fs = require("node:fs");
+let config;
+exports.construct = (moduleConfig) => { config = moduleConfig; };
+exports.start = () => fs.writeFileSync(config.markerPath, "commonjs");
+`,
+      );
+
+      const mod = new Module(createManifest(folder));
+      await mod.construct({ markerPath } satisfies NativeModuleConfig);
+      await mod.start();
+
+      expect(await fs.readFile(markerPath, "utf-8")).to.equal("commonjs");
+    } finally {
+      await fs.rm(folder, { recursive: true, force: true });
+    }
+  });
+
+  it("propagates native ESM syntax errors", async () => {
+    const folder = await fs.mkdtemp(path.join(os.tmpdir(), "ajs-esm-syntax-"));
+    try {
+      await fs.writeFile(
+        path.join(folder, "package.json"),
+        JSON.stringify({ type: "module" }),
+      );
+      await fs.writeFile(path.join(folder, "index.js"), "export const = ;\n");
+      const mod = new Module(createManifest(folder));
+
+      let thrown: unknown;
+      try {
+        await mod.construct({});
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).to.be.instanceOf(SyntaxError);
+    } finally {
+      await fs.rm(folder, { recursive: true, force: true });
+    }
+  });
+
+  it("uses a fresh native ESM generation after source changes", async () => {
+    const folder = await fs.mkdtemp(path.join(os.tmpdir(), "ajs-esm-fresh-"));
+    const markerPath = path.join(folder, "marker.txt");
+    try {
+      await fs.writeFile(
+        path.join(folder, "package.json"),
+        JSON.stringify({ type: "module" }),
+      );
+      await fs.writeFile(
+        path.join(folder, "value.js"),
+        'export const importedValue = "value";\n',
+      );
+      const entryPath = path.join(folder, "index.js");
+      await fs.writeFile(entryPath, esmSource("v1"));
+
+      const first = new Module(createManifest(folder));
+      await first.construct({ markerPath } satisfies NativeModuleConfig);
+      await first.start();
+      await first.destroy();
+      await fs.writeFile(entryPath, esmSource("v2"));
+
+      const second = new Module(createManifest(folder));
+      await second.construct({ markerPath } satisfies NativeModuleConfig);
+      await second.start();
+
+      expect(await fs.readFile(markerPath, "utf-8")).to.equal("value:v2");
+    } finally {
+      await fs.rm(folder, { recursive: true, force: true });
+    }
   });
 });

--- a/test/core/runtime/module-loading.test.ts
+++ b/test/core/runtime/module-loading.test.ts
@@ -85,7 +85,7 @@ describe("runtime module-loading", () => {
     const manifest = {
       name: "alpha",
       version: "1.0.0",
-      main: __filename,
+      main: require.resolve("chai"),
       folder: "/mods/alpha",
       imports: [],
       source: { type: "local", path: "/mods/alpha" },
@@ -177,7 +177,7 @@ describe("runtime module-loading", () => {
     const manifest = {
       name: "alpha",
       version: "1.0.0",
-      main: __filename,
+      main: require.resolve("chai"),
       folder: "/mods/alpha",
       imports: [],
       source: { type: "local", path: "/mods/alpha" },

--- a/test/index.build-start.test.ts
+++ b/test/index.build-start.test.ts
@@ -117,6 +117,48 @@ describe("build and launchFromBuild", () => {
     expect(Object.keys(artifact.modules)).to.have.length(0);
   });
 
+  it("launches a native ESM module from a build artifact", async () => {
+    const projectFolder = makeTempDir("antelope-build-esm-");
+    tempDirs.push(projectFolder);
+    const moduleFolder = path.join(projectFolder, "esm-module");
+    const markerPath = path.join(projectFolder, "esm-started.txt");
+    fs.mkdirSync(moduleFolder, { recursive: true });
+    writeJson(path.join(moduleFolder, "package.json"), {
+      name: "esm-module",
+      version: "1.0.0",
+      type: "module",
+      main: "index.js",
+      exports: "./index.js",
+    });
+    fs.writeFileSync(
+      path.join(moduleFolder, "index.js"),
+      `import fs from "node:fs/promises";
+const ready = await Promise.resolve(true);
+let config;
+export function construct(moduleConfig) { config = moduleConfig; }
+export async function start() { if (ready) await fs.writeFile(config.markerPath, "started"); }
+`,
+    );
+    writeTsConfig(projectFolder, {
+      name: "esm-build-test",
+      modules: {
+        esm: {
+          source: { type: "local", path: "./esm-module" },
+          config: { markerPath },
+        },
+      },
+    });
+
+    await build(projectFolder);
+    const manager = await launchFromBuild(projectFolder);
+    try {
+      expect(fs.readFileSync(markerPath, "utf-8")).to.equal("started");
+    } finally {
+      await manager.stopAll();
+      await manager.destroyAll();
+    }
+  });
+
   it("launchFromBuild throws when build artifact is missing", async () => {
     const projectFolder = makeTempDir("antelope-start-missing-");
     tempDirs.push(projectFolder);

--- a/test/index.launch.test.ts
+++ b/test/index.launch.test.ts
@@ -43,7 +43,7 @@ describe("launch", () => {
           {
             name: id,
             version: "1.0.0",
-            main: __filename,
+            main: require.resolve("chai"),
             folder: `/mods/${id}`,
             manifest: { name: id, version: "1.0.0" },
             source: { type: "local", path: `/mods/${id}`, watchDir },

--- a/test/integration/hmr.test.ts
+++ b/test/integration/hmr.test.ts
@@ -48,12 +48,12 @@ async function assertStableStartCount(
 }
 
 function moduleSource(version: string): string {
-  return `const fs = require("node:fs");
+  return `import fs from "node:fs";
 let cfg;
-exports.construct = (c) => { cfg = c; };
-exports.start = () => { fs.writeFileSync(cfg.markerPath, "${version}"); };
-exports.stop = () => {};
-exports.destroy = () => {};
+export const construct = (c) => { cfg = c; };
+export const start = () => { fs.writeFileSync(cfg.markerPath, "${version}"); };
+export const stop = () => {};
+export const destroy = () => {};
 `;
 }
 
@@ -69,7 +69,13 @@ describe("HMR end-to-end", () => {
     await fs.mkdir(modulePath, { recursive: true });
     await fs.writeFile(
       path.join(modulePath, "package.json"),
-      JSON.stringify({ name: "mod", version: "1.0.0", main: "index.js" }),
+      JSON.stringify({
+        name: "mod",
+        version: "1.0.0",
+        type: "module",
+        main: "index.js",
+        exports: "./index.js",
+      }),
     );
     await fs.writeFile(indexPath, moduleSource("v1"));
 

--- a/test/integration/hmr.test.ts
+++ b/test/integration/hmr.test.ts
@@ -47,11 +47,12 @@ async function assertStableStartCount(
   }
 }
 
-function moduleSource(version: string): string {
+function nativeEsmModuleSource(): string {
   return `import fs from "node:fs";
+import { version } from "./version.js";
 let cfg;
 export const construct = (c) => { cfg = c; };
-export const start = () => { fs.writeFileSync(cfg.markerPath, "${version}"); };
+export const start = () => { fs.writeFileSync(cfg.markerPath, version); };
 export const stop = () => {};
 export const destroy = () => {};
 `;
@@ -65,6 +66,7 @@ describe("HMR end-to-end", () => {
     const modulePath = path.join(projectFolder, "mod");
     const markerPath = path.join(projectFolder, "marker.txt");
     const indexPath = path.join(modulePath, "index.js");
+    const versionPath = path.join(modulePath, "version.js");
 
     await fs.mkdir(modulePath, { recursive: true });
     await fs.writeFile(
@@ -77,7 +79,8 @@ describe("HMR end-to-end", () => {
         exports: "./index.js",
       }),
     );
-    await fs.writeFile(indexPath, moduleSource("v1"));
+    await fs.writeFile(indexPath, nativeEsmModuleSource());
+    await fs.writeFile(versionPath, 'export const version = "v1";\n');
 
     const config = {
       name: "hmr-test",
@@ -99,7 +102,7 @@ describe("HMR end-to-end", () => {
 
       await waitFor(async () => (await readMarker(markerPath)) === "v1", 2000);
 
-      await fs.writeFile(indexPath, moduleSource("v2"));
+      await fs.writeFile(versionPath, 'export const version = "v2";\n');
 
       await waitFor(
         async () => (await readMarker(markerPath)) === "v2",

--- a/test/integration/launch.test.ts
+++ b/test/integration/launch.test.ts
@@ -24,6 +24,58 @@ async function writeProjectConfig(
 }
 
 describe("Launch Function", () => {
+  it("rejects native ESM interface imports until identities are canonicalized", async () => {
+    const projectFolder = await fs.mkdtemp(
+      path.join(os.tmpdir(), "ajs-esm-interface-"),
+    );
+    try {
+      const modulePath = path.join(projectFolder, "esm-module");
+      await fs.mkdir(modulePath, { recursive: true });
+      await fs.writeFile(
+        path.join(modulePath, "package.json"),
+        JSON.stringify({
+          name: "esm-module",
+          version: "1.0.0",
+          type: "module",
+          main: "index.js",
+          dependencies: { "@antelopejs/interface-core": "*" },
+        }),
+      );
+      await fs.writeFile(
+        path.join(modulePath, "index.js"),
+        'import "@antelopejs/interface-core";\n',
+      );
+      await writeProjectConfig(projectFolder, {
+        name: "esm-interface-test",
+        modules: {
+          esm: {
+            source: {
+              type: "local",
+              path: "./esm-module",
+              main: "index.js",
+            },
+          },
+        },
+      });
+
+      let thrown: unknown;
+      try {
+        await launch(projectFolder);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect((thrown as Error).message).to.include(
+        "Native ESM module 'esm' imports unsupported AntelopeJS interfaces: @antelopejs/interface-core",
+      );
+      expect((thrown as Error).message).to.include(
+        "companion runtime-identity support",
+      );
+    } finally {
+      await fs.rm(projectFolder, { recursive: true, force: true });
+    }
+  });
+
   it("should return ModuleManager instance", async () => {
     const projectFolder = await fs.mkdtemp(
       path.join(os.tmpdir(), "ajs-project-"),

--- a/test/integration/test-module.test.ts
+++ b/test/integration/test-module.test.ts
@@ -20,6 +20,63 @@ async function writeMinimalAntelopeModule(folder: string): Promise<void> {
 }
 
 describe("TestModule Function", () => {
+  it("runs tests after starting a native ESM module", async () => {
+    const moduleFolder = await fs.mkdtemp(
+      path.join(os.tmpdir(), "ajs-test-esm-"),
+    );
+    const markerPath = path.join(moduleFolder, "started.txt");
+    try {
+      await fs.writeFile(
+        path.join(moduleFolder, "package.json"),
+        JSON.stringify({
+          name: "esm-test-module",
+          version: "1.0.0",
+          type: "module",
+          main: "index.js",
+          exports: "./index.js",
+          antelopeJs: { test: "./antelope.test.config.ts" },
+        }),
+      );
+      await fs.writeFile(
+        path.join(moduleFolder, "index.js"),
+        `import fs from "node:fs/promises";
+await Promise.resolve();
+let config;
+export function construct(moduleConfig) { config = moduleConfig; }
+export async function start() { await fs.writeFile(config.markerPath, "started"); }
+`,
+      );
+      await fs.writeFile(
+        path.join(moduleFolder, "antelope.test.config.ts"),
+        `export default ${JSON.stringify({
+          name: "esm-test",
+          modules: {
+            esm: {
+              source: { type: "local", path: ".", main: "index.js" },
+              config: { markerPath },
+            },
+          },
+        })};\n`,
+      );
+      const testFile = path.join(moduleFolder, "lifecycle.test.cjs");
+      await fs.writeFile(
+        testFile,
+        `const assert = require("node:assert");
+const fs = require("node:fs");
+describe("native ESM test module", () => {
+  it("starts before tests run", () => assert.equal(fs.readFileSync(${JSON.stringify(markerPath)}, "utf-8"), "started"));
+});
+`,
+      );
+
+      const failures = await TestModule(moduleFolder, [testFile]);
+
+      expect(failures).to.equal(0);
+    } finally {
+      await fs.rm(moduleFolder, { recursive: true, force: true });
+    }
+  });
+
   it("should run tests and return success code", async () => {
     const moduleFolder = await fs.mkdtemp(
       path.join(os.tmpdir(), "ajs-module-"),


### PR DESCRIPTION
## Summary

- load AntelopeJS module entry points through Node's native ESM loader using resolved `file:` URLs
- preserve CommonJS loading while supporting `type: module`, `.mjs`, ESM imports, and top-level await
- add an import generation query so hot reloads evaluate fresh entry-point code
- require Node.js 20+ and exercise Node 20, 22, and 24 in CI
- fail clearly when a native ESM module declares AntelopeJS interface imports, pending the companion runtime-identity PR/work needed to canonicalize identities in Node's ESM loader

## Compatibility

The core package remains CommonJS, and existing CommonJS module lifecycle exports continue to load. Native ESM lifecycle exports now load and run through Node's supported dynamic `import()` mechanism. Syntax and evaluation failures propagate unchanged.

Native ESM modules that import AntelopeJS interface packages are intentionally rejected before construction. The existing interface resolver only canonicalizes CommonJS identities; allowing those imports before companion ESM runtime-identity support would falsely imply safe interface identity handling.

## Verification

Locally verified with Node.js 20.9.0, 22.23.2, and 24.19.0:

- `pnpm build`
- `pnpm test` (607 unit tests plus all playground phases)
- `pnpm test:coverage` (at least 96.41% statements, 93.24% branches)
- `pnpm lint` (exit 0; reports only existing informational/warning findings in untouched files)
- targeted ESM/CJS/TLA/syntax-error/HMR/build/test-harness tests
- built `dist/core/module.js` retains native `import(specifier)` rather than a TypeScript-generated `require()`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds native ESM module loading, top-level-await support, ESM interface-import validation, and generation-based cache busting for hot reloads. The child-cache fix remains incomplete for non-relative file-URL imports.
- Loads entry points through resolved `file:` URLs while retaining CommonJS compatibility.
- Propagates reload generations through relative ESM imports.
- Rejects native ESM modules declaring AntelopeJS interface dependencies.
- Raises the supported Node.js baseline and expands CI coverage to Node 20, 22, and 24.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because native ESM hot reload can still execute stale module-owned child code imported through an absolute file URL.

The `Reply from :` says child ESM cache propagation was fixed, but the resolve hook still returns non-dot specifiers unchanged; an absolute file-URL child therefore retains its ESM cache key across reloads and provides a concrete residual counterexample.

**Files Needing Attention:** src/core/module.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/module.ts | Adds native dynamic importing and an ESM resolve hook, but cache-generation propagation omits valid non-relative file-URL child imports. |
| src/core/module-manager.ts | Adds pre-construction rejection for native ESM modules declaring AntelopeJS interface dependencies. |
| test/core/module.test.ts | Covers ESM loading, top-level await, syntax failures, CommonJS compatibility, and relative child refreshes, but not file-URL child imports. |
| test/integration/hmr.test.ts | Converts HMR coverage to native ESM and verifies that editing a relatively imported child refreshes its implementation. |
| package.json | Declares Node.js 20.6 or newer as the supported runtime. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Module-owned child file changes] --> B[Watcher queues module reload]
  B --> C[Entry point receives new generation URL]
  C --> D{Child specifier starts with dot?}
  D -- Yes --> E[Generation propagated to child URL]
  E --> F[Updated child evaluated]
  D -- No: absolute file URL --> G[Child URL remains unchanged]
  G --> H[Node reuses stale ESM cache entry]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/core/module.ts:15
**File-URL children remain stale**

When a watched native ESM module imports a module-owned child through an absolute `file:` URL, this branch skips generation propagation because the specifier does not start with `.`, causing HMR to reuse the child's old ESM cache entry and restart the module with stale child code.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(runtime): refresh ESM child imports ..."](https://github.com/antelopejs/antelopejs/commit/b9188bd8f02646d9152c8a1e91388ca8df43c43b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54582798)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->