### PR TITLE
fix(runtime): make lifecycle transitions transactional

### DIFF
--- a/src/core/interface-registry.ts
+++ b/src/core/interface-registry.ts
@@ -29,4 +29,10 @@ export class InterfaceRegistry {
     }
     internal.interfaceConnections[moduleId] = connectionIDs;
   }
+
+  clear(moduleIds: string[]): void {
+    for (const moduleId of moduleIds) {
+      delete internal.interfaceConnections[moduleId];
+    }
+  }
 }

--- a/src/core/module-lifecycle.ts
+++ b/src/core/module-lifecycle.ts
@@ -4,7 +4,7 @@ import { type ModuleCallbacks, ModuleState } from "../types";
 export class ModuleLifecycle {
   private callbacks?: ModuleCallbacks;
   private _state: ModuleState = ModuleState.Loaded;
-  private starting?: Promise<void>;
+  private transition: Promise<void> = Promise.resolve();
 
   constructor(private moduleId: string) {}
 
@@ -16,57 +16,42 @@ export class ModuleLifecycle {
     this.callbacks = callbacks;
   }
 
-  async construct(config: unknown): Promise<void> {
+  construct(config: unknown): Promise<void> {
+    return this.enqueue(() => this.runConstruct(config));
+  }
+
+  private async runConstruct(config: unknown): Promise<void> {
     if (this._state !== ModuleState.Loaded) {
       return;
     }
 
+    this._state = ModuleState.Constructed;
     if (this.callbacks?.construct) {
       await this.callbacks.construct(config);
     }
 
     Events.ModuleConstructed.emit(this.moduleId);
-    this._state = ModuleState.Constructed;
   }
 
-  async start(): Promise<void> {
-    if (this.starting) {
-      return this.starting;
-    }
+  start(): Promise<void> {
+    return this.enqueue(() => this.runStart());
+  }
 
+  private async runStart(): Promise<void> {
     if (this._state !== ModuleState.Constructed) {
       return;
     }
 
-    this.starting = this.runStart();
-    return this.starting;
+    await this.callbacks?.start?.();
+    Events.ModuleStarted.emit(this.moduleId);
+    this._state = ModuleState.Active;
   }
 
-  private async runStart(): Promise<void> {
-    try {
-      await this.callbacks?.start?.();
-      Events.ModuleStarted.emit(this.moduleId);
-      this._state = ModuleState.Active;
-    } finally {
-      this.starting = undefined;
-    }
+  stop(): Promise<void> {
+    return this.enqueue(() => this.runStop());
   }
 
-  /**
-   * An async start hook leaves the state on `Constructed` until it settles, so
-   * guards below must wait for it instead of reading a state that is still in
-   * transition - otherwise a stop racing a pending start silently no-ops and
-   * the module ends up active anyway.
-   */
-  private async settleStart(): Promise<void> {
-    if (this.starting) {
-      await this.starting.catch(() => undefined);
-    }
-  }
-
-  async stop(): Promise<void> {
-    await this.settleStart();
-
+  private async runStop(): Promise<void> {
     if (this._state !== ModuleState.Active) {
       return;
     }
@@ -78,15 +63,17 @@ export class ModuleLifecycle {
     this._state = ModuleState.Constructed;
   }
 
-  async destroy(): Promise<void> {
-    await this.settleStart();
+  destroy(): Promise<void> {
+    return this.enqueue(() => this.runDestroy());
+  }
 
+  private async runDestroy(): Promise<void> {
     if (this._state === ModuleState.Loaded) {
       return;
     }
 
     if (this._state === ModuleState.Active) {
-      await this.stop();
+      await this.runStop();
     }
 
     if (this.callbacks?.destroy) {
@@ -95,5 +82,11 @@ export class ModuleLifecycle {
 
     Events.ModuleDestroyed.emit(this.moduleId);
     this._state = ModuleState.Loaded;
+  }
+
+  private enqueue(operation: () => Promise<void>): Promise<void> {
+    const result = this.transition.then(operation, operation);
+    this.transition = result.catch(() => undefined);
+    return result;
   }
 }

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import { Logging } from "@antelopejs/interface-core/logging";
+import { ModuleState } from "../types";
 import {
   type InterfaceConnectionRef,
   InterfaceRegistry,
@@ -37,6 +38,8 @@ interface ModuleManagerDeps {
   interfaceRegistry?: InterfaceRegistry;
   moduleTracker?: ModuleTracker;
 }
+
+type ModuleOperation = (module: Module) => Promise<void>;
 
 export class ModuleManager {
   public readonly registry: ModuleRegistry;
@@ -245,24 +248,33 @@ export class ModuleManager {
   }
 
   async constructAll(): Promise<void> {
+    const modules = [...this.loaded.values()];
     this.resolverDetour.attach();
     this.applyInterfaceStubs();
-    try {
-      await Promise.all(
-        [...this.loaded.values()].map(({ module, config }) =>
-          module.construct(config.config).catch((err) => {
-            Logger.Error(`Failed to construct module:`);
-            Logger.Error(`  - ID: ${module.id}`);
-            Logger.Error(`  - Version: ${module.version}`);
-            Logger.Error("  - Error:", err);
-            throw err;
-          }),
-        ),
-      );
-    } catch (err) {
-      this.resolverDetour.detach();
-      throw err;
+    const results = await Promise.allSettled(
+      modules.map(({ module, config }) =>
+        this.constructModule(module, config.config),
+      ),
+    );
+    const errors = collectRejectedErrors(results);
+    if (errors.length === 0) {
+      return;
     }
+
+    const constructed = modules.filter(
+      ({ module }, index) =>
+        results[index].status === "fulfilled" ||
+        module.state !== ModuleState.Loaded,
+    );
+    const cleanupErrors = await runModuleOperations(
+      constructed.reverse(),
+      (module) => module.destroy(),
+    );
+    this.resolverDetour.detach();
+    throw new AggregateError(
+      [...errors, ...cleanupErrors],
+      "Failed to construct modules",
+    );
   }
 
   async constructModules(modules: ManagedModule[]): Promise<void> {
@@ -270,74 +282,109 @@ export class ModuleManager {
     this.applyInterfaceStubs();
     await Promise.all(
       modules.map(({ module, config }) =>
-        module.construct(config.config).catch((err) => {
-          Logger.Error(`Failed to construct module:`);
-          Logger.Error(`  - ID: ${module.id}`);
-          Logger.Error(`  - Version: ${module.version}`);
-          Logger.Error("  - Error:", err);
-          throw err;
-        }),
+        this.constructModule(module, config.config),
       ),
     );
   }
 
   async startAll(): Promise<void> {
-    await this.startModules([...this.loaded.values()]);
+    try {
+      await this.startModules([...this.loaded.values()]);
+    } catch (error) {
+      let cleanupErrors: unknown[] = [];
+      try {
+        await this.destroyAll();
+      } catch (cleanupError) {
+        cleanupErrors = unpackErrors(cleanupError);
+      }
+      throw new AggregateError(
+        [...unpackErrors(error), ...cleanupErrors],
+        "Failed to start modules",
+      );
+    }
   }
 
   async startModules(modules: ManagedModule[]): Promise<void> {
-    const starting: Promise<void>[] = [];
-    for (const { module } of modules) {
-      starting.push(module.start());
+    modules.forEach(({ module }) => {
       this.trackModuleStart(module.id);
+    });
+    const results = await Promise.allSettled(
+      modules.map(({ module }) => module.start()),
+    );
+    const errors = collectRejectedErrors(results);
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "Failed to start modules");
     }
-    await Promise.all(starting);
   }
 
   async stopAll(): Promise<void> {
-    const reverseOrder = [...this.startupOrder].reverse();
-    const idsToStop =
-      reverseOrder.length > 0
-        ? reverseOrder
-        : [...this.loaded.keys()].reverse();
-
-    for (const id of idsToStop) {
-      const entry = this.loaded.get(id);
-      if (!entry) {
-        continue;
-      }
-
-      try {
-        await entry.module.stop();
-      } catch (error) {
-        Logger.Error(`Failed to stop module ${id}:`, error);
-      }
-    }
-
+    const modules = this.getReverseLifecycleModules();
+    const errors = await runModuleOperations(modules, (module) =>
+      module.stop(),
+    );
     this.startupOrder = [];
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "Failed to stop modules");
+    }
   }
 
   async destroyAll(): Promise<void> {
-    const reverseOrder = [...this.startupOrder].reverse();
-    const idsToDestroy =
-      reverseOrder.length > 0
-        ? reverseOrder
-        : [...this.loaded.keys()].reverse();
-
-    try {
-      for (const id of idsToDestroy) {
-        const entry = this.loaded.get(id);
-        if (!entry) {
-          continue;
-        }
-        await entry.module.destroy();
-      }
-    } finally {
-      this.startupOrder = [];
-      this.stubbedInterfacePaths.clear();
-      clearStubInterfaceWarnings();
-      this.resolverDetour.detach();
+    const modules = this.getReverseLifecycleModules();
+    const errors = await runModuleOperations(modules, (module) =>
+      module.destroy(),
+    );
+    this.clearManagedState();
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "Failed to destroy modules");
     }
+  }
+
+  private async constructModule(
+    module: Module,
+    config: unknown,
+  ): Promise<void> {
+    try {
+      await module.construct(config);
+    } catch (error) {
+      Logger.Error(`Failed to construct module:`);
+      Logger.Error(`  - ID: ${module.id}`);
+      Logger.Error(`  - Version: ${module.version}`);
+      Logger.Error("  - Error:", error);
+      throw error;
+    }
+  }
+
+  private getReverseLifecycleModules(): ManagedModule[] {
+    const orderedIds = [...this.startupOrder].reverse();
+    const seen = new Set(orderedIds);
+    for (const id of [...this.loaded.keys()].reverse()) {
+      if (!seen.has(id)) {
+        orderedIds.push(id);
+      }
+    }
+    return orderedIds.flatMap((id) => {
+      const entry = this.loaded.get(id);
+      return entry ? [entry] : [];
+    });
+  }
+
+  private clearManagedState(): void {
+    const moduleIds = this.getAllManagedModules().map(
+      ({ module }) => module.id,
+    );
+    this.interfaceRegistry.clear(moduleIds);
+    this.loaded.clear();
+    this.staticModules.length = 0;
+    this.registry.clear();
+    this.resolvedAssociations.clear();
+    this.resolver.moduleByFolder.clear();
+    this.resolver.modulesById.clear();
+    this.resolver.interfacePackages.clear();
+    this.moduleTracker.clear();
+    this.startupOrder = [];
+    this.stubbedInterfacePaths.clear();
+    clearStubInterfaceWarnings();
+    this.resolverDetour.detach();
   }
 
   private trackModuleStart(moduleId: string): void {
@@ -478,6 +525,33 @@ export class ModuleManager {
     }
     return normalizedFile.startsWith(normalizedDir + path.sep);
   }
+}
+
+function collectRejectedErrors(
+  results: PromiseSettledResult<unknown>[],
+): unknown[] {
+  return results.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : [],
+  );
+}
+
+function unpackErrors(error: unknown): unknown[] {
+  return error instanceof AggregateError ? error.errors : [error];
+}
+
+async function runModuleOperations(
+  modules: ManagedModule[],
+  operation: ModuleOperation,
+): Promise<unknown[]> {
+  const errors: unknown[] = [];
+  for (const { module } of modules) {
+    try {
+      await operation(module);
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  return errors;
 }
 
 function extractPackageRoot(

--- a/src/core/module-registry.ts
+++ b/src/core/module-registry.ts
@@ -14,4 +14,8 @@ export class ModuleRegistry {
   list(): string[] {
     return [...this.modules.keys()];
   }
+
+  clear(): void {
+    this.modules.clear();
+  }
 }

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -1,4 +1,5 @@
 import { Logging } from "@antelopejs/interface-core/logging";
+import { Events } from "@antelopejs/interface-core/modules";
 import { type ModuleCallbacks, ModuleState } from "../types";
 import { ModuleLifecycle } from "./module-lifecycle";
 import type { ModuleManifest } from "./module-manifest";
@@ -54,6 +55,7 @@ export class Module {
       Logger.Debug(`Successfully loaded module ${this.id}`);
     } catch (err) {
       Logger.Error(`Failed to load module ${this.id}`, err);
+      Events.ModuleDestroyed.emit(this.id);
       throw err;
     }
     this.lifecycle.setCallbacks(this.callbacks);

--- a/src/core/runtime/launch-sequence.ts
+++ b/src/core/runtime/launch-sequence.ts
@@ -24,6 +24,7 @@ import {
 import {
   applyVerboseChannels,
   loadProjectConfig,
+  releaseProcessShutdownManager,
   setupProcessHandlers,
   withRaisedMaxListeners,
 } from "./runtime-bootstrap";
@@ -31,6 +32,7 @@ import type {
   LoaderConfig,
   LoaderContext,
   LoaderContextProvider,
+  PreparedProject,
   ProjectPreparer,
   StartedProject,
 } from "./runtime-types";
@@ -143,39 +145,79 @@ export async function runLaunchSequence(
   const shutdownManager = new ShutdownManager();
   setupProcessHandlers(shutdownManager);
 
-  const project = await prepare(projectFolder, env);
+  let manager: ModuleManager | undefined;
+  try {
+    const project = await prepare(projectFolder, env);
 
-  setupAntelopeProjectLogging(project.logging);
-  applyVerboseChannels(options.verbose);
+    setupAntelopeProjectLogging(project.logging);
+    applyVerboseChannels(options.verbose);
 
-  await project.verify();
+    await project.verify();
 
-  await registerCoreRuntimeInterface({
-    dev: project.dev,
-    projectPath: projectFolder,
-    env,
-    fs: project.fs,
-    shutdownManager,
+    await registerCoreRuntimeInterface({
+      dev: project.dev,
+      projectPath: projectFolder,
+      env,
+      fs: project.fs,
+      shutdownManager,
+    });
+
+    manager = new ModuleManager();
+    await startModuleManager(manager, project);
+
+    return {
+      manager,
+      dev: project.dev,
+      loadContext: project.loadContext,
+      fs: project.fs,
+      shutdownManager,
+    };
+  } catch (error) {
+    const cleanupErrors = await cleanupFailedLaunch(manager, shutdownManager);
+    releaseProcessShutdownManager(shutdownManager);
+    if (cleanupErrors.length === 0) {
+      throw error;
+    }
+    throw new AggregateError(
+      [...unpackLaunchErrors(error), ...cleanupErrors],
+      "Failed to launch project",
+    );
+  }
+}
+
+async function startModuleManager(
+  manager: ModuleManager,
+  project: PreparedProject,
+): Promise<void> {
+  await withRaisedMaxListeners(async () => {
+    registerCoreModuleInterface(manager, project.loadContext);
+    await registerCoreInterfaces(manager);
+
+    manager.addModules(await project.createEntries());
+
+    ensureGraphIsValid(manager);
+    await constructAndStartModules(manager);
   });
+}
 
-  const manager = await withRaisedMaxListeners(async () => {
-    const moduleManager = new ModuleManager();
+async function cleanupFailedLaunch(
+  manager: ModuleManager | undefined,
+  shutdownManager: ShutdownManager,
+): Promise<unknown[]> {
+  const errors: unknown[] = [];
+  try {
+    await manager?.destroyAll();
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    await shutdownManager.shutdown();
+  } catch (error) {
+    errors.push(error);
+  }
+  return errors;
+}
 
-    registerCoreModuleInterface(moduleManager, project.loadContext);
-    await registerCoreInterfaces(moduleManager);
-
-    moduleManager.addModules(await project.createEntries());
-
-    ensureGraphIsValid(moduleManager);
-    await constructAndStartModules(moduleManager);
-    return moduleManager;
-  });
-
-  return {
-    manager,
-    dev: project.dev,
-    loadContext: project.loadContext,
-    fs: project.fs,
-    shutdownManager,
-  };
+function unpackLaunchErrors(error: unknown): unknown[] {
+  return error instanceof AggregateError ? error.errors : [error];
 }

--- a/src/core/runtime/module-loading.ts
+++ b/src/core/runtime/module-loading.ts
@@ -6,6 +6,7 @@ import type {
 } from "@antelopejs/interface-core/config";
 import { Logging } from "@antelopejs/interface-core/logging";
 import * as moduleInterfaceBeta from "@antelopejs/interface-core/modules";
+import { ModuleState } from "../../types";
 import { terminalDisplay } from "../cli/terminal-display";
 import type { ExpandedModuleConfig } from "../config/config-parser";
 import { registerGitDownloader } from "../downloaders/git";
@@ -16,7 +17,11 @@ import { DownloaderRegistry } from "../downloaders/registry";
 import { NodeFileSystem } from "../filesystem";
 import { Module } from "../module";
 import { ModuleCache } from "../module-cache";
-import type { ModuleConfig, ModuleManager } from "../module-manager";
+import type {
+  ManagedModule,
+  ModuleConfig,
+  ModuleManager,
+} from "../module-manager";
 import { ModuleManifest } from "../module-manifest";
 import { findUnresolvedInterfaces } from "../resolution/interface-resolution";
 import type {
@@ -351,20 +356,85 @@ async function reloadLoadedModuleFromSource(
     return;
   }
 
-  await entry.module.destroy();
-  manager.unrequireModuleFiles(moduleId);
+  const previous = entry.module;
   const manifest = await loadModuleManifestFromSource(
     loaderContext,
-    entry.module.manifest.source,
+    previous.manifest.source,
     moduleId,
     true,
   );
   const replacement = new Module(manifest);
   ensureReloadedModuleId(replacement, moduleId);
-  manager.replaceLoadedModule(moduleId, replacement);
-  manager.refreshAssociations();
-  await replacement.construct(entry.config.config);
-  await replacement.start();
+  const previousWasActive = previous.state === ModuleState.Active;
+  try {
+    await previous.destroy();
+  } catch (error) {
+    const recoveryErrors = await recoverPreviousModule(
+      previous,
+      previousWasActive,
+    );
+    throw new AggregateError(
+      [error, ...recoveryErrors],
+      `Failed to destroy module ${moduleId} during reload`,
+    );
+  }
+  manager.unrequireModuleFiles(moduleId);
+  await activateReplacement(manager, entry, replacement);
+}
+
+async function recoverPreviousModule(
+  previous: Module,
+  previousWasActive: boolean,
+): Promise<unknown[]> {
+  if (!previousWasActive || previous.state !== ModuleState.Constructed) {
+    return [];
+  }
+  try {
+    await previous.start();
+    return [];
+  } catch (error) {
+    return [error];
+  }
+}
+
+async function activateReplacement(
+  manager: ModuleManager,
+  entry: ManagedModule,
+  replacement: Module,
+): Promise<void> {
+  let replacementInstalled = false;
+  try {
+    replacementInstalled = Boolean(
+      manager.replaceLoadedModule(replacement.id, replacement),
+    );
+    if (!replacementInstalled) {
+      throw new Error(`Failed to replace module ${replacement.id}`);
+    }
+    manager.refreshAssociations();
+    await replacement.construct(entry.config.config);
+    await replacement.start();
+  } catch (error) {
+    const cleanupErrors = replacementInstalled
+      ? await cleanupReplacement(replacement)
+      : [];
+    throw new AggregateError(
+      [...unpackReloadErrors(error), ...cleanupErrors],
+      `Failed to activate replacement module ${replacement.id}`,
+    );
+  }
+}
+
+async function cleanupReplacement(replacement: Module): Promise<unknown[]> {
+  try {
+    await replacement.destroy();
+    return [];
+  } catch (error) {
+    return [error];
+  }
+}
+
+function unpackReloadErrors(error: unknown): unknown[] {
+  return error instanceof AggregateError ? error.errors : [error];
 }
 
 export async function reloadWatchedModule(

--- a/src/core/runtime/runtime-bootstrap.ts
+++ b/src/core/runtime/runtime-bootstrap.ts
@@ -56,6 +56,14 @@ export function setupProcessHandlers(shutdownManager?: ShutdownManager): void {
   });
 }
 
+export function releaseProcessShutdownManager(
+  shutdownManager: ShutdownManager,
+): void {
+  if (activeShutdownManager === shutdownManager) {
+    activeShutdownManager = undefined;
+  }
+}
+
 export async function withRaisedMaxListeners<T>(
   task: () => Promise<T>,
 ): Promise<T> {

--- a/src/core/shutdown/shutdown-manager.ts
+++ b/src/core/shutdown/shutdown-manager.ts
@@ -128,14 +128,22 @@ export class ShutdownManager {
   }
 
   private runHandlersWithTimeout(): Promise<void> {
+    let timeout: NodeJS.Timeout | undefined;
     const timeoutPromise = new Promise<void>((resolve) => {
-      setTimeout(() => {
+      timeout = setTimeout(() => {
         Logger.Error("Shutdown timed out, forcing completion");
         resolve();
       }, this.timeoutMs);
     });
 
-    return Promise.race([this.executeHandlers(), timeoutPromise]);
+    return Promise.race([this.executeHandlers(), timeoutPromise]).finally(
+      () => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        this.handlers = [];
+      },
+    );
   }
 
   private async executeHandlers(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
 } from "./core/runtime/module-loading";
 import {
   loadProjectRuntimeConfig,
+  releaseProcessShutdownManager,
   withRaisedMaxListeners,
 } from "./core/runtime/runtime-bootstrap";
 import type {
@@ -70,15 +71,33 @@ function registerModuleShutdownHandler(
   shutdownManager: ShutdownManager,
   manager: ModuleManager,
 ): void {
-  shutdownManager.register(async () => {
+  shutdownManager.register(
+    () => shutdownModules(manager),
+    SHUTDOWN_PRIORITY_MODULES,
+  );
+}
+
+async function shutdownModules(manager: ModuleManager): Promise<void> {
+  const errors: unknown[] = [];
+  try {
     await manager.stopAll();
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
     await manager.destroyAll();
-  }, SHUTDOWN_PRIORITY_MODULES);
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "Shutdown failed");
+  }
 }
 
 function registerShutdownCleanup(shutdownManager: ShutdownManager): void {
   shutdownManager.register(async () => {
     shutdownManager.removeSignalHandlers();
+    releaseProcessShutdownManager(shutdownManager);
     if (activeShutdownManager === shutdownManager) {
       activeShutdownManager = undefined;
     }
@@ -176,8 +195,14 @@ async function startProject(
   options: LaunchOptions,
 ): Promise<ModuleManager> {
   const started = await runLaunchSequence(prepare, projectFolder, env, options);
-  await setupPostLaunchFeatures(started, projectFolder, env, options);
-  return started.manager;
+  try {
+    await setupPostLaunchFeatures(started, projectFolder, env, options);
+    return started.manager;
+  } catch (error) {
+    await started.shutdownManager.shutdown();
+    releaseProcessShutdownManager(started.shutdownManager);
+    throw error;
+  }
 }
 
 let isRestarting = false;

--- a/test/core/module-lifecycle.test.ts
+++ b/test/core/module-lifecycle.test.ts
@@ -68,6 +68,24 @@ describe("ModuleLifecycle", () => {
     expect(lifecycle.state).to.equal(ModuleState.Constructed);
   });
 
+  it("allows cleanup after construct fails", async () => {
+    const destroy = sinon.stub().resolves();
+    const lifecycle = new ModuleLifecycle("mod");
+    lifecycle.setCallbacks({
+      construct: async () => {
+        throw new Error("construct failed");
+      },
+      destroy,
+    });
+
+    await lifecycle.construct({}).catch(() => undefined);
+    expect(lifecycle.state).to.equal(ModuleState.Constructed);
+
+    await lifecycle.destroy();
+    expect(destroy.calledOnce).to.equal(true);
+    expect(lifecycle.state).to.equal(ModuleState.Loaded);
+  });
+
   it("should stop active modules during destroy", async () => {
     const callbacks = {
       stop: sinon.spy(),
@@ -235,5 +253,50 @@ describe("ModuleLifecycle", () => {
     await lifecycle.destroy();
 
     expect(calls).to.deep.equal(["construct", "start", "stop", "destroy"]);
+  });
+
+  it("serializes overlapping construct calls", async () => {
+    const construct = sinon.stub().callsFake(
+      () =>
+        new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        }),
+    );
+    const lifecycle = new ModuleLifecycle("mod");
+    lifecycle.setCallbacks({ construct });
+
+    await Promise.all([lifecycle.construct({}), lifecycle.construct({})]);
+
+    expect(construct.calledOnce).to.equal(true);
+    expect(lifecycle.state).to.equal(ModuleState.Constructed);
+  });
+
+  it("serializes overlapping stop and destroy calls", async () => {
+    const calls: string[] = [];
+    const lifecycle = new ModuleLifecycle("mod");
+    lifecycle.setCallbacks({
+      start: async () => {
+        await new Promise((resolve) => setImmediate(resolve));
+        calls.push("start");
+      },
+      stop: () => {
+        calls.push("stop");
+      },
+      destroy: () => {
+        calls.push("destroy");
+      },
+    });
+
+    await lifecycle.construct({});
+    await Promise.all([
+      lifecycle.start(),
+      lifecycle.stop(),
+      lifecycle.stop(),
+      lifecycle.destroy(),
+      lifecycle.destroy(),
+    ]);
+
+    expect(calls).to.deep.equal(["start", "stop", "destroy"]);
+    expect(lifecycle.state).to.equal(ModuleState.Loaded);
   });
 });

--- a/test/core/module-manager.test.ts
+++ b/test/core/module-manager.test.ts
@@ -523,9 +523,169 @@ describe("ModuleManager", () => {
 
     await manager.startAll();
 
-    await manager.stopAll();
+    let thrown: unknown;
+    try {
+      await manager.stopAll();
+    } catch (error) {
+      thrown = error;
+    }
 
     expect(calls).to.deep.equal(["stop:modC", "stop:modA"]);
+    expect(thrown).to.be.instanceOf(AggregateError);
+    expect((thrown as AggregateError).errors).to.have.length(1);
+  });
+
+  it("waits for sibling constructs and aggregates rollback errors", async () => {
+    const calls: string[] = [];
+    const manager = new ModuleManager();
+    const detour = (manager as any).resolverDetour;
+    const detach = sinon.stub(detour, "detach");
+    sinon.stub(detour, "attach");
+    sinon.stub(manager as any, "applyInterfaceStubs");
+
+    let settleA: () => void = () => undefined;
+    const moduleA = {
+      id: "a",
+      version: "1.0.0",
+      construct: () =>
+        new Promise<void>((resolve) => {
+          settleA = () => {
+            calls.push("construct:a");
+            resolve();
+          };
+        }),
+      destroy: async () => {
+        calls.push("destroy:a");
+      },
+    };
+    const moduleB = {
+      id: "b",
+      version: "1.0.0",
+      construct: async () => {
+        throw new Error("construct:b");
+      },
+      destroy: sinon.stub().resolves(),
+    };
+    const moduleC = {
+      id: "c",
+      version: "1.0.0",
+      construct: async () => {
+        calls.push("construct:c");
+      },
+      destroy: async () => {
+        calls.push("destroy:c");
+        throw new Error("destroy:c");
+      },
+    };
+
+    (manager as any).loaded.set("a", { module: moduleA, config: {} });
+    (manager as any).loaded.set("b", { module: moduleB, config: {} });
+    (manager as any).loaded.set("c", { module: moduleC, config: {} });
+
+    const pending = manager.constructAll();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(detach.called).to.equal(false);
+    settleA();
+
+    let thrown: unknown;
+    try {
+      await pending;
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(calls).to.deep.equal([
+      "construct:c",
+      "construct:a",
+      "destroy:c",
+      "destroy:a",
+    ]);
+    expect(detach.calledOnce).to.equal(true);
+    expect(thrown).to.be.instanceOf(AggregateError);
+    expect((thrown as AggregateError).errors).to.have.length(2);
+  });
+
+  it("destroys every module and clears state after multiple failures", async () => {
+    const calls: string[] = [];
+    const manager = new ModuleManager();
+    const makeModule = (id: string, shouldFail: boolean) => ({
+      id,
+      destroy: async () => {
+        calls.push(id);
+        if (shouldFail) {
+          throw new Error(`destroy:${id}`);
+        }
+      },
+    });
+
+    (manager as any).loaded.set("a", {
+      module: makeModule("a", true),
+      config: {},
+    });
+    (manager as any).loaded.set("b", {
+      module: makeModule("b", true),
+      config: {},
+    });
+    (manager as any).loaded.set("c", {
+      module: makeModule("c", false),
+      config: {},
+    });
+
+    let thrown: unknown;
+    try {
+      await manager.destroyAll();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(calls).to.deep.equal(["c", "b", "a"]);
+    expect(thrown).to.be.instanceOf(AggregateError);
+    expect((thrown as AggregateError).errors).to.have.length(2);
+    expect(manager.listModules()).to.deep.equal([]);
+    expect([...manager.getLoadedModules()]).to.deep.equal([]);
+    expect(manager.resolver.modulesById.size).to.equal(0);
+  });
+
+  it("cleans every live module after a start failure", async () => {
+    const calls: string[] = [];
+    const manager = new ModuleManager();
+    const makeModule = (id: string, shouldFail: boolean) => ({
+      id,
+      start: async () => {
+        calls.push(`start:${id}`);
+        if (shouldFail) {
+          throw new Error(`start:${id}`);
+        }
+      },
+      destroy: async () => {
+        calls.push(`destroy:${id}`);
+      },
+    });
+
+    for (const id of ["a", "b", "c"]) {
+      (manager as any).loaded.set(id, {
+        module: makeModule(id, id === "b"),
+        config: {},
+      });
+    }
+
+    let thrown: unknown;
+    try {
+      await manager.startAll();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(calls).to.deep.equal([
+      "start:a",
+      "start:b",
+      "start:c",
+      "destroy:c",
+      "destroy:b",
+      "destroy:a",
+    ]);
+    expect(thrown).to.be.instanceOf(AggregateError);
+    expect(manager.listModules()).to.deep.equal([]);
   });
 
   it("populates interfacePackages for resolvable npm interface packages", async () => {

--- a/test/core/runtime/launch-sequence.test.ts
+++ b/test/core/runtime/launch-sequence.test.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs/promises";
+import Module from "node:module";
+import os from "node:os";
+import path from "node:path";
+import type { ModuleSourceLocal } from "@antelopejs/interface-core/config";
+import * as runtimeInterface from "@antelopejs/interface-core/runtime";
+import { expect } from "chai";
+import sinon from "sinon";
+import { NodeFileSystem } from "../../../src/core/filesystem";
+import { ModuleManifest } from "../../../src/core/module-manifest";
+import { runLaunchSequence } from "../../../src/core/runtime/launch-sequence";
+import type { ProjectPreparer } from "../../../src/core/runtime/runtime-types";
+import { ShutdownManager } from "../../../src/core/shutdown";
+
+describe("runtime launch-sequence", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("releases module and registered runtime resources after startup fails", async () => {
+    const projectFolder = await fs.mkdtemp(
+      path.join(os.tmpdir(), "ajs-launch-failure-"),
+    );
+    const moduleFolder = path.join(projectFolder, "failing-module");
+    const previousResolver = (Module as any)._resolveFilename;
+    const shutdown = sinon.spy(ShutdownManager.prototype, "shutdown");
+
+    try {
+      await fs.mkdir(moduleFolder, { recursive: true });
+      await fs.writeFile(
+        path.join(moduleFolder, "package.json"),
+        JSON.stringify({
+          name: "failing-module",
+          version: "1.0.0",
+          main: "index.js",
+        }),
+      );
+      await fs.writeFile(
+        path.join(moduleFolder, "index.js"),
+        `
+const runtime = require("@antelopejs/interface-core/runtime");
+exports.construct = () => runtime.RegisterDevServer("api", [{ port: 3000 }]);
+exports.start = () => Promise.reject(new Error("startup failed"));
+`,
+      );
+      const source: ModuleSourceLocal = {
+        type: "local",
+        path: moduleFolder,
+        main: "index.js",
+      };
+      const manifest = await ModuleManifest.create(
+        moduleFolder,
+        source,
+        "failing-module",
+      );
+      const nodeFileSystem = new NodeFileSystem();
+      const prepare: ProjectPreparer = async () => ({
+        fs: nodeFileSystem,
+        dev: true,
+        loadContext: async () => ({}) as any,
+        verify: async () => undefined,
+        createEntries: async () => [{ manifest, config: {} }],
+      });
+
+      let thrown: unknown;
+      try {
+        await runLaunchSequence(prepare, projectFolder, "test", {});
+      } catch (error) {
+        thrown = error;
+      }
+
+      const registryPath = path.join(
+        projectFolder,
+        runtimeInterface.DEV_REGISTRY_PATH,
+      );
+      expect(thrown).to.be.instanceOf(AggregateError);
+      expect(shutdown.calledOnce).to.equal(true);
+      expect(await nodeFileSystem.exists(registryPath)).to.equal(false);
+      expect((Module as any)._resolveFilename).to.equal(previousResolver);
+    } finally {
+      (Module as any)._resolveFilename = previousResolver;
+      await fs.rm(projectFolder, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/core/runtime/module-loading.test.ts
+++ b/test/core/runtime/module-loading.test.ts
@@ -2,6 +2,7 @@ import * as moduleInterfaceBeta from "@antelopejs/interface-core/modules";
 import { expect } from "chai";
 import sinon from "sinon";
 import { terminalDisplay } from "../../../src/core/cli/terminal-display";
+import { Module } from "../../../src/core/module";
 import type { ModuleManager } from "../../../src/core/module-manager";
 import {
   constructAndStartModules,
@@ -10,6 +11,48 @@ import {
   registerCoreModuleInterface,
   reloadWatchedModule,
 } from "../../../src/core/runtime/module-loading";
+
+interface ReloadHarness {
+  oldModule: any;
+  entry: any;
+  manager: any;
+  loaderContext: any;
+}
+
+function createReloadHarness(): ReloadHarness {
+  const oldModule = {
+    id: "alpha",
+    state: "active",
+    manifest: { source: { type: "local", path: "/mods/alpha" } },
+    destroy: sinon.stub().resolves(),
+  };
+  const entry: any = { module: oldModule, config: { config: {} } };
+  const manifest = {
+    name: "alpha",
+    version: "2.0.0",
+    main: __filename,
+    folder: "/mods/alpha",
+    imports: [],
+    source: { type: "local", path: "/mods/alpha" },
+  } as any;
+  const manager = {
+    getLoadedModuleEntry: sinon.stub().returns(entry),
+    unrequireModuleFiles: sinon.stub(),
+    replaceLoadedModule: sinon
+      .stub()
+      .callsFake((_id: string, replacement: Module) => {
+        entry.module = replacement;
+        return entry;
+      }),
+    refreshAssociations: sinon.stub(),
+  };
+  const loaderContext = {
+    cache: {},
+    projectFolder: "/project",
+    registry: { load: sinon.stub().resolves([manifest]) },
+  } as any;
+  return { oldModule, entry, manager, loaderContext };
+}
 
 describe("runtime module-loading", () => {
   afterEach(() => {
@@ -65,6 +108,8 @@ describe("runtime module-loading", () => {
   it("reloads watched modules from source when a loader context is provided", async () => {
     const entry = {
       module: {
+        id: "alpha",
+        state: "active",
         manifest: { source: { type: "local", path: "/mods/alpha" } },
         destroy: sinon.stub().resolves(),
       },
@@ -73,7 +118,7 @@ describe("runtime module-loading", () => {
       },
     };
 
-    const replaceLoadedModuleStub = sinon.stub();
+    const replaceLoadedModuleStub = sinon.stub().returns(entry);
     const refreshAssociationsStub = sinon.stub();
     const manager = {
       getLoadedModuleEntry: sinon.stub().returns(entry),
@@ -100,7 +145,7 @@ describe("runtime module-loading", () => {
 
     await reloadWatchedModule(manager, "alpha", loaderContext);
 
-    expect(entry.module.destroy.calledOnce).to.equal(true);
+    expect((entry.module as any).destroy.calledOnce).to.equal(true);
     expect(manager.unrequireModuleFiles.calledWith("alpha")).to.equal(true);
     const expectedSource = { type: "local", path: "/mods/alpha", id: "alpha" };
     expect(
@@ -117,6 +162,8 @@ describe("runtime module-loading", () => {
   it("propagates error when registry.load fails during reload", async () => {
     const entry = {
       module: {
+        id: "alpha",
+        state: "active",
         manifest: { source: { type: "local", path: "/mods/alpha" } },
         destroy: sinon.stub().resolves(),
       },
@@ -149,7 +196,7 @@ describe("runtime module-loading", () => {
     }
 
     expect(thrown).to.be.instanceOf(Error);
-    expect(entry.module.destroy.calledOnce).to.equal(true);
+    expect(entry.module.destroy.called).to.equal(false);
     expect(manager.replaceLoadedModule.called).to.equal(false);
   });
 
@@ -157,6 +204,8 @@ describe("runtime module-loading", () => {
     const destroyStub = sinon.stub().resolves();
     const entry = {
       module: {
+        id: "alpha",
+        state: "active",
         manifest: { source: { type: "local", path: "/mods/alpha" } },
         destroy: destroyStub,
       },
@@ -165,7 +214,7 @@ describe("runtime module-loading", () => {
       },
     };
 
-    const replaceLoadedModuleStub = sinon.stub();
+    const replaceLoadedModuleStub = sinon.stub().returns(entry);
     const refreshAssociationsStub = sinon.stub();
     const manager = {
       getLoadedModuleEntry: sinon.stub().returns(entry),
@@ -207,6 +256,191 @@ describe("runtime module-loading", () => {
 
     expect(replaceLoadedModuleStub.calledOnce).to.equal(true);
     expect(refreshAssociationsStub.calledOnce).to.equal(true);
+    expect(destroyStub.calledOnce).to.equal(true);
+  });
+
+  it("resolves and validates a replacement before destroying the live module", async () => {
+    const calls: string[] = [];
+    const harness = createReloadHarness();
+    harness.loaderContext.registry.load.callsFake(async () => {
+      calls.push("load");
+      return [
+        {
+          name: "alpha",
+          version: "2.0.0",
+          main: __filename,
+          folder: "/mods/alpha",
+          imports: [],
+          source: { type: "local", path: "/mods/alpha" },
+        },
+      ];
+    });
+    harness.oldModule.destroy.callsFake(async () => {
+      calls.push("destroy-old");
+    });
+    harness.manager.replaceLoadedModule.callsFake(
+      (_id: string, replacement: Module) => {
+        calls.push("replace");
+        harness.entry.module = replacement;
+        return harness.entry;
+      },
+    );
+    harness.manager.refreshAssociations.callsFake(() => {
+      calls.push("associate");
+    });
+    const construct = sinon
+      .stub(Module.prototype, "construct")
+      .callsFake(async function (this: Module) {
+        calls.push("construct");
+      });
+    const start = sinon.stub(Module.prototype, "start").callsFake(async () => {
+      calls.push("start");
+    });
+
+    await reloadWatchedModule(harness.manager, "alpha", harness.loaderContext);
+
+    expect(calls).to.deep.equal([
+      "load",
+      "destroy-old",
+      "replace",
+      "associate",
+      "construct",
+      "start",
+    ]);
+    expect(construct.calledOnce).to.equal(true);
+    expect(start.calledOnce).to.equal(true);
+  });
+
+  it("keeps the old module installed when its destroy fails", async () => {
+    const harness = createReloadHarness();
+    harness.oldModule.start = sinon.stub().callsFake(async () => {
+      harness.oldModule.state = "active";
+    });
+    harness.oldModule.destroy.callsFake(async () => {
+      harness.oldModule.state = "constructed";
+      throw new Error("destroy-old");
+    });
+
+    let thrown: unknown;
+    try {
+      await reloadWatchedModule(
+        harness.manager,
+        "alpha",
+        harness.loaderContext,
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.be.instanceOf(AggregateError);
+    expect(harness.entry.module).to.equal(harness.oldModule);
+    expect(harness.manager.replaceLoadedModule.called).to.equal(false);
+    expect(harness.manager.unrequireModuleFiles.called).to.equal(false);
+    expect(harness.oldModule.start.calledOnce).to.equal(true);
+    expect(harness.oldModule.state).to.equal("active");
+  });
+
+  it("leaves a stopped safe state when replacement installation fails", async () => {
+    const harness = createReloadHarness();
+    harness.manager.replaceLoadedModule.returns(undefined);
+
+    let thrown: unknown;
+    try {
+      await reloadWatchedModule(
+        harness.manager,
+        "alpha",
+        harness.loaderContext,
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.be.instanceOf(AggregateError);
+    expect(harness.oldModule.destroy.calledOnce).to.equal(true);
+    expect(harness.entry.module).to.equal(harness.oldModule);
+  });
+
+  it("cleans the replacement when association fails", async () => {
+    const harness = createReloadHarness();
+    harness.manager.refreshAssociations.throws(new Error("associate"));
+    const destroy = sinon.stub(Module.prototype, "destroy").resolves();
+
+    let thrown: unknown;
+    try {
+      await reloadWatchedModule(
+        harness.manager,
+        "alpha",
+        harness.loaderContext,
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.be.instanceOf(AggregateError);
+    expect(harness.entry.module).to.not.equal(harness.oldModule);
+    expect(destroy.calledOnce).to.equal(true);
+  });
+
+  it("cleans the replacement when construct fails", async () => {
+    const harness = createReloadHarness();
+    sinon.stub(Module.prototype, "construct").rejects(new Error("construct"));
+    const destroy = sinon.stub(Module.prototype, "destroy").resolves();
+
+    let thrown: unknown;
+    try {
+      await reloadWatchedModule(
+        harness.manager,
+        "alpha",
+        harness.loaderContext,
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.be.instanceOf(AggregateError);
+    expect(destroy.calledOnce).to.equal(true);
+  });
+
+  it("cleans the replacement when start fails", async () => {
+    const harness = createReloadHarness();
+    sinon.stub(Module.prototype, "construct").resolves();
+    sinon.stub(Module.prototype, "start").rejects(new Error("start"));
+    const destroy = sinon.stub(Module.prototype, "destroy").resolves();
+
+    let thrown: unknown;
+    try {
+      await reloadWatchedModule(
+        harness.manager,
+        "alpha",
+        harness.loaderContext,
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.be.instanceOf(AggregateError);
+    expect(destroy.calledOnce).to.equal(true);
+  });
+
+  it("aggregates activation and replacement cleanup failures", async () => {
+    const harness = createReloadHarness();
+    sinon.stub(Module.prototype, "construct").rejects(new Error("construct"));
+    sinon.stub(Module.prototype, "destroy").rejects(new Error("cleanup"));
+
+    let thrown: unknown;
+    try {
+      await reloadWatchedModule(
+        harness.manager,
+        "alpha",
+        harness.loaderContext,
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.be.instanceOf(AggregateError);
+    expect((thrown as AggregateError).errors).to.have.length(2);
+    expect(harness.entry.module).to.not.equal(harness.oldModule);
   });
 
   it("constructs and starts modules, and fails gracefully on construct errors", async () => {
@@ -372,15 +606,19 @@ describe("runtime module-loading", () => {
     );
     expect(startModulesStub.called).to.equal(false);
 
-    manager.getLoadedModuleEntry = sinon.stub().returns({
+    const liveDestroy = sinon.stub().resolves();
+    const liveEntry = {
       module: {
+        id: "alpha",
+        state: "active",
         manifest: { source: { type: "local", path: "/mods/alpha" } },
-        destroy: sinon.stub().resolves(),
+        destroy: liveDestroy,
       },
       config: {
         config: {},
       },
-    }) as any;
+    };
+    manager.getLoadedModuleEntry = sinon.stub().returns(liveEntry) as any;
 
     registryLoadStub.resolves([]);
     let reloadNoManifestError: unknown;
@@ -390,6 +628,7 @@ describe("runtime module-loading", () => {
       reloadNoManifestError = error;
     }
     expect(reloadNoManifestError).to.be.instanceOf(Error);
+    expect(liveDestroy.called).to.equal(false);
 
     registryLoadStub.resolves([
       {
@@ -405,5 +644,6 @@ describe("runtime module-loading", () => {
       reloadMismatchError = error;
     }
     expect(reloadMismatchError).to.be.instanceOf(Error);
+    expect(liveDestroy.called).to.equal(false);
   });
 });


### PR DESCRIPTION
## Summary

- serialize module lifecycle transitions so concurrent start, stop, and destroy calls are idempotent
- settle sibling construction/start operations, roll back successful work, and aggregate primary and cleanup failures
- make stop/destroy exhaustive and deterministic while clearing manager-owned registries, resolver state, and process resources
- move HMR source loading and identity validation ahead of the commit boundary, recover the old generation when its destruction fails, and leave failed post-commit replacements stopped and retryable
- clean modules and runtime resources when launch or post-launch setup fails

## Rollback invariants

- resolver detours remain attached until sibling construction and rollback settle
- construction failure destroys every generation that reached a cleanup-capable state
- startup failure destroys all loaded generations in reverse order and releases runtime resources
- reload source/download/manifest/identity failures never destroy the live generation
- old-generation destroy failure restores an active old service when stop had already completed
- replacement association/construct/start failures destroy the replacement; cleanup failures are retained in the aggregate error
- stop and destroy attempt every managed module; terminal teardown removes normal addressability while privately retaining only failed cleanup generations for deterministic retry

## Verification

- `pnpm test` — 646 unit/integration tests and all three playground phases passed
- `pnpm test:coverage` — 96.26% lines, 92.99% branches, 96.12% functions, 96.26% statements
- `pnpm build` — passed
- `pnpm lint` — passed (existing unrelated warnings remain in CLI files)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes module lifecycle transitions transactional and deterministic, with exhaustive rollback and cleanup behavior.
- Serializes overlapping construct, start, stop, and destroy operations.
- Aggregates lifecycle and cleanup failures while preserving deterministic teardown order.
- Improves failed-launch cleanup and HMR replacement recovery.
- Clears manager, resolver, shutdown, and runtime state at terminal boundaries.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/module-lifecycle.ts | Serializes lifecycle transitions and makes destruction exhaustive across stop and destroy failures. |
| src/core/module-manager.ts | Adds deterministic bulk lifecycle operations, rollback, failure aggregation, private cleanup retries, and terminal manager-state clearing. |
| src/core/runtime/module-loading.ts | Validates replacements before commit and adds recovery or cleanup for failures around HMR replacement. |
| src/core/runtime/launch-sequence.ts | Ensures failed launches clean module and shutdown resources while retaining cleanup failures. |
| src/core/shutdown/shutdown-manager.ts | Clears timeout and handler state after shutdown execution completes. |
| src/index.ts | Attempts both stop and destroy during shutdown and aggregates their failures. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Caller
  participant Lifecycle
  participant Manager
  participant Runtime

  Caller->>Lifecycle: construct / start / stop / destroy
  Lifecycle->>Lifecycle: enqueue transition
  Lifecycle-->>Caller: settle transition

  alt lifecycle operation fails
    Manager->>Lifecycle: destroy remaining generations
    Lifecycle-->>Manager: cleanup results
    Manager->>Runtime: release registries and resources
    Manager-->>Caller: aggregate primary and cleanup errors
  else operation succeeds
    Manager-->>Caller: transition completed
  end
```

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/antelopejs/antelopejs/commit/0f48bbce6d38b0604a9d66cb8c84cec627ec83e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54583319)</sub>

<!-- /greptile_comment -->