### PR TITLE
fix(runtime): require discoverable core interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:coverage": "c8 --check-coverage --lines 90 --functions 90 --branches 90 --statements 90 mocha --require ts-node/register --require test/setup.ts 'test/**/*.test.ts' --exit"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.11",
+    "@antelopejs/interface-core": "^0.0.12",
     "@types/proper-lockfile": "^4.1.4",
     "boxen": "^8.0.1",
     "chalk": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.11
-        version: 0.0.11
+        specifier: ^0.0.12
+        version: 0.0.12
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
@@ -128,8 +128,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.11':
-    resolution: {integrity: sha512-eKE3F9XY0eIzdLBXms8QAY4BHmA8+XXZnta0vZ411q9GiSbI2S1Q3lfYzmnXU4ZK9i+/SIYPplOsA02gIdxODg==}
+  '@antelopejs/interface-core@0.0.12':
+    resolution: {integrity: sha512-GsLcP1i2GJV6eWzcasecpIvKmPRmovNf6bK4eCHEV2DfkvlSpfyrqMFz7YGCKwntV0azyQO3dfdXPcNHXnZy6w==}
 
   '@antelopejs/interface-core@0.0.6':
     resolution: {integrity: sha512-OMna86iT/ylL6wJl6FCPw9ieddULXGs4jTmeiDBNEXYQ9acnVXjS/+SaN0UR0h7oY7WTD9VwKXVwG95qjNIA1w==}
@@ -1789,7 +1789,7 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.11':
+  '@antelopejs/interface-core@0.0.12':
     dependencies:
       reflect-metadata: 0.2.2
 

--- a/test/integration/provider-routing.test.ts
+++ b/test/integration/provider-routing.test.ts
@@ -6,18 +6,26 @@ import {
   ImplementInterface,
   InterfaceFunction,
 } from "@antelopejs/interface-core";
+import * as moduleInterface from "@antelopejs/interface-core/modules";
+import * as runtimeInterface from "@antelopejs/interface-core/runtime";
 import { expect } from "chai";
-import launch, { type ModuleManager } from "../../src";
+import launch, { ModuleManager } from "../../src";
 import { Module } from "../../src/core/module";
 import { buildProviderRoutes } from "../../src/core/module-context";
+import { registerCoreRuntimeInterface } from "../../src/core/runtime/dev-server-registry";
 import {
   createLoaderContext,
+  registerCoreInterfaces,
+  registerCoreModuleInterface,
   reloadWatchedModule,
 } from "../../src/core/runtime/module-loading";
+import { InMemoryFileSystem } from "../helpers/in-memory-filesystem";
 
 const ROUTING_RESULTS_KEY = "__antelopeProviderRouting";
 const INTERFACE_NAME = "routing-interface";
 const STRESS_ITERATIONS = 40;
+const CORE_MODULE_ID = "antelopejs";
+const REAL_CONSUMER_ID = "cms";
 
 interface RoutingResult {
   module: string;
@@ -218,6 +226,17 @@ function routingResults(): RoutingResults {
   ] as RoutingResults;
 }
 
+async function unavailableLoaderContext(): Promise<never> {
+  throw new Error("Loader context is unavailable in the routing test");
+}
+
+function destroyCoreProviders(): void {
+  moduleInterface.RunWithModuleContext(
+    { module: CORE_MODULE_ID, provider: CORE_MODULE_ID },
+    () => moduleInterface.Events.ModuleDestroyed.emit(CORE_MODULE_ID),
+  );
+}
+
 async function destroyProject(
   manager: ModuleManager | undefined,
   folder: string,
@@ -231,6 +250,47 @@ async function destroyProject(
 }
 
 describe("provider-aware runtime", () => {
+  it("discovers core runtime and module providers from the canonical root", async () => {
+    const manager = new ModuleManager();
+    await registerCoreInterfaces(manager);
+    registerCoreModuleInterface(manager, unavailableLoaderContext);
+    await registerCoreRuntimeInterface({
+      dev: false,
+      env: "production",
+      fs: new InMemoryFileSystem(),
+      projectPath: process.cwd(),
+    });
+
+    try {
+      const providerRoutes = buildProviderRoutes(REAL_CONSUMER_ID, [
+        {
+          interfaceName: "@antelopejs/interface-core",
+          packageEntry: require.resolve("@antelopejs/interface-core"),
+          provider: CORE_MODULE_ID,
+          providerCount: 1,
+        },
+      ]);
+      const runtimeInfo = await moduleInterface.RunWithModuleContext(
+        { module: REAL_CONSUMER_ID, providerRoutes },
+        () => runtimeInterface.GetRuntimeInfo(),
+      );
+      const modules = await moduleInterface.RunWithModuleContext(
+        { module: REAL_CONSUMER_ID, providerRoutes },
+        () => moduleInterface.ListModules(),
+      );
+
+      expect(runtimeInfo).to.include({ dev: false, env: "production" });
+      expect(modules).to.include(CORE_MODULE_ID);
+      expect(providerRoutes).to.include({
+        "async:runtime.GetRuntimeInfo": CORE_MODULE_ID,
+        "async:runtime.RegisterDevServer": CORE_MODULE_ID,
+        "async:modules.ListModules": CORE_MODULE_ID,
+      });
+    } finally {
+      destroyCoreProviders();
+    }
+  });
+
   it("routes explicit and default providers independently of construct timing", async function () {
     this.timeout(20000);
     const project = await createRoutingProject();

--- a/test/package-consumer/run.ts
+++ b/test/package-consumer/run.ts
@@ -36,8 +36,8 @@ function packCore(): string {
 function inspectManifest(tarball: string): void {
   const content = run("tar", ["-xOf", tarball, "package/package.json"], root);
   const manifest = JSON.parse(content) as PackedManifest;
-  if (manifest.dependencies?.["@antelopejs/interface-core"] !== "^0.0.11") {
-    throw new Error("Packed core does not depend on interface-core ^0.0.11.");
+  if (manifest.dependencies?.["@antelopejs/interface-core"] !== "^0.0.12") {
+    throw new Error("Packed core does not depend on interface-core ^0.0.12.");
   }
   if (/github:AntelopeJS\/interface-core|patches\//.test(content)) {
     throw new Error(
@@ -54,7 +54,7 @@ function installConsumer(tarball: string): void {
       private: true,
       dependencies: {
         "@antelopejs/core": `file:${tarball}`,
-        "@antelopejs/interface-core": "0.0.11",
+        "@antelopejs/interface-core": "0.0.12",
         "reflect-metadata": "0.2.2",
       },
     }),


### PR DESCRIPTION
## Summary
- require `@antelopejs/interface-core` 0.0.12 so canonical root discovery includes module and runtime declarations
- lock the Core runtime to the 0.0.12 candidate
- exercise real Core module/runtime interface registration through canonical provider routing
- update the packed consumer contract to require 0.0.12

## Validation
- `pnpm lint`
- `pnpm build`
- `pnpm test:unit` (672 passing)
- targeted canonical provider-routing regression

## Release ordering
This PR depends on AntelopeJS/interface-core#11 and can only install from the public registry after 0.0.12 is published.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Core runtime dependency to `@antelopejs/interface-core` 0.0.12 and adds coverage for canonical discovery and routing of Core module/runtime interfaces.
- Updates the dependency manifest, lockfile, and packed-consumer contract to 0.0.12.
- Exercises real Core interface registration and provider routing through the canonical package root.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The dependency, lockfile, consumer contract, and canonical provider-routing coverage are updated consistently, and the investigation established no reachable incorrect behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Raises the interface-core dependency requirement from 0.0.11 to 0.0.12. |
| pnpm-lock.yaml | Resolves the root interface-core dependency to 0.0.12 with a matching snapshot. |
| test/integration/provider-routing.test.ts | Adds integration coverage for discovering and routing the canonical Core module and runtime providers; no concrete defect was established. |
| test/package-consumer/run.ts | Updates packed-manifest validation and the test consumer to require interface-core 0.0.12. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): require discoverable core ..."](https://github.com/antelopejs/antelopejs/commit/e9a0c6d230b8338d0aa5d8ab83fd51dfe336503a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55619407)</sub>

<!-- /greptile_comment -->