### PR TITLE
fix(runtime): resolve static module package dependencies

### DIFF
--- a/src/core/runtime/module-loading.ts
+++ b/src/core/runtime/module-loading.ts
@@ -521,12 +521,12 @@ export function ensureGraphIsValid(manager: ModuleManager): void {
     disabledExports: config.disabledExports,
   }));
 
-  // Static modules handle their own interface deps — treat them as resolved
-  const staticDeps = allModules
+  const staticPackages = allModules
     .filter(({ module }) => !loadedIds.has(module.id))
-    .flatMap(({ module }) =>
-      Object.keys(module.manifest.manifest.dependencies ?? {}),
-    );
+    .flatMap(({ module }) => [
+      module.manifest.manifest.name,
+      ...Object.keys(module.manifest.manifest.dependencies ?? {}),
+    ]);
 
   const consumers = loadedModules.map(({ module }) => ({
     id: module.id,
@@ -538,7 +538,7 @@ export function ensureGraphIsValid(manager: ModuleManager): void {
   const { unresolved, stubbed } = findUnresolvedInterfaces(
     providers,
     consumers,
-    staticDeps,
+    staticPackages,
   );
   if (unresolved.length > 0) {
     const details = unresolved

--- a/test/core/runtime/module-loading.test.ts
+++ b/test/core/runtime/module-loading.test.ts
@@ -105,6 +105,42 @@ describe("runtime module-loading", () => {
     expect(() => ensureGraphIsValid(manager)).to.not.throw();
   });
 
+  it("treats a static module package as an available dependency", () => {
+    const staticEntry = {
+      module: {
+        id: "antelopejs",
+        manifest: {
+          name: "antelopejs",
+          folder: process.cwd(),
+          implements: ["@antelopejs/interface-core"],
+          manifest: {
+            name: "@antelopejs/core",
+            version: "1.4.7",
+            dependencies: { "@antelopejs/interface-core": "*" },
+          },
+        },
+      },
+      config: {},
+    };
+    const loadedEntry = {
+      module: {
+        id: "app",
+        manifest: {
+          folder: process.cwd(),
+          implements: [],
+          manifest: { dependencies: { "@antelopejs/core": "*" } },
+        },
+      },
+      config: {},
+    };
+    const manager = {
+      getAllManagedModules: () => [staticEntry, loadedEntry],
+      getLoadedModules: () => [loadedEntry].values(),
+    } as any;
+
+    expect(() => ensureGraphIsValid(manager)).to.not.throw();
+  });
+
   it("reloads watched modules and ignores unknown ones", async () => {
     const managerWithoutEntry = {
       getLoadedModuleEntry: sinon.stub().returns(undefined),


### PR DESCRIPTION
## Summary

- treat each static module's package name as already available during graph validation
- keep static module dependencies in the known-resolved set
- cover an application module that depends on the statically registered `@antelopejs/core` package

## Problem

After #97 made package discovery deterministic, `@antelopejs/core` is correctly recognized as an Antelope package through its `antelopeJs` metadata. A project that is itself loaded as a module and declares Core as a runtime dependency then fails production build with:

```text
Unresolved interface dependencies:
  - app requires @antelopejs/core
```

The Core runtime is already registered as a static module, but graph validation only considered the static module's dependencies resolved, not the static module package itself.

## Validation

- regression test fails on `main` and passes with this change
- build passes
- 671 unit tests pass
- package-consumer routing passes
- playground launch/build/launch-from-build passes
- coverage passes: 94.73% statements/lines, 92.25% branches, 91.22% functions
- lint passes with the existing 2 warnings and 1 info
- real benchmark application production build now completes from the packed candidate

No throughput claim: this only corrects graph validation and does not alter request hot paths.

## Release note

The ecosystem benchmark subsequently identified a separate dependency-range blocker: published providers such as `@antelopejs/api@1.2.2` still require old `@antelopejs/interface-core` patch ranges. Those packages must be made compatible and released before publishing the next Core version.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes dependency-graph validation so a statically registered module’s own package is recognized as available, not only its declared dependencies.

- Renames the known-resolved collection from `staticDeps` to `staticPackages`.
- Adds each static module’s manifest package name to that collection.
- Adds a regression test for an application module depending on the statically registered `@antelopejs/core` package.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the focused validation change matching the static-module lifecycle and covered by a regression test.

Static entries are deliberately excluded from ordinary loaded-module providers, and the change now includes both their package names and dependencies in the graph validator’s known-resolved set without altering runtime loading behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/core/runtime/module-loading.ts | Extends graph validation’s known-resolved set with static modules’ own package names, matching the existing static-module availability model. |
| test/core/runtime/module-loading.test.ts | Adds focused regression coverage showing that a loaded application may depend on the package represented by a static module. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Collect managed modules] --> B[Identify static modules]
  B --> C[Collect package names and dependencies]
  C --> D[Seed known-resolved packages]
  D --> E[Validate loaded-module consumers]
  E --> F{Unresolved dependencies?}
  F -->|Yes| G[Throw validation error]
  F -->|No| H[Continue startup or build]
```

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): resolve static module pack..."](https://github.com/antelopejs/antelopejs/commit/86348cc2f99335b31f9ef95517cd3d52d619a10e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55184331)</sub>

<!-- /greptile_comment -->