### PR TITLE
feat(loader): resolve interface facades per consumer

### DIFF
--- a/docs/3.module-development/2.exporting-interfaces.md
+++ b/docs/3.module-development/2.exporting-interfaces.md
@@ -28,6 +28,7 @@ The interface file declares types, internal proxy functions, and public wrapper 
 
 ```typescript [src/interface/index.ts]
 import { InterfaceFunction } from "@antelopejs/interface-core";
+import type { InterfaceFacadeScope } from "@antelopejs/interface-core/facades";
 
 export interface User {
   id: string;
@@ -54,9 +55,27 @@ export function CreateUser(name: string, email: string): Promise<User> {
 export function DeleteUser(id: string): Promise<void> {
   return internal.deleteUserProxy(id);
 }
+
+// The resolver binds InterfaceFunction exports automatically. These public
+// wrappers close over the canonical `internal` namespace, so expose equivalent
+// wrappers built from the consumer facade's bound namespace.
+export function BuildInterfaceFacade(
+  _scope: InterfaceFacadeScope,
+  facade: Record<string, unknown>,
+) {
+  const bound = (facade.internal as typeof internal);
+  return {
+    GetUser: (id: string) => bound.getUserProxy(id),
+    CreateUser: (name: string, email: string) =>
+      bound.createUserProxy(name, email),
+    DeleteUser: (id: string) => bound.deleteUserProxy(id),
+  };
+}
 ```
 
-`InterfaceFunction` creates a typed proxy that the core wires to an implementation at runtime. The wrapper functions forward calls to the proxies, giving consumers a straightforward function-based API without exposing the proxy mechanism.
+`InterfaceFunction` creates a typed proxy that the core wires to an implementation at runtime. The wrapper functions forward calls to the proxies, giving consumers a straightforward function-based API without exposing the proxy mechanism. Core creates one interface facade for each consumer generation and automatically binds direct `InterfaceFunction` exports, including nested namespace exports. `BuildInterfaceFacade` is only required for derived functions that close over canonical proxy functions, as above, or for decorators that perform registration work.
+
+The application syntax remains unchanged. A consumer still imports `GetUser`; the resolver supplies the generation-specific facade before evaluating that consumer.
 
 ### Step 2 — Write the Implementation
 

--- a/docs/3.module-development/2.exporting-interfaces.md
+++ b/docs/3.module-development/2.exporting-interfaces.md
@@ -13,6 +13,7 @@ An embedded interface lives inside the module that implements it. The module con
 my-module/
 ├── src/
 │   ├── index.ts
+│   ├── interface-declarations.ts
 │   ├── interface/
 │   │   └── index.ts
 │   └── implementations/
@@ -87,18 +88,37 @@ export namespace internal {
 
 The exported namespace and function names must match exactly. The core binds each proxy to its implementation by matching the namespace structure and function names between the interface and the implementation.
 
-### Step 3 — Declare the Interface in `package.json`
+### Step 3 — Add the Declaration Entry
 
-The `implements` field in `package.json` lists the npm package names from which consumers import the interface. For an embedded interface, the module lists its own package name because consumers import the interface from it.
+An embedded interface must expose every proxy through a side-effect-free `./interface-declarations` subpath. The core loads this subpath during graph preparation, before the module enters its lifecycle generation.
+
+Create an aggregate that imports only interface declarations:
+
+```typescript [src/interface-declarations.ts]
+export * as UserInterface from "./interface";
+```
+
+Export the compiled aggregate from `package.json`. The `implements` field lists the npm package names from which consumers import the interface. An embedded interface lists its own package name.
 
 ```json [package.json]
 {
   "name": "@your-org/my-module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./interface": "./dist/interface/index.js",
+    "./interface-declarations": "./dist/interface-declarations.js"
+  },
   "antelopeJs": {
     "implements": ["@your-org/my-module"]
   }
 }
 ```
+
+The declaration entry and its complete import closure must not import the application entry point or modules that perform lifecycle work, register routes, initialize databases, or load other application subsystems. Import utility leaf modules directly when a barrel export pulls application code into the declaration graph.
+
+::important
+Resolving `./interface-declarations` is not sufficient by itself. Add a package regression that imports the subpath in a fresh process, verifies that the application entry point and its side effects remain unloaded, and checks that the aggregate exposes the same proxy objects as the public interface subpaths.
+::
 
 Consumers can then import the interface using the module's package name and the `interface` subpath:
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:coverage": "c8 --check-coverage --lines 90 --functions 90 --branches 90 --statements 90 mocha --require ts-node/register --require test/setup.ts 'test/**/*.test.ts' --exit"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.12",
+    "@antelopejs/interface-core": "^0.0.13",
     "@types/proper-lockfile": "^4.1.4",
     "boxen": "^8.0.1",
     "chalk": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,7 +129,7 @@ importers:
 packages:
 
   '@antelopejs/interface-core@0.0.13':
-    resolution: {integrity: sha512-Y5TSlO2N1KywdJB/NpwRtybxFPro1rqSDUzs4PXUc7IDy4Zd/PZFE7RSq287Fq/7n4DwhxeC/GVrPxXJPXw4Qg==}
+    resolution: {integrity: sha512-/QdBq0jcEqQtjkzdZkmmkjn76T8RqiM9ZTFlh8+O6N3vxGW+UxJAGF9ZEJzAhOgtzuLDtnhSLrIYuEZmYQJH8g==}
 
   '@antelopejs/interface-core@0.0.6':
     resolution: {integrity: sha512-OMna86iT/ylL6wJl6FCPw9ieddULXGs4jTmeiDBNEXYQ9acnVXjS/+SaN0UR0h7oY7WTD9VwKXVwG95qjNIA1w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.12
-        version: 0.0.12
+        specifier: ^0.0.13
+        version: 0.0.13
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
@@ -128,8 +128,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.12':
-    resolution: {integrity: sha512-GsLcP1i2GJV6eWzcasecpIvKmPRmovNf6bK4eCHEV2DfkvlSpfyrqMFz7YGCKwntV0azyQO3dfdXPcNHXnZy6w==}
+  '@antelopejs/interface-core@0.0.13':
+    resolution: {integrity: sha512-Y5TSlO2N1KywdJB/NpwRtybxFPro1rqSDUzs4PXUc7IDy4Zd/PZFE7RSq287Fq/7n4DwhxeC/GVrPxXJPXw4Qg==}
 
   '@antelopejs/interface-core@0.0.6':
     resolution: {integrity: sha512-OMna86iT/ylL6wJl6FCPw9ieddULXGs4jTmeiDBNEXYQ9acnVXjS/+SaN0UR0h7oY7WTD9VwKXVwG95qjNIA1w==}
@@ -1789,7 +1789,7 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.12':
+  '@antelopejs/interface-core@0.0.13':
     dependencies:
       reflect-metadata: 0.2.2
 

--- a/src/core/module-context.ts
+++ b/src/core/module-context.ts
@@ -5,7 +5,7 @@ import {
 
 export interface InterfaceProviderRoute {
   interfaceName: string;
-  packageEntry?: string;
+  declarationEntry?: string;
   provider: string;
   providerCount: number;
 }
@@ -44,7 +44,7 @@ function collectProxyIdentities(value: unknown): string[] {
 }
 
 function loadInterfaceDeclaration(route: InterfaceProviderRoute): unknown {
-  if (!route.packageEntry) {
+  if (!route.declarationEntry) {
     if (route.providerCount > 1) {
       throw new Error(
         `Cannot route '${route.interfaceName}' between ${route.providerCount} providers because its package could not be resolved. Configure one provider or install a resolvable interface package.`,
@@ -54,10 +54,10 @@ function loadInterfaceDeclaration(route: InterfaceProviderRoute): unknown {
   }
 
   try {
-    return require(route.packageEntry);
+    return require(route.declarationEntry);
   } catch (error) {
     throw new Error(
-      `Failed to prepare provider routing for '${route.interfaceName}' from '${route.packageEntry}'.`,
+      `Failed to prepare provider routing for '${route.interfaceName}' from '${route.declarationEntry}'.`,
       { cause: error },
     );
   }

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -71,6 +71,27 @@ interface ModuleOperationResults {
   failed: ManagedModule[];
 }
 
+function collectCachedModuleClosure(
+  entryPath: string,
+  files: Set<string>,
+): void {
+  const entry = require.cache[require.resolve(entryPath)];
+  if (!entry) {
+    return;
+  }
+  const pending = [entry];
+  const visited = new Set<NodeModule>();
+  while (pending.length > 0) {
+    const loaded = pending.pop();
+    if (!loaded || visited.has(loaded)) {
+      continue;
+    }
+    visited.add(loaded);
+    files.add(loaded.filename);
+    pending.push(...loaded.children);
+  }
+}
+
 export class ModuleManager {
   public readonly registry: ModuleRegistry;
   public readonly resolver: Resolver;
@@ -95,6 +116,7 @@ export class ModuleManager {
     InterfacePackagePlan
   >();
   private readonly interfaceDeclarationEntries = new Map<string, string>();
+  private readonly interfaceDeclarationFiles = new Set<string>();
   private pendingCleanup: ManagedModule[] = [];
   private startupOrder: string[] = [];
 
@@ -138,6 +160,7 @@ export class ModuleManager {
     }
 
     this.rebuildAssociations();
+    this.prepareModuleFiles(created);
     return created;
   }
 
@@ -193,6 +216,9 @@ export class ModuleManager {
 
     for (const filePath of Object.keys(require.cache)) {
       if (!this.isPathWithin(filePath, moduleFolder)) {
+        continue;
+      }
+      if (this.interfaceDeclarationFiles.has(filePath)) {
         continue;
       }
       let shouldDelete = true;
@@ -359,6 +385,7 @@ export class ModuleManager {
     try {
       this.validateInterfacePackages();
       this.applyInterfaceStubs();
+      this.prepareModuleFiles(modules);
     } catch (error) {
       if (leaseAcquired) {
         throw aggregateErrors(
@@ -400,6 +427,7 @@ export class ModuleManager {
     try {
       this.validateInterfacePackages();
       this.applyInterfaceStubs();
+      this.prepareModuleFiles(modules);
       await Promise.all(
         modules.map(({ module, config }) =>
           this.constructModule(module, config.config),
@@ -518,6 +546,7 @@ export class ModuleManager {
     this.resolver.interfacePackageEntries.clear();
     this.resolver.interfacePackageResolveFrom.clear();
     this.interfaceDeclarationEntries.clear();
+    this.interfaceDeclarationFiles.clear();
     this.interfacePackagePlans.clear();
     this.startupOrder = [];
     return this.releaseRuntimeState();
@@ -561,6 +590,7 @@ export class ModuleManager {
     this.resolver.interfacePackages.clear();
     this.resolver.interfacePackageEntries.clear();
     this.resolver.interfacePackageResolveFrom.clear();
+    this.interfaceDeclarationEntries.clear();
     this.interfacePackagePlans.clear();
     this.resolvedAssociations.clear();
     this.resolvedConnections.clear();
@@ -905,6 +935,28 @@ export class ModuleManager {
         buildProviderRoutes(module.id, routes),
         this.isProvider({ module, config }),
       );
+    }
+    this.refreshInterfaceDeclarationFiles();
+  }
+
+  private refreshInterfaceDeclarationFiles(): void {
+    const files = new Set<string>();
+    const entries = new Set(this.interfaceDeclarationEntries.values());
+    for (const entry of entries) {
+      collectCachedModuleClosure(entry, files);
+    }
+    this.interfaceDeclarationFiles.clear();
+    for (const filePath of files) {
+      this.interfaceDeclarationFiles.add(filePath);
+    }
+  }
+
+  private prepareModuleFiles(modules: ManagedModule[]): void {
+    this.refreshInterfaceDeclarationFiles();
+    for (const { module } of modules) {
+      if (module.state === ModuleState.Loaded && module.manifest?.folder) {
+        this.unrequireModuleFiles(module.id);
+      }
     }
   }
 

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -28,6 +28,7 @@ import {
   clearStubInterfaceWarnings,
   logStubInterfaceWarningOnce,
   neutralizeInterfacePackage,
+  type StubInterfaceCleanup,
 } from "./resolution/stub-interface-runtime";
 
 const Logger = new Logging.Channel("loader");
@@ -74,6 +75,7 @@ export class ModuleManager {
   private readonly interfaceRegistry: InterfaceRegistry;
   private readonly moduleTracker: ModuleTracker;
   private readonly resolverDetour: ResolverDetour;
+  private readonly interfaceStubCleanups: StubInterfaceCleanup[] = [];
   private readonly resolvedAssociations = new Map<string, Set<string>>();
   private readonly resolvedConnections = new Map<
     string,
@@ -291,19 +293,23 @@ export class ModuleManager {
       ? this.collectTestStubProviders(interfaceName)
       : [];
     if (!providers.length) {
-      neutralizeInterfacePackage(
-        resolvedPackage.root,
-        interfaceName,
-        shouldNeutralizeRegistrations,
+      this.interfaceStubCleanups.push(
+        ...neutralizeInterfacePackage(
+          resolvedPackage.root,
+          interfaceName,
+          shouldNeutralizeRegistrations,
+        ),
       );
       return;
     }
     providers.forEach((provider) => {
-      neutralizeInterfacePackage(
-        resolvedPackage.root,
-        interfaceName,
-        true,
-        provider,
+      this.interfaceStubCleanups.push(
+        ...neutralizeInterfacePackage(
+          resolvedPackage.root,
+          interfaceName,
+          true,
+          provider,
+        ),
       );
     });
   }
@@ -519,6 +525,13 @@ export class ModuleManager {
     clearStubInterfaceWarnings();
     this.moduleTracker.clear();
     this.interfaceRegistry.clear();
+    for (const cleanup of this.interfaceStubCleanups.splice(0)) {
+      try {
+        cleanup();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
     try {
       this.resolverDetour.detach();
     } catch (error) {

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -274,12 +274,58 @@ export class ModuleManager {
         Logger.Error(`Failed to load interface '${interfaceName}':`, err);
         continue;
       }
+      this.neutralizeStubbedInterface(
+        interfaceName,
+        resolvedPackage,
+        shouldNeutralizeRegistrations,
+      );
+    }
+  }
+
+  private neutralizeStubbedInterface(
+    interfaceName: string,
+    resolvedPackage: ResolvedPackage,
+    shouldNeutralizeRegistrations: boolean,
+  ) {
+    const providers = shouldNeutralizeRegistrations
+      ? this.collectTestStubProviders(interfaceName)
+      : [];
+    if (!providers.length) {
       neutralizeInterfacePackage(
         resolvedPackage.root,
         interfaceName,
         shouldNeutralizeRegistrations,
       );
+      return;
     }
+    providers.forEach((provider) => {
+      neutralizeInterfacePackage(
+        resolvedPackage.root,
+        interfaceName,
+        true,
+        provider,
+      );
+    });
+  }
+
+  private collectTestStubProviders(interfaceName: string): string[] {
+    const consumers = new Set(
+      this.collectInterfacePackageConsumers(interfaceName).map(
+        ({ moduleId }) => moduleId,
+      ),
+    );
+    return this.getAllManagedModules()
+      .filter(
+        (managed) =>
+          consumers.has(managed.module.id) && this.isProvider(managed),
+      )
+      .map(({ module }) => module.id);
+  }
+
+  private isProvider({ module, config }: ManagedModule): boolean {
+    return (module.manifest.implements ?? []).some(
+      (interfaceName) => !config.disabledExports?.has(interfaceName),
+    );
   }
 
   public applyTestInterfaceStubs(): void {
@@ -802,12 +848,9 @@ export class ModuleManager {
           ).size,
         }),
       );
-      const isProvider = (module.manifest.implements ?? []).some(
-        (interfaceName) => !config.disabledExports?.has(interfaceName),
-      );
       module.setProviderRoutes(
         buildProviderRoutes(module.id, routes),
-        isProvider,
+        this.isProvider({ module, config }),
       );
     }
   }

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -20,6 +20,7 @@ import {
   type ResolvedPackage,
   resolvePackage,
   resolvePackageAtRoot,
+  resolvePackageSubpath,
 } from "./resolution/package-resolution";
 import { PathMapper } from "./resolution/path-mapper";
 import { Resolver } from "./resolution/resolver";
@@ -32,6 +33,7 @@ import {
 } from "./resolution/stub-interface-runtime";
 
 const Logger = new Logging.Channel("loader");
+const INTERFACE_DECLARATIONS_SUBPATH = "interface-declarations";
 
 export interface ModuleConfig {
   config?: unknown;
@@ -92,6 +94,7 @@ export class ModuleManager {
     string,
     InterfacePackagePlan
   >();
+  private readonly interfaceDeclarationEntries = new Map<string, string>();
   private pendingCleanup: ManagedModule[] = [];
   private startupOrder: string[] = [];
 
@@ -514,6 +517,7 @@ export class ModuleManager {
     this.resolver.interfacePackages.clear();
     this.resolver.interfacePackageEntries.clear();
     this.resolver.interfacePackageResolveFrom.clear();
+    this.interfaceDeclarationEntries.clear();
     this.interfacePackagePlans.clear();
     this.startupOrder = [];
     return this.releaseRuntimeState();
@@ -613,7 +617,17 @@ export class ModuleManager {
         canonicalPackage,
         consumers: this.collectInterfacePackageConsumers(ifacePkg),
       });
-      this.registerInterfacePackage(ifacePkg, canonicalPackage);
+      this.registerInterfacePackage(
+        ifacePkg,
+        canonicalPackage,
+        this.resolveInterfaceDeclarationEntry(
+          ifacePkg,
+          canonicalPackage,
+          modules.some(
+            (provider) => provider.manifest.manifest.name === ifacePkg,
+          ),
+        ),
+      );
     }
     for (const [packageName, canonicalPackage] of this
       .stubbedInterfacePackages) {
@@ -624,8 +638,33 @@ export class ModuleManager {
         canonicalPackage,
         consumers: this.collectInterfacePackageConsumers(packageName),
       });
-      this.registerInterfacePackage(packageName, canonicalPackage);
+      this.registerInterfacePackage(
+        packageName,
+        canonicalPackage,
+        canonicalPackage.entry,
+      );
     }
+  }
+
+  private resolveInterfaceDeclarationEntry(
+    packageName: string,
+    resolvedPackage: ResolvedPackage,
+    isSelfImplemented: boolean,
+  ): string {
+    if (!isSelfImplemented) {
+      return resolvedPackage.entry;
+    }
+    const declarationEntry = resolvePackageSubpath(
+      packageName,
+      INTERFACE_DECLARATIONS_SUBPATH,
+      resolvedPackage,
+    );
+    if (declarationEntry) {
+      return declarationEntry;
+    }
+    throw new Error(
+      `Self-implemented interface package '${packageName}' must export a side-effect-free './${INTERFACE_DECLARATIONS_SUBPATH}' entry.`,
+    );
   }
 
   private resolveImplementedPackage(
@@ -670,6 +709,7 @@ export class ModuleManager {
   private registerInterfacePackage(
     packageName: string,
     resolvedPackage: ResolvedPackage,
+    declarationEntry = resolvedPackage.entry,
   ): void {
     this.resolver.interfacePackages.set(packageName, resolvedPackage.root);
     this.resolver.interfacePackageEntries.set(
@@ -680,6 +720,7 @@ export class ModuleManager {
       packageName,
       resolvedPackage.resolveFrom,
     );
+    this.interfaceDeclarationEntries.set(packageName, declarationEntry);
   }
 
   private validateInterfacePackages(): void {
@@ -853,8 +894,7 @@ export class ModuleManager {
       const routes: InterfaceProviderRoute[] = [...selected].map(
         ([interfaceName, provider]) => ({
           interfaceName,
-          packageEntry:
-            this.resolver.interfacePackageEntries.get(interfaceName),
+          declarationEntry: this.interfaceDeclarationEntries.get(interfaceName),
           provider,
           providerCount: new Set(
             connections.get(interfaceName)?.map(({ module }) => module),

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -256,7 +256,7 @@ export class ModuleManager {
     );
   }
 
-  private applyInterfaceStubs(): void {
+  private applyInterfaceStubs(shouldNeutralizeRegistrations = false): void {
     const implemented = this.collectImplementedInterfaces();
     for (const [interfaceName, resolvedPackage] of [
       ...this.stubbedInterfacePackages,
@@ -274,8 +274,16 @@ export class ModuleManager {
         Logger.Error(`Failed to load interface '${interfaceName}':`, err);
         continue;
       }
-      neutralizeInterfacePackage(resolvedPackage.root, interfaceName);
+      neutralizeInterfacePackage(
+        resolvedPackage.root,
+        interfaceName,
+        shouldNeutralizeRegistrations,
+      );
     }
+  }
+
+  public applyTestInterfaceStubs(): void {
+    this.applyInterfaceStubs(true);
   }
 
   private collectImplementedInterfaces(): Set<string> {

--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -200,6 +200,8 @@ export class ModuleManager {
       return;
     }
 
+    this.resolver.clearModuleFacades(moduleId);
+
     const moduleFolder = path.resolve(entry.module.manifest.folder);
     const avoidedFolders = new Set<string>();
 
@@ -545,6 +547,7 @@ export class ModuleManager {
     this.resolver.interfacePackages.clear();
     this.resolver.interfacePackageEntries.clear();
     this.resolver.interfacePackageResolveFrom.clear();
+    this.resolver.clearFacades();
     this.interfaceDeclarationEntries.clear();
     this.interfaceDeclarationFiles.clear();
     this.interfacePackagePlans.clear();
@@ -931,9 +934,12 @@ export class ModuleManager {
           ).size,
         }),
       );
-      module.setProviderRoutes(
-        buildProviderRoutes(module.id, routes),
-        this.isProvider({ module, config }),
+      this.resolver.setModuleContext(
+        module.id,
+        module.setProviderRoutes(
+          buildProviderRoutes(module.id, routes),
+          this.isProvider({ module, config }),
+        ),
       );
     }
     this.refreshInterfaceDeclarationFiles();

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -47,13 +47,18 @@ export class Module {
   setProviderRoutes(
     providerRoutes: Readonly<Record<string, string>>,
     isProvider: boolean,
-  ): void {
+  ): ModuleExecutionContext {
     this.executionContext = {
       module: this.id,
       owner: this.executionContext.owner,
       provider: isProvider ? this.id : undefined,
       providerRoutes,
     };
+    return this.executionContext;
+  }
+
+  runWithContext<T>(callback: () => T): T {
+    return RunWithModuleContext(this.executionContext, callback);
   }
 
   async reload(): Promise<void> {

--- a/src/core/resolution/package-resolution.ts
+++ b/src/core/resolution/package-resolution.ts
@@ -112,6 +112,21 @@ export function resolvePackage(
   }
 }
 
+export function resolvePackageSubpath(
+  packageName: string,
+  subpath: string,
+  resolvedPackage: ResolvedPackage,
+): string | undefined {
+  try {
+    const entry = createRequire(
+      path.join(resolvedPackage.root, "__antelope_resolver__.js"),
+    ).resolve(`${packageName}/${subpath}`);
+    return isPathWithin(entry, resolvedPackage.root) ? entry : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolvePackageAtRoot(
   packageName: string,
   packageRoot: string,

--- a/src/core/resolution/resolver-detour.ts
+++ b/src/core/resolution/resolver-detour.ts
@@ -81,15 +81,27 @@ class ResolverDetourCoordinator {
         options,
       ) as string;
     }
+    if (result.exact) {
+      return result.resolvedPath;
+    }
     const contextParent = result.resolveFrom
       ? { ...parent, filename: path.join(result.resolveFrom, "_") }
       : parent;
-    return this.originalResolver?.(
+    const resolvedPath = this.originalResolver?.(
       result.resolvedPath,
       contextParent,
       isMain,
       options,
     ) as string;
+    if (!result.facadeModuleId) {
+      return resolvedPath;
+    }
+    return (
+      activeResolver?.createInterfaceFacade(
+        resolvedPath,
+        result.facadeModuleId,
+      ) ?? resolvedPath
+    );
   }
 }
 

--- a/src/core/resolution/resolver.ts
+++ b/src/core/resolution/resolver.ts
@@ -1,3 +1,8 @@
+import { createHash } from "node:crypto";
+import Module from "node:module";
+import path from "node:path";
+import { CreateInterfaceFacade } from "@antelopejs/interface-core/facades";
+import type { ModuleExecutionContext } from "@antelopejs/interface-core/modules";
 import type { ModuleManifest } from "../module-manifest";
 import { isPathWithin, resolvePackage } from "./package-resolution";
 import type { PathMapper } from "./path-mapper";
@@ -10,6 +15,8 @@ export interface ModuleRef {
 export interface ResolveResult {
   resolvedPath: string;
   resolveFrom?: string;
+  exact?: boolean;
+  facadeModuleId?: string;
 }
 
 const CORE_PKG = "@antelopejs/interface-core";
@@ -24,6 +31,8 @@ export class Resolver {
   public readonly interfacePackageEntries = new Map<string, string>();
   public readonly interfacePackageResolveFrom = new Map<string, string>();
   public stubModulePath?: string;
+  private readonly moduleContexts = new Map<string, ModuleExecutionContext>();
+  private readonly facadePaths = new Map<string, Set<string>>();
 
   constructor(private pathMapper: PathMapper) {}
 
@@ -46,10 +55,32 @@ export class Resolver {
 
     const interfaceResult = this.resolveInterfacePackage(request);
     if (interfaceResult) {
-      return interfaceResult;
+      return matchingModule &&
+        this.moduleContexts.has(matchingModule.id) &&
+        !this.isImplementedInterfaceRequest(request, matchingModule)
+        ? { ...interfaceResult, facadeModuleId: matchingModule.id }
+        : interfaceResult;
     }
 
     return undefined;
+  }
+
+  setModuleContext(moduleId: string, context: ModuleExecutionContext): void {
+    this.moduleContexts.set(moduleId, context);
+  }
+
+  clearModuleFacades(moduleId: string): void {
+    for (const facadePath of this.facadePaths.get(moduleId) ?? []) {
+      delete require.cache[facadePath];
+    }
+    this.facadePaths.delete(moduleId);
+  }
+
+  clearFacades(): void {
+    for (const moduleId of this.facadePaths.keys()) {
+      this.clearModuleFacades(moduleId);
+    }
+    this.moduleContexts.clear();
   }
 
   private resolveInterfaceCore(request: string): ResolveResult | undefined {
@@ -60,6 +91,51 @@ export class Resolver {
       return { resolvedPath: request, resolveFrom: CORE_RESOLVE_FROM };
     }
     return undefined;
+  }
+
+  createInterfaceFacade(entry: string, moduleId: string): string | undefined {
+    const context = this.moduleContexts.get(moduleId);
+    if (!context) {
+      return undefined;
+    }
+    const facadePath = this.getFacadePath(entry, moduleId, context.owner);
+    if (!require.cache[facadePath]) {
+      const declaration = require(entry) as Record<string, unknown>;
+      const facade = CreateInterfaceFacade(declaration, context);
+      if (facade === declaration) {
+        return undefined;
+      }
+      const facadeModule = new Module(facadePath);
+      facadeModule.filename = facadePath;
+      facadeModule.paths = (Module as any)._nodeModulePaths(
+        path.dirname(entry),
+      );
+      facadeModule.exports = facade;
+      facadeModule.loaded = true;
+      require.cache[facadePath] = facadeModule;
+      const paths = this.facadePaths.get(moduleId) ?? new Set<string>();
+      paths.add(facadePath);
+      this.facadePaths.set(moduleId, paths);
+    }
+    return facadePath;
+  }
+
+  private getFacadePath(
+    entry: string,
+    moduleId: string,
+    owner = moduleId,
+  ): string {
+    const generation = Buffer.from(owner).toString("base64url");
+    const consumer = Buffer.from(moduleId).toString("base64url");
+    const declaration = createHash("sha256")
+      .update(entry)
+      .digest("hex")
+      .slice(0, 16);
+    return path.join(
+      path.dirname(entry),
+      ".antelope-facades",
+      `${declaration}-${consumer}-${generation}.cjs`,
+    );
   }
 
   private resolveInterfacePackage(request: string): ResolveResult | undefined {
@@ -77,6 +153,16 @@ export class Resolver {
       }
     }
     return undefined;
+  }
+
+  private isImplementedInterfaceRequest(
+    request: string,
+    module: ModuleRef,
+  ): boolean {
+    return (module.manifest.implements ?? []).some(
+      (interfaceName) =>
+        request === interfaceName || request.startsWith(`${interfaceName}/`),
+    );
   }
 
   private resolveLocalModule(fileName?: string): ModuleRef | undefined {

--- a/src/core/resolution/stub-interface-runtime.ts
+++ b/src/core/resolution/stub-interface-runtime.ts
@@ -23,10 +23,23 @@ function neutralizeAsyncProxy(proxy: AsyncProxy, interfaceName: string): void {
   proxy.onCall(() => makeRejection(interfaceName), true);
 }
 
+function neutralizeRegisteringProxy(
+  proxy: RegisteringProxy,
+  interfaceName: string,
+): void {
+  proxy.onRegister((id) => {
+    Logger.Trace(
+      `Interface '${interfaceName}' has no provider; registration '${String(id)}' recorded but inert.`,
+    );
+  }, true);
+  proxy.onUnregister(() => {});
+}
+
 function walk(
   value: unknown,
   interfaceName: string,
   seen: WeakSet<object>,
+  shouldNeutralizeRegistrations: boolean,
 ): void {
   if (value === null || value === undefined) {
     return;
@@ -51,6 +64,9 @@ function walk(
     return;
   }
   if (value instanceof RegisteringProxy) {
+    if (shouldNeutralizeRegistrations) {
+      neutralizeRegisteringProxy(value, interfaceName);
+    }
     return;
   }
   // EventProxy needs no neutralization: register() never requires a provider
@@ -60,7 +76,12 @@ function walk(
   }
 
   for (const key of Object.keys(value as Record<string, unknown>)) {
-    walk((value as Record<string, unknown>)[key], interfaceName, seen);
+    walk(
+      (value as Record<string, unknown>)[key],
+      interfaceName,
+      seen,
+      shouldNeutralizeRegistrations,
+    );
   }
 }
 
@@ -68,7 +89,14 @@ export function neutralizeInterfaceAsyncProxies(
   exports: unknown,
   interfaceName: string,
 ): void {
-  walk(exports, interfaceName, new WeakSet());
+  walk(exports, interfaceName, new WeakSet(), false);
+}
+
+export function neutralizeInterfaceTestProxies(
+  exports: unknown,
+  interfaceName: string,
+): void {
+  walk(exports, interfaceName, new WeakSet(), true);
 }
 
 function isWithin(filePath: string, dirPath: string): boolean {
@@ -83,6 +111,7 @@ function isWithin(filePath: string, dirPath: string): boolean {
 export function neutralizeInterfacePackage(
   packageRoot: string,
   interfaceName: string,
+  shouldNeutralizeRegistrations = false,
 ): void {
   const cache = (Module as unknown as { _cache: Record<string, NodeModule> })
     ._cache;
@@ -92,7 +121,12 @@ export function neutralizeInterfacePackage(
       continue;
     }
     const cachedModule = cache[filename];
-    walk(cachedModule.exports, interfaceName, seen);
+    walk(
+      cachedModule.exports,
+      interfaceName,
+      seen,
+      shouldNeutralizeRegistrations,
+    );
   }
 }
 

--- a/src/core/resolution/stub-interface-runtime.ts
+++ b/src/core/resolution/stub-interface-runtime.ts
@@ -6,6 +6,7 @@ import {
   RegisteringProxy,
 } from "@antelopejs/interface-core";
 import { Logging } from "@antelopejs/interface-core/logging";
+import { RunWithModuleContext } from "@antelopejs/interface-core/modules";
 
 const Logger = new Logging.Channel("loader");
 const warned = new Set<string>();
@@ -26,13 +27,21 @@ function neutralizeAsyncProxy(proxy: AsyncProxy, interfaceName: string): void {
 function neutralizeRegisteringProxy(
   proxy: RegisteringProxy,
   interfaceName: string,
+  provider?: string,
 ): void {
-  proxy.onRegister((id) => {
-    Logger.Trace(
-      `Interface '${interfaceName}' has no provider; registration '${String(id)}' recorded but inert.`,
-    );
-  }, true);
-  proxy.onUnregister(() => {});
+  const neutralize = () => {
+    proxy.onRegister((id) => {
+      Logger.Trace(
+        `Interface '${interfaceName}' has no provider; registration '${String(id)}' recorded but inert.`,
+      );
+    }, true);
+    proxy.onUnregister(() => {});
+  };
+  if (!provider) {
+    neutralize();
+    return;
+  }
+  RunWithModuleContext({ module: provider, provider }, neutralize);
 }
 
 function walk(
@@ -40,6 +49,7 @@ function walk(
   interfaceName: string,
   seen: WeakSet<object>,
   shouldNeutralizeRegistrations: boolean,
+  registrationProvider?: string,
 ): void {
   if (value === null || value === undefined) {
     return;
@@ -65,7 +75,7 @@ function walk(
   }
   if (value instanceof RegisteringProxy) {
     if (shouldNeutralizeRegistrations) {
-      neutralizeRegisteringProxy(value, interfaceName);
+      neutralizeRegisteringProxy(value, interfaceName, registrationProvider);
     }
     return;
   }
@@ -81,6 +91,7 @@ function walk(
       interfaceName,
       seen,
       shouldNeutralizeRegistrations,
+      registrationProvider,
     );
   }
 }
@@ -95,8 +106,9 @@ export function neutralizeInterfaceAsyncProxies(
 export function neutralizeInterfaceTestProxies(
   exports: unknown,
   interfaceName: string,
+  registrationProvider?: string,
 ): void {
-  walk(exports, interfaceName, new WeakSet(), true);
+  walk(exports, interfaceName, new WeakSet(), true, registrationProvider);
 }
 
 function isWithin(filePath: string, dirPath: string): boolean {
@@ -112,6 +124,7 @@ export function neutralizeInterfacePackage(
   packageRoot: string,
   interfaceName: string,
   shouldNeutralizeRegistrations = false,
+  registrationProvider?: string,
 ): void {
   const cache = (Module as unknown as { _cache: Record<string, NodeModule> })
     ._cache;
@@ -126,6 +139,7 @@ export function neutralizeInterfacePackage(
       interfaceName,
       seen,
       shouldNeutralizeRegistrations,
+      registrationProvider,
     );
   }
 }

--- a/src/core/resolution/stub-interface-runtime.ts
+++ b/src/core/resolution/stub-interface-runtime.ts
@@ -11,6 +11,8 @@ import { RunWithModuleContext } from "@antelopejs/interface-core/modules";
 const Logger = new Logging.Channel("loader");
 const warned = new Set<string>();
 
+export type StubInterfaceCleanup = () => void;
+
 function makeRejection(interfaceName: string): Promise<never> {
   return Promise.reject(
     new Error(
@@ -20,28 +22,29 @@ function makeRejection(interfaceName: string): Promise<never> {
   );
 }
 
-function neutralizeAsyncProxy(proxy: AsyncProxy, interfaceName: string): void {
-  proxy.onCall(() => makeRejection(interfaceName), true);
+function neutralizeAsyncProxy(
+  proxy: AsyncProxy,
+  interfaceName: string,
+): StubInterfaceCleanup {
+  const lease = proxy.onCall(() => makeRejection(interfaceName), true);
+  return () => proxy.detach(lease);
 }
 
 function neutralizeRegisteringProxy(
   proxy: RegisteringProxy,
   interfaceName: string,
   provider?: string,
-): void {
-  const neutralize = () => {
-    proxy.onRegister((id) => {
-      Logger.Trace(
-        `Interface '${interfaceName}' has no provider; registration '${String(id)}' recorded but inert.`,
-      );
-    }, true);
-    proxy.onUnregister(() => {});
+): StubInterfaceCleanup {
+  const register = (id: unknown) => {
+    Logger.Trace(
+      `Interface '${interfaceName}' has no provider; registration '${String(id)}' recorded but inert.`,
+    );
   };
-  if (!provider) {
-    neutralize();
-    return;
-  }
-  RunWithModuleContext({ module: provider, provider }, neutralize);
+  const attach = () => proxy.onHandlers(register, () => {}, true);
+  const lease = provider
+    ? RunWithModuleContext({ module: provider, provider }, attach)
+    : attach();
+  return () => proxy.detach(lease);
 }
 
 function walk(
@@ -49,6 +52,7 @@ function walk(
   interfaceName: string,
   seen: WeakSet<object>,
   shouldNeutralizeRegistrations: boolean,
+  cleanups: StubInterfaceCleanup[],
   registrationProvider?: string,
 ): void {
   if (value === null || value === undefined) {
@@ -57,7 +61,9 @@ function walk(
   if (typeof value === "function") {
     const maybeProxy = (value as { proxy?: unknown }).proxy;
     if (maybeProxy instanceof AsyncProxy) {
-      neutralizeAsyncProxy(maybeProxy as AsyncProxy, interfaceName);
+      cleanups.push(
+        neutralizeAsyncProxy(maybeProxy as AsyncProxy, interfaceName),
+      );
     }
     return;
   }
@@ -70,12 +76,14 @@ function walk(
   seen.add(value as object);
 
   if (value instanceof AsyncProxy) {
-    neutralizeAsyncProxy(value, interfaceName);
+    cleanups.push(neutralizeAsyncProxy(value, interfaceName));
     return;
   }
   if (value instanceof RegisteringProxy) {
     if (shouldNeutralizeRegistrations) {
-      neutralizeRegisteringProxy(value, interfaceName, registrationProvider);
+      cleanups.push(
+        neutralizeRegisteringProxy(value, interfaceName, registrationProvider),
+      );
     }
     return;
   }
@@ -91,6 +99,7 @@ function walk(
       interfaceName,
       seen,
       shouldNeutralizeRegistrations,
+      cleanups,
       registrationProvider,
     );
   }
@@ -99,16 +108,27 @@ function walk(
 export function neutralizeInterfaceAsyncProxies(
   exports: unknown,
   interfaceName: string,
-): void {
-  walk(exports, interfaceName, new WeakSet(), false);
+): StubInterfaceCleanup[] {
+  const cleanups: StubInterfaceCleanup[] = [];
+  walk(exports, interfaceName, new WeakSet(), false, cleanups);
+  return cleanups;
 }
 
 export function neutralizeInterfaceTestProxies(
   exports: unknown,
   interfaceName: string,
   registrationProvider?: string,
-): void {
-  walk(exports, interfaceName, new WeakSet(), true, registrationProvider);
+): StubInterfaceCleanup[] {
+  const cleanups: StubInterfaceCleanup[] = [];
+  walk(
+    exports,
+    interfaceName,
+    new WeakSet(),
+    true,
+    cleanups,
+    registrationProvider,
+  );
+  return cleanups;
 }
 
 function isWithin(filePath: string, dirPath: string): boolean {
@@ -125,10 +145,11 @@ export function neutralizeInterfacePackage(
   interfaceName: string,
   shouldNeutralizeRegistrations = false,
   registrationProvider?: string,
-): void {
+): StubInterfaceCleanup[] {
   const cache = (Module as unknown as { _cache: Record<string, NodeModule> })
     ._cache;
   const seen = new WeakSet<object>();
+  const cleanups: StubInterfaceCleanup[] = [];
   for (const filename of Object.keys(cache)) {
     if (!isWithin(filename, packageRoot)) {
       continue;
@@ -139,9 +160,11 @@ export function neutralizeInterfacePackage(
       interfaceName,
       seen,
       shouldNeutralizeRegistrations,
+      cleanups,
       registrationProvider,
     );
   }
+  return cleanups;
 }
 
 export function logStubInterfaceWarningOnce(

--- a/src/core/resolution/stub-interface-runtime.ts
+++ b/src/core/resolution/stub-interface-runtime.ts
@@ -23,18 +23,6 @@ function neutralizeAsyncProxy(proxy: AsyncProxy, interfaceName: string): void {
   proxy.onCall(() => makeRejection(interfaceName), true);
 }
 
-function neutralizeRegisteringProxy(
-  proxy: RegisteringProxy,
-  interfaceName: string,
-): void {
-  proxy.onRegister((id) => {
-    Logger.Trace(
-      `Interface '${interfaceName}' has no provider; registration '${String(id)}' recorded but inert.`,
-    );
-  }, true);
-  proxy.onUnregister(() => {});
-}
-
 function walk(
   value: unknown,
   interfaceName: string,
@@ -63,7 +51,6 @@ function walk(
     return;
   }
   if (value instanceof RegisteringProxy) {
-    neutralizeRegisteringProxy(value, interfaceName);
     return;
   }
   // EventProxy needs no neutralization: register() never requires a provider

--- a/src/core/test/test-module.ts
+++ b/src/core/test/test-module.ts
@@ -129,6 +129,7 @@ export async function setupTestEnvironment(
         fs,
       });
       await constructAndStartModules(manager);
+      manager.applyTestInterfaceStubs();
       internal.testStubMode = true;
       registerTestDir(path.resolve(moduleRoot), manager);
       return manager;

--- a/src/core/test/test-module.ts
+++ b/src/core/test/test-module.ts
@@ -212,9 +212,12 @@ export async function executeTests(
     mocha.addFile(file);
   }
 
-  return new Promise<number>((resolve) => {
-    mocha.run((count) => resolve(count));
-  });
+  const run = () =>
+    new Promise<number>((resolve) => {
+      mocha.run((count) => resolve(count));
+    });
+  const firstModule = manager?.getAllManagedModules()[0]?.module;
+  return firstModule ? firstModule.runWithContext(run) : run();
 }
 
 async function discoverTestFiles(

--- a/test/core/module-manager.test.ts
+++ b/test/core/module-manager.test.ts
@@ -978,15 +978,20 @@ describe("ModuleManager", () => {
     expect(resolver.interfacePackages.size).to.equal(0);
   });
 
-  it("clears require cache for module files while preserving submodules", () => {
+  it("clears application cache while preserving declarations and submodules", () => {
     const manager = new ModuleManager();
     const moduleFolder = path.resolve("test", "module");
     const submoduleFolder = path.join(moduleFolder, "child");
     const nodeModulesFolder = path.join(moduleFolder, "node_modules");
+    const declarationEntries = [
+      path.join(moduleFolder, "interface-declarations.js"),
+      path.join(moduleFolder, "interfaces", "nested.js"),
+    ];
 
     const cacheEntries = [
       path.join(moduleFolder, "index.js"),
       path.join(moduleFolder, "src", "util.js"),
+      ...declarationEntries,
       path.join(submoduleFolder, "index.js"),
       path.join(nodeModulesFolder, "dep.js"),
       path.resolve("other", "file.js"),
@@ -1010,12 +1015,18 @@ describe("ModuleManager", () => {
       },
       config: {},
     });
+    declarationEntries.forEach((entry) => {
+      (manager as any).interfaceDeclarationFiles.add(entry);
+    });
 
     manager.unrequireModuleFiles("test");
 
     expect(require.cache[path.join(moduleFolder, "index.js")]).to.be.undefined;
     expect(require.cache[path.join(moduleFolder, "src", "util.js")]).to.be
       .undefined;
+    declarationEntries.forEach((entry) => {
+      expect(require.cache[entry]).to.not.be.undefined;
+    });
     expect(require.cache[path.join(submoduleFolder, "index.js")]).to.not.be
       .undefined;
     expect(require.cache[path.join(nodeModulesFolder, "dep.js")]).to.not.be

--- a/test/core/module.test.ts
+++ b/test/core/module.test.ts
@@ -76,6 +76,27 @@ describe("Module", () => {
     expect(contexts[0].owner).to.match(/^context-module#\d+$/);
   });
 
+  it("runs test work in the configured module context", async () => {
+    const mod = new Module(
+      { ...manifest, name: "test-context" },
+      sinon.stub().resolves({}),
+    );
+    mod.setProviderRoutes({ "async:example": "provider" }, false);
+
+    const context = await mod.runWithContext(async () => {
+      await Promise.resolve();
+      return GetModuleContext();
+    });
+
+    expect(context).to.include({
+      module: "test-context",
+      provider: undefined,
+    });
+    expect(context?.providerRoutes).to.deep.equal({
+      "async:example": "provider",
+    });
+  });
+
   it("uses distinct owners for replacement generations", async () => {
     const owners: Array<string | undefined> = [];
     const createModule = () =>

--- a/test/core/resolution/interface-facade.test.ts
+++ b/test/core/resolution/interface-facade.test.ts
@@ -1,0 +1,199 @@
+import assert from "node:assert";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import * as Api from "@antelopejs/interface-api";
+import * as Auth from "@antelopejs/interface-auth";
+import {
+  GetInterfaceProxyIdentity,
+  ModuleContextInvalidatedError,
+} from "@antelopejs/interface-core";
+import {
+  Events,
+  type ModuleExecutionContext,
+  RunWithModuleContext,
+} from "@antelopejs/interface-core/modules";
+import { PathMapper } from "../../../src/core/resolution/path-mapper";
+import { Resolver } from "../../../src/core/resolution/resolver";
+import { ResolverDetour } from "../../../src/core/resolution/resolver-detour";
+
+function providerContext(provider: string): ModuleExecutionContext {
+  return {
+    module: provider,
+    owner: `${provider}#1`,
+    provider,
+  };
+}
+
+function consumerContext(
+  owner: string,
+  authProvider: string,
+): ModuleExecutionContext {
+  const verifyIdentity = GetInterfaceProxyIdentity(Auth.internal.Verify.proxy);
+  const routesIdentity = GetInterfaceProxyIdentity(Api.routesProxy);
+  assert(verifyIdentity);
+  assert(routesIdentity);
+  return {
+    module: "facade-consumer",
+    owner,
+    providerRoutes: {
+      [verifyIdentity]: authProvider,
+      [routesIdentity]: "api-provider",
+    },
+  };
+}
+
+function registerInterfacePackage(
+  resolver: Resolver,
+  packageName: string,
+): void {
+  const entry = require.resolve(packageName);
+  const root = path.dirname(require.resolve(`${packageName}/package.json`));
+  resolver.interfacePackages.set(packageName, root);
+  resolver.interfacePackageEntries.set(packageName, entry);
+  resolver.interfacePackageResolveFrom.set(packageName, root);
+}
+
+function tokenRequest(token: string): IncomingMessage {
+  return {
+    headers: { "x-antelopejs-auth": token },
+  } as unknown as IncomingMessage;
+}
+
+describe("resolver interface facades", () => {
+  it("selects providers per consumer generation without wrapping route callbacks", async () => {
+    const consumerFolder = path.join(os.tmpdir(), "ajs-facade-consumer");
+    const resolver = new Resolver(new PathMapper(() => false));
+    resolver.moduleByFolder.set(consumerFolder, {
+      id: "facade-consumer",
+      manifest: { paths: [], srcAliases: [] } as any,
+    });
+    registerInterfacePackage(resolver, "@antelopejs/interface-api");
+    registerInterfacePackage(resolver, "@antelopejs/interface-auth");
+    const oldContext = consumerContext(
+      "facade-consumer#old",
+      "auth-provider-a",
+    );
+    const newContext = consumerContext(
+      "facade-consumer#new",
+      "auth-provider-b",
+    );
+    resolver.setModuleContext("facade-consumer", oldContext);
+    const detour = new ResolverDetour(resolver);
+    const consumerRequire = createRequire(
+      path.join(consumerFolder, "index.cjs"),
+    );
+    const nestedRequire = createRequire(
+      path.join(consumerFolder, "nested", "handler.cjs"),
+    );
+    const authLeaseA = RunWithModuleContext(
+      providerContext("auth-provider-a"),
+      () =>
+        Auth.internal.Verify.proxy.onCall(async (token) => `a:${token}`, true),
+    );
+    const authLeaseB = RunWithModuleContext(
+      providerContext("auth-provider-b"),
+      () =>
+        Auth.internal.Verify.proxy.onCall(async (token) => `b:${token}`, true),
+    );
+    const registered: Api.RouteHandler[] = [];
+    const apiLease = RunWithModuleContext(providerContext("api-provider"), () =>
+      Api.routesProxy.onHandlers(
+        (_id, handler) => registered.push(handler),
+        () => {},
+        true,
+      ),
+    );
+    detour.attach();
+
+    try {
+      const oldAuth = consumerRequire(
+        "@antelopejs/interface-auth",
+      ) as typeof Auth;
+      const oldApi = consumerRequire("@antelopejs/interface-api") as typeof Api;
+      assert.strictEqual(nestedRequire("@antelopejs/interface-auth"), oldAuth);
+      assert.notStrictEqual(oldAuth, Auth);
+      assert.strictEqual(oldApi.HTTPResult, Api.HTTPResult);
+      assert.equal(await oldAuth.ValidateRaw("token"), "a:token");
+
+      class OldController {
+        handler(authenticated: unknown) {
+          return authenticated;
+        }
+      }
+      const oldDescriptor = Object.getOwnPropertyDescriptor(
+        OldController.prototype,
+        "handler",
+      );
+      assert(oldDescriptor);
+      oldAuth.Authentication()(OldController.prototype, "handler", 0);
+      oldApi.Get("/old")(OldController.prototype, "handler", oldDescriptor);
+      assert.strictEqual(
+        registered[0].callback,
+        OldController.prototype.handler,
+      );
+
+      RunWithModuleContext(oldContext, () =>
+        Events.ModuleDestroyed.emit("facade-consumer"),
+      );
+      resolver.clearModuleFacades("facade-consumer");
+      resolver.setModuleContext("facade-consumer", newContext);
+
+      const staleError = await oldAuth.ValidateRaw("token").then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      assert(staleError instanceof ModuleContextInvalidatedError);
+
+      const newAuth = consumerRequire(
+        "@antelopejs/interface-auth",
+      ) as typeof Auth;
+      const newApi = consumerRequire("@antelopejs/interface-api") as typeof Api;
+      assert.notStrictEqual(newAuth, oldAuth);
+      assert.equal(
+        await Promise.resolve().then(() => newAuth.ValidateRaw("token")),
+        "b:token",
+      );
+
+      class NewController {
+        handler(authenticated: unknown) {
+          return authenticated;
+        }
+      }
+      const newDescriptor = Object.getOwnPropertyDescriptor(
+        NewController.prototype,
+        "handler",
+      );
+      assert(newDescriptor);
+      newAuth.Authentication()(NewController.prototype, "handler", 0);
+      newApi.Get("/new")(NewController.prototype, "handler", newDescriptor);
+      const currentRoute = registered.at(-1);
+      assert(currentRoute);
+      assert.strictEqual(
+        currentRoute.callback,
+        NewController.prototype.handler,
+      );
+      const authProvider = currentRoute.parameters[0]?.provider;
+      assert(authProvider);
+      assert.equal(
+        await Promise.resolve().then(() =>
+          authProvider({
+            rawRequest: tokenRequest("request-token"),
+            rawResponse: {} as ServerResponse,
+          } as Api.RequestContext),
+        ),
+        "b:request-token",
+      );
+    } finally {
+      RunWithModuleContext(newContext, () =>
+        Events.ModuleDestroyed.emit("facade-consumer"),
+      );
+      resolver.clearFacades();
+      detour.detach();
+      Api.routesProxy.detach(apiLease);
+      Auth.internal.Verify.proxy.detach(authLeaseA);
+      Auth.internal.Verify.proxy.detach(authLeaseB);
+    }
+  });
+});

--- a/test/core/resolution/stub-interface-runtime.test.ts
+++ b/test/core/resolution/stub-interface-runtime.test.ts
@@ -7,7 +7,10 @@ import {
 import { internal } from "@antelopejs/interface-core/internal";
 import { expect } from "chai";
 import { ModuleLifecycle } from "../../../src/core/module-lifecycle";
-import { neutralizeInterfaceAsyncProxies } from "../../../src/core/resolution/stub-interface-runtime";
+import {
+  neutralizeInterfaceAsyncProxies,
+  neutralizeInterfaceTestProxies,
+} from "../../../src/core/resolution/stub-interface-runtime";
 import { ModuleState } from "../../../src/types";
 
 describe("neutralizeInterfaceAsyncProxies", () => {
@@ -55,6 +58,19 @@ describe("neutralizeInterfaceAsyncProxies", () => {
     internal.testStubMode = true;
     try {
       expect(() => reg.register("id-1")).to.throw();
+      expect(() => reg.unregister("id-1")).to.not.throw();
+    } finally {
+      internal.testStubMode = false;
+    }
+  });
+
+  it("neutralizes RegisteringProxy only when test stubs are enabled", () => {
+    const reg = new RegisteringProxy<(id: string) => void>();
+    neutralizeInterfaceTestProxies({ reg }, "reg-iface");
+
+    internal.testStubMode = true;
+    try {
+      expect(() => reg.register("id-1")).to.not.throw();
       expect(() => reg.unregister("id-1")).to.not.throw();
     } finally {
       internal.testStubMode = false;

--- a/test/core/resolution/stub-interface-runtime.test.ts
+++ b/test/core/resolution/stub-interface-runtime.test.ts
@@ -47,14 +47,14 @@ describe("neutralizeInterfaceAsyncProxies", () => {
     expect(rejected).to.equal(true);
   });
 
-  it("makes RegisteringProxy.register() a no-op in test stub mode", () => {
+  it("leaves RegisteringProxy behavior unchanged in test stub mode", () => {
     const reg = new RegisteringProxy<(id: string) => void>();
     const iface = { reg };
     neutralizeInterfaceAsyncProxies(iface, "reg-iface");
 
     internal.testStubMode = true;
     try {
-      expect(() => reg.register("id-1")).to.not.throw();
+      expect(() => reg.register("id-1")).to.throw();
       expect(() => reg.unregister("id-1")).to.not.throw();
     } finally {
       internal.testStubMode = false;
@@ -90,7 +90,7 @@ describe("neutralizeInterfaceAsyncProxies", () => {
     internal.testStubMode = true;
     try {
       expect(lifecycle.state).to.equal(ModuleState.Active);
-      expect(() => reg.register("trigger-2")).to.not.throw();
+      expect(() => reg.register("trigger-2")).to.throw();
     } finally {
       internal.testStubMode = false;
     }

--- a/test/integration/interface-declaration-routing.test.ts
+++ b/test/integration/interface-declaration-routing.test.ts
@@ -396,7 +396,7 @@ function assertSideEffectRelaunches(state: RuntimeState): void {
 
 const SIDE_EFFECT_PROVIDER_SOURCE = `
 const { ImplementInterface } = require("@antelopejs/interface-core");
-const { BindToCurrentModuleContext, GetModuleContext } = require("@antelopejs/interface-core/modules");
+const { GetModuleContext } = require("@antelopejs/interface-core/modules");
 const declarations = require("./interface-declarations");
 require("./routes");
 require("./db");
@@ -408,8 +408,6 @@ state.declarationReferences.push([
   declarations.Registration.Registrations,
   declarations.Nested.GetModule,
 ]);
-const routeCallback = BindToCurrentModuleContext(() => declarations.Nested.GetModule());
-declarations.Registration.Registrations.register("route", routeCallback);
 exports.InterfaceDeclarations = declarations;
 exports.construct = () => {
   ImplementInterface(declarations.Nested, { GetModule: () => GetModuleContext().module });
@@ -423,7 +421,10 @@ exports.destroy = () => {};
 `;
 
 const SIDE_EFFECT_CONSUMER_SOURCE = `
+const declarations = require("${PROVIDER_ID}/interface-declarations");
 const state = global.${STATE_KEY};
+const routeCallback = () => declarations.Nested.GetModule();
+declarations.Registration.Registrations.register("route", routeCallback);
 exports.construct = async () => {
   await state.registrationReady;
   state.result = await state.routeCallback();

--- a/test/integration/interface-declaration-routing.test.ts
+++ b/test/integration/interface-declaration-routing.test.ts
@@ -1,0 +1,436 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { RegisteringProxy } from "@antelopejs/interface-core";
+import type { ModuleSourceLocal } from "@antelopejs/interface-core/config";
+import { internal } from "@antelopejs/interface-core/internal";
+import {
+  type ModuleExecutionContext,
+  RunWithModuleContext,
+} from "@antelopejs/interface-core/modules";
+import type { AttachmentLease } from "@antelopejs/interface-core/proxies";
+import { expect } from "chai";
+import { ModuleManager } from "../../src/core/module-manager";
+import { ModuleManifest } from "../../src/core/module-manifest";
+
+const PROVIDER_ID = "self-interface";
+const CONSUMER_ID = "provider-consumer";
+const STATE_KEY = "__antelopeSelfInterfaceState";
+
+interface RuntimeState {
+  evaluations: Array<ModuleExecutionContext | undefined>;
+  sequence: string[];
+  registered: string[];
+  unregistered: string[];
+  runtimeErrors: unknown[];
+  result?: string;
+  routeCallback?: () => Promise<string>;
+  registrationContext?: ModuleExecutionContext;
+  unregistrationContext?: ModuleExecutionContext;
+  resolveRegistrationReady(): void;
+  resolveConsumerRegistered(): void;
+  resolveReplayCompleted(): void;
+  registrationReady: Promise<void>;
+  consumerRegistered: Promise<void>;
+  replayCompleted: Promise<void>;
+}
+
+interface GlobalRuntimeState {
+  [STATE_KEY]?: RuntimeState;
+}
+
+interface RegistrationDeclarations {
+  Registrations: RegisteringProxy<
+    (id: string, callback: () => Promise<string>) => void
+  >;
+}
+
+interface SelfInterfaceFixture {
+  root: string;
+  providerFolder: string;
+  consumerFolder: string;
+  registrationEntry: string;
+}
+
+interface FixturePackageJson {
+  exports: Record<string, string>;
+}
+
+function createDeferred(): [Promise<void>, () => void] {
+  let resolve = (): void => undefined;
+  const promise = new Promise<void>((currentResolve) => {
+    resolve = currentResolve;
+  });
+  return [promise, resolve];
+}
+
+function createRuntimeState(): RuntimeState {
+  const [registrationReady, resolveRegistrationReady] = createDeferred();
+  const [consumerRegistered, resolveConsumerRegistered] = createDeferred();
+  const [replayCompleted, resolveReplayCompleted] = createDeferred();
+  return {
+    evaluations: [],
+    sequence: [],
+    registered: [],
+    unregistered: [],
+    runtimeErrors: [],
+    registrationReady,
+    consumerRegistered,
+    replayCompleted,
+    resolveRegistrationReady,
+    resolveConsumerRegistered,
+    resolveReplayCompleted,
+  };
+}
+
+function getRuntimeState(): RuntimeState {
+  return (globalThis as GlobalRuntimeState)[STATE_KEY] as RuntimeState;
+}
+
+async function linkInterfaceCore(folder: string): Promise<void> {
+  const packageRoot = path.dirname(
+    require.resolve("@antelopejs/interface-core/package.json"),
+  );
+  const scope = path.join(folder, "node_modules", "@antelopejs");
+  await fs.mkdir(scope, { recursive: true });
+  await fs.symlink(packageRoot, path.join(scope, "interface-core"), "dir");
+}
+
+async function writeProviderManifest(folder: string): Promise<void> {
+  await fs.mkdir(folder, { recursive: true });
+  await fs.writeFile(
+    path.join(folder, "package.json"),
+    JSON.stringify({
+      name: PROVIDER_ID,
+      version: "1.0.0",
+      main: "index.js",
+      exports: {
+        ".": "./index.js",
+        "./interface-declarations": "./interface-declarations.js",
+        "./registering": "./registering.js",
+      },
+      dependencies: { "@antelopejs/interface-core": "*" },
+      antelopeJs: { implements: [PROVIDER_ID] },
+    }),
+  );
+}
+
+async function writeProviderDeclarations(
+  folder: string,
+  identity: string,
+): Promise<void> {
+  await fs.writeFile(
+    path.join(folder, "registering.js"),
+    `const { RegisteringProxy } = require("@antelopejs/interface-core"); exports.Registrations = new RegisteringProxy(${JSON.stringify(`${identity}.registering`)});`,
+  );
+  await fs.writeFile(
+    path.join(folder, "nested.js"),
+    `const { InterfaceFunction } = require("@antelopejs/interface-core"); exports.GetModule = InterfaceFunction(${JSON.stringify(`${identity}.nested`)});`,
+  );
+  await fs.writeFile(
+    path.join(folder, "interface-declarations.js"),
+    `exports.Registration = require("./registering");`,
+  );
+}
+
+async function writeProviderPackage(
+  folder: string,
+  mainSource: string,
+  identity: string,
+): Promise<void> {
+  await writeProviderManifest(folder);
+  await fs.writeFile(path.join(folder, "index.js"), mainSource);
+  await writeProviderDeclarations(folder, identity);
+  await linkInterfaceCore(folder);
+}
+
+async function writeConsumerPackage(
+  folder: string,
+  source: string,
+): Promise<void> {
+  await fs.mkdir(folder, { recursive: true });
+  await fs.writeFile(
+    path.join(folder, "package.json"),
+    JSON.stringify({
+      name: CONSUMER_ID,
+      version: "1.0.0",
+      main: "index.js",
+      dependencies: {
+        "@antelopejs/interface-core": "*",
+        [PROVIDER_ID]: "*",
+      },
+      antelopeJs: { implements: ["consumer-interface"] },
+    }),
+  );
+  await fs.writeFile(path.join(folder, "index.js"), source);
+  await linkInterfaceCore(folder);
+}
+
+async function createFixture(
+  providerSource: string,
+  consumerSource: string,
+): Promise<SelfInterfaceFixture> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "ajs-self-interface-"));
+  const providerFolder = path.join(root, PROVIDER_ID);
+  const consumerFolder = path.join(root, CONSUMER_ID);
+  await writeProviderPackage(
+    providerFolder,
+    providerSource,
+    path.basename(root),
+  );
+  await writeConsumerPackage(consumerFolder, consumerSource);
+  await fs.symlink(
+    providerFolder,
+    path.join(consumerFolder, "node_modules", PROVIDER_ID),
+    "dir",
+  );
+  return {
+    root,
+    providerFolder,
+    consumerFolder,
+    registrationEntry: path.join(providerFolder, "registering.js"),
+  };
+}
+
+async function createManifest(
+  folder: string,
+  name: string,
+): Promise<ModuleManifest> {
+  const source: ModuleSourceLocal = { type: "local", path: folder };
+  return ModuleManifest.create(folder, source, name);
+}
+
+async function createManager(
+  fixture: SelfInterfaceFixture,
+): Promise<ModuleManager> {
+  const provider = await createManifest(fixture.providerFolder, PROVIDER_ID);
+  const consumer = await createManifest(fixture.consumerFolder, CONSUMER_ID);
+  const manager = new ModuleManager();
+  manager.addModules([{ manifest: provider }, { manifest: consumer }]);
+  return manager;
+}
+
+async function removeDeclarationExport(
+  fixture: SelfInterfaceFixture,
+): Promise<void> {
+  const manifestPath = path.join(fixture.providerFolder, "package.json");
+  const manifest = JSON.parse(
+    await fs.readFile(manifestPath, "utf8"),
+  ) as FixturePackageJson;
+  delete manifest.exports["./interface-declarations"];
+  await fs.writeFile(manifestPath, JSON.stringify(manifest));
+}
+
+function clearFixtureModules(root: string): void {
+  Object.keys(require.cache)
+    .filter((entry) => entry.startsWith(`${root}${path.sep}`))
+    .forEach((entry) => {
+      delete require.cache[entry];
+    });
+}
+
+async function removeFixture(fixture: SelfInterfaceFixture): Promise<void> {
+  clearFixtureModules(fixture.root);
+  delete (globalThis as GlobalRuntimeState)[STATE_KEY];
+  await fs.rm(fixture.root, { recursive: true, force: true });
+}
+
+function replayRegistrations(fixture: SelfInterfaceFixture): string[] {
+  const declaration = require(
+    fixture.registrationEntry,
+  ) as RegistrationDeclarations;
+  const replayed: string[] = [];
+  let lease: AttachmentLease | undefined;
+  RunWithModuleContext(
+    { module: "probe", owner: "probe#1", provider: PROVIDER_ID },
+    () => {
+      lease = declaration.Registrations.onRegister(
+        (id) => replayed.push(id),
+        true,
+      );
+    },
+  );
+  declaration.Registrations.detach(lease);
+  return replayed;
+}
+
+async function verifySideEffectLifecycle(
+  manager: ModuleManager,
+  fixture: SelfInterfaceFixture,
+): Promise<void> {
+  expect(getRuntimeState().evaluations).to.deep.equal([]);
+  await manager.constructAll();
+  const state = getRuntimeState();
+  expect(state.evaluations[0]).to.include({
+    module: PROVIDER_ID,
+    provider: PROVIDER_ID,
+  });
+  expect(state.evaluations[0]?.owner).to.match(/^self-interface#/);
+  expect(state.result).to.equal(PROVIDER_ID);
+  await manager.destroyAll();
+  expect(replayRegistrations(fixture)).to.deep.equal([]);
+  expect(state.runtimeErrors).to.deep.equal([]);
+}
+
+async function verifyEarlyRegistrationLifecycle(
+  manager: ModuleManager,
+): Promise<void> {
+  await manager.constructAll();
+  const state = getRuntimeState();
+  expect(state.sequence).to.deep.equal([
+    "consumer-register",
+    "provider-attach",
+    "provider-replay",
+  ]);
+  expect(state.registrationContext).to.include({
+    module: PROVIDER_ID,
+    provider: PROVIDER_ID,
+  });
+  await manager.destroyAll();
+  expect(state.registered).to.deep.equal(["early"]);
+  expect(state.unregistered).to.deep.equal(["early"]);
+  expect(state.unregistrationContext).to.include({
+    module: PROVIDER_ID,
+    provider: PROVIDER_ID,
+  });
+  expect(state.runtimeErrors).to.deep.equal([]);
+}
+
+const SIDE_EFFECT_PROVIDER_SOURCE = `
+const { ImplementInterface } = require("@antelopejs/interface-core");
+const { BindToCurrentModuleContext, GetModuleContext } = require("@antelopejs/interface-core/modules");
+const declarations = require("./interface-declarations");
+const nested = require("./nested");
+const state = global.${STATE_KEY};
+state.evaluations.push(GetModuleContext());
+const routeCallback = BindToCurrentModuleContext(() => nested.GetModule());
+declarations.Registration.Registrations.register("route", routeCallback);
+exports.InterfaceDeclarations = declarations;
+exports.construct = () => {
+  ImplementInterface(nested, { GetModule: () => GetModuleContext().module });
+  declarations.Registration.Registrations.onHandlers((id, callback) => {
+    state.registered.push(id);
+    state.routeCallback = callback;
+    state.resolveRegistrationReady();
+  }, (id) => state.unregistered.push(id));
+};
+exports.destroy = () => {};
+`;
+
+const SIDE_EFFECT_CONSUMER_SOURCE = `
+const state = global.${STATE_KEY};
+exports.construct = async () => {
+  await state.registrationReady;
+  state.result = await state.routeCallback();
+};
+exports.destroy = () => {};
+`;
+
+const EARLY_REGISTRATION_PROVIDER_SOURCE = `
+const { GetModuleContext } = require("@antelopejs/interface-core/modules");
+const registrations = require("./registering").Registrations;
+const state = global.${STATE_KEY};
+exports.construct = async () => {
+  await state.consumerRegistered;
+  state.sequence.push("provider-attach");
+  registrations.onHandlers((id) => {
+    state.sequence.push("provider-replay");
+    state.registered.push(id);
+    state.registrationContext = GetModuleContext();
+    state.resolveReplayCompleted();
+  }, (id) => {
+    state.unregistered.push(id);
+    state.unregistrationContext = GetModuleContext();
+  });
+};
+exports.destroy = () => {};
+`;
+
+const EARLY_REGISTRATION_CONSUMER_SOURCE = `
+const registrations = require("${PROVIDER_ID}/registering").Registrations;
+const state = global.${STATE_KEY};
+exports.construct = async () => {
+  state.sequence.push("consumer-register");
+  registrations.register("early", () => undefined);
+  state.resolveConsumerRegistered();
+  await state.replayCompleted;
+};
+exports.destroy = () => {};
+`;
+
+describe("interface declaration routing for self-implemented packages", () => {
+  let previousRuntimeReporter: typeof internal.runtimeErrorReporter;
+
+  beforeEach(() => {
+    const state = createRuntimeState();
+    (globalThis as GlobalRuntimeState)[STATE_KEY] = state;
+    previousRuntimeReporter = internal.runtimeErrorReporter;
+    internal.runtimeErrorReporter = (error) => state.runtimeErrors.push(error);
+  });
+
+  afterEach(() => {
+    internal.runtimeErrorReporter = previousRuntimeReporter;
+  });
+
+  it("rejects a self-implemented interface without a declaration entry", async () => {
+    const fixture = await createFixture(
+      SIDE_EFFECT_PROVIDER_SOURCE,
+      SIDE_EFFECT_CONSUMER_SOURCE,
+    );
+    const manager = new ModuleManager();
+    try {
+      await removeDeclarationExport(fixture);
+      const provider = await createManifest(
+        fixture.providerFolder,
+        PROVIDER_ID,
+      );
+      const consumer = await createManifest(
+        fixture.consumerFolder,
+        CONSUMER_ID,
+      );
+      expect(() =>
+        manager.addModules([{ manifest: provider }, { manifest: consumer }]),
+      ).to.throw(/must export.+\.\/interface-declarations/);
+      expect(getRuntimeState().evaluations).to.deep.equal([]);
+    } finally {
+      await manager.destroyAll();
+      await removeFixture(fixture);
+    }
+  });
+
+  it("loads a side-effectful provider main only within its lifecycle generation", async () => {
+    const fixture = await createFixture(
+      SIDE_EFFECT_PROVIDER_SOURCE,
+      SIDE_EFFECT_CONSUMER_SOURCE,
+    );
+    let manager: ModuleManager | undefined;
+    try {
+      manager = await createManager(fixture);
+      await verifySideEffectLifecycle(manager, fixture);
+      manager = undefined;
+    } finally {
+      if (manager) {
+        await manager.destroyAll();
+      }
+      await removeFixture(fixture);
+    }
+  });
+
+  it("routes an early subpath registration to its future provider", async () => {
+    const fixture = await createFixture(
+      EARLY_REGISTRATION_PROVIDER_SOURCE,
+      EARLY_REGISTRATION_CONSUMER_SOURCE,
+    );
+    let manager: ModuleManager | undefined;
+    try {
+      manager = await createManager(fixture);
+      await verifyEarlyRegistrationLifecycle(manager);
+      manager = undefined;
+    } finally {
+      if (manager) {
+        await manager.destroyAll();
+      }
+      await removeFixture(fixture);
+    }
+  });
+});

--- a/test/integration/interface-declaration-routing.test.ts
+++ b/test/integration/interface-declaration-routing.test.ts
@@ -12,6 +12,7 @@ import type { AttachmentLease } from "@antelopejs/interface-core/proxies";
 import { expect } from "chai";
 import { ModuleManager } from "../../src/core/module-manager";
 import { ModuleManifest } from "../../src/core/module-manifest";
+import { reloadWatchedModule } from "../../src/core/runtime/module-loading";
 
 const PROVIDER_ID = "self-interface";
 const CONSUMER_ID = "provider-consumer";
@@ -19,6 +20,9 @@ const STATE_KEY = "__antelopeSelfInterfaceState";
 
 interface RuntimeState {
   evaluations: Array<ModuleExecutionContext | undefined>;
+  applicationEvaluations: string[];
+  declarationEvaluations: string[];
+  declarationReferences: unknown[][];
   sequence: string[];
   registered: string[];
   unregistered: string[];
@@ -50,6 +54,7 @@ interface SelfInterfaceFixture {
   providerFolder: string;
   consumerFolder: string;
   registrationEntry: string;
+  applicationEntries: string[];
 }
 
 interface FixturePackageJson {
@@ -70,6 +75,9 @@ function createRuntimeState(): RuntimeState {
   const [replayCompleted, resolveReplayCompleted] = createDeferred();
   return {
     evaluations: [],
+    applicationEvaluations: [],
+    declarationEvaluations: [],
+    declarationReferences: [],
     sequence: [],
     registered: [],
     unregistered: [],
@@ -121,15 +129,23 @@ async function writeProviderDeclarations(
 ): Promise<void> {
   await fs.writeFile(
     path.join(folder, "registering.js"),
-    `const { RegisteringProxy } = require("@antelopejs/interface-core"); exports.Registrations = new RegisteringProxy(${JSON.stringify(`${identity}.registering`)});`,
+    `global.${STATE_KEY}.declarationEvaluations.push("registering"); const { RegisteringProxy } = require("@antelopejs/interface-core"); exports.Registrations = new RegisteringProxy(${JSON.stringify(`${identity}.registering`)});`,
   );
   await fs.writeFile(
     path.join(folder, "nested.js"),
-    `const { InterfaceFunction } = require("@antelopejs/interface-core"); exports.GetModule = InterfaceFunction(${JSON.stringify(`${identity}.nested`)});`,
+    `global.${STATE_KEY}.declarationEvaluations.push("nested"); const { InterfaceFunction } = require("@antelopejs/interface-core"); exports.GetModule = InterfaceFunction(${JSON.stringify(`${identity}.nested`)});`,
   );
   await fs.writeFile(
     path.join(folder, "interface-declarations.js"),
-    `exports.Registration = require("./registering");`,
+    `global.${STATE_KEY}.declarationEvaluations.push("interface-declarations"); exports.Registration = require("./registering"); exports.Nested = require("./nested");`,
+  );
+  await fs.writeFile(
+    path.join(folder, "routes.js"),
+    `global.${STATE_KEY}.applicationEvaluations.push("routes");`,
+  );
+  await fs.writeFile(
+    path.join(folder, "db.js"),
+    `global.${STATE_KEY}.applicationEvaluations.push("db");`,
   );
 }
 
@@ -189,6 +205,9 @@ async function createFixture(
     providerFolder,
     consumerFolder,
     registrationEntry: path.join(providerFolder, "registering.js"),
+    applicationEntries: ["index.js", "routes.js", "db.js"].map((fileName) =>
+      path.join(providerFolder, fileName),
+    ),
   };
 }
 
@@ -203,11 +222,18 @@ async function createManifest(
 async function createManager(
   fixture: SelfInterfaceFixture,
 ): Promise<ModuleManager> {
+  const manager = new ModuleManager();
+  await addFixtureModules(manager, fixture);
+  return manager;
+}
+
+async function addFixtureModules(
+  manager: ModuleManager,
+  fixture: SelfInterfaceFixture,
+): Promise<void> {
   const provider = await createManifest(fixture.providerFolder, PROVIDER_ID);
   const consumer = await createManifest(fixture.consumerFolder, CONSUMER_ID);
-  const manager = new ModuleManager();
   manager.addModules([{ manifest: provider }, { manifest: consumer }]);
-  return manager;
 }
 
 async function removeDeclarationExport(
@@ -227,6 +253,12 @@ function clearFixtureModules(root: string): void {
     .forEach((entry) => {
       delete require.cache[entry];
     });
+}
+
+function assertApplicationCacheCleared(fixture: SelfInterfaceFixture): void {
+  fixture.applicationEntries.forEach((entry) => {
+    expect(require.cache[entry]).to.be.undefined;
+  });
 }
 
 async function removeFixture(fixture: SelfInterfaceFixture): Promise<void> {
@@ -258,14 +290,16 @@ async function verifySideEffectLifecycle(
   manager: ModuleManager,
   fixture: SelfInterfaceFixture,
 ): Promise<void> {
-  expect(getRuntimeState().evaluations).to.deep.equal([]);
+  const evaluationIndex = getRuntimeState().evaluations.length;
   await manager.constructAll();
   const state = getRuntimeState();
-  expect(state.evaluations[0]).to.include({
+  expect(state.evaluations[evaluationIndex]).to.include({
     module: PROVIDER_ID,
     provider: PROVIDER_ID,
   });
-  expect(state.evaluations[0]?.owner).to.match(/^self-interface#/);
+  expect(state.evaluations[evaluationIndex]?.owner).to.match(
+    /^self-interface#\d+$/,
+  );
   expect(state.result).to.equal(PROVIDER_ID);
   await manager.destroyAll();
   expect(replayRegistrations(fixture)).to.deep.equal([]);
@@ -296,18 +330,89 @@ async function verifyEarlyRegistrationLifecycle(
   expect(state.runtimeErrors).to.deep.equal([]);
 }
 
+async function reloadProvider(
+  manager: ModuleManager,
+  fixture: SelfInterfaceFixture,
+): Promise<void> {
+  const manifest = await createManifest(fixture.providerFolder, PROVIDER_ID);
+  const loaderContext = {
+    cache: {},
+    projectFolder: fixture.root,
+    registry: { load: async () => [manifest] },
+  } as any;
+  await reloadWatchedModule(manager, PROVIDER_ID, loaderContext);
+}
+
+async function exerciseSideEffectRelaunches(
+  fixture: SelfInterfaceFixture,
+): Promise<RuntimeState> {
+  let manager: ModuleManager | undefined;
+  try {
+    manager = await createManager(fixture);
+    assertApplicationCacheCleared(fixture);
+    await verifySideEffectLifecycle(manager, fixture);
+    await addFixtureModules(manager, fixture);
+    assertApplicationCacheCleared(fixture);
+    await verifySideEffectLifecycle(manager, fixture);
+    manager = await createManager(fixture);
+    assertApplicationCacheCleared(fixture);
+    await verifySideEffectLifecycle(manager, fixture);
+    manager = undefined;
+    return getRuntimeState();
+  } finally {
+    if (manager) {
+      await manager.destroyAll();
+    }
+  }
+}
+
+function assertSideEffectRelaunches(state: RuntimeState): void {
+  expect(state.applicationEvaluations).to.deep.equal([
+    "routes",
+    "db",
+    "main",
+    "routes",
+    "db",
+    "main",
+    "routes",
+    "db",
+    "main",
+  ]);
+  expect(state.declarationEvaluations).to.deep.equal([
+    "interface-declarations",
+    "registering",
+    "nested",
+  ]);
+  expect(
+    new Set(state.evaluations.map((context) => context?.owner)).size,
+  ).to.equal(3);
+  for (const references of state.declarationReferences.slice(1)) {
+    expect(references).to.deep.equal(state.declarationReferences[0]);
+    references.forEach((reference, index) => {
+      expect(reference).to.equal(state.declarationReferences[0][index]);
+    });
+  }
+}
+
 const SIDE_EFFECT_PROVIDER_SOURCE = `
 const { ImplementInterface } = require("@antelopejs/interface-core");
 const { BindToCurrentModuleContext, GetModuleContext } = require("@antelopejs/interface-core/modules");
 const declarations = require("./interface-declarations");
-const nested = require("./nested");
+require("./routes");
+require("./db");
 const state = global.${STATE_KEY};
+state.applicationEvaluations.push("main");
 state.evaluations.push(GetModuleContext());
-const routeCallback = BindToCurrentModuleContext(() => nested.GetModule());
+state.declarationReferences.push([
+  declarations,
+  declarations.Registration.Registrations,
+  declarations.Nested.GetModule,
+]);
+const routeCallback = BindToCurrentModuleContext(() => declarations.Nested.GetModule());
 declarations.Registration.Registrations.register("route", routeCallback);
 exports.InterfaceDeclarations = declarations;
 exports.construct = () => {
-  ImplementInterface(nested, { GetModule: () => GetModuleContext().module });
+  ImplementInterface(declarations.Nested, { GetModule: () => GetModuleContext().module });
   declarations.Registration.Registrations.onHandlers((id, callback) => {
     state.registered.push(id);
     state.routeCallback = callback;
@@ -403,15 +508,9 @@ describe("interface declaration routing for self-implemented packages", () => {
       SIDE_EFFECT_PROVIDER_SOURCE,
       SIDE_EFFECT_CONSUMER_SOURCE,
     );
-    let manager: ModuleManager | undefined;
     try {
-      manager = await createManager(fixture);
-      await verifySideEffectLifecycle(manager, fixture);
-      manager = undefined;
+      assertSideEffectRelaunches(await exerciseSideEffectRelaunches(fixture));
     } finally {
-      if (manager) {
-        await manager.destroyAll();
-      }
       await removeFixture(fixture);
     }
   });
@@ -426,6 +525,47 @@ describe("interface declaration routing for self-implemented packages", () => {
       manager = await createManager(fixture);
       await verifyEarlyRegistrationLifecycle(manager);
       manager = undefined;
+    } finally {
+      if (manager) {
+        await manager.destroyAll();
+      }
+      await removeFixture(fixture);
+    }
+  });
+
+  it("preserves declaration identities while hot reloading application files", async () => {
+    const fixture = await createFixture(
+      SIDE_EFFECT_PROVIDER_SOURCE,
+      SIDE_EFFECT_CONSUMER_SOURCE,
+    );
+    let manager: ModuleManager | undefined;
+    try {
+      manager = await createManager(fixture);
+      await manager.constructAll();
+      await reloadProvider(manager, fixture);
+
+      const state = getRuntimeState();
+      expect(state.applicationEvaluations).to.deep.equal([
+        "routes",
+        "db",
+        "main",
+        "routes",
+        "db",
+        "main",
+      ]);
+      expect(state.declarationEvaluations).to.deep.equal([
+        "interface-declarations",
+        "registering",
+        "nested",
+      ]);
+      expect(state.evaluations[0]?.owner).to.not.equal(
+        state.evaluations[1]?.owner,
+      );
+      expect(await state.routeCallback?.()).to.equal(PROVIDER_ID);
+      await manager.destroyAll();
+      manager = undefined;
+      expect(replayRegistrations(fixture)).to.deep.equal([]);
+      expect(state.runtimeErrors).to.deep.equal([]);
     } finally {
       if (manager) {
         await manager.destroyAll();

--- a/test/integration/interface-facade-routing.test.ts
+++ b/test/integration/interface-facade-routing.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { ModuleSourceLocal } from "@antelopejs/interface-core/config";
+import { ModuleManager } from "../../src/core/module-manager";
+import { ModuleManifest } from "../../src/core/module-manifest";
+
+const STATE_KEY = "__antelopeInterfaceFacadeIntegration";
+const API_INTERFACE = "@antelopejs/interface-api";
+const AUTH_INTERFACE = "@antelopejs/interface-auth";
+const CORE_INTERFACE = "@antelopejs/interface-core";
+
+interface FacadeIntegrationState {
+  direct: Record<string, string>;
+  routes: Array<{
+    callback: (...args: unknown[]) => unknown;
+    parameters: Array<{
+      provider?: (context: unknown) => Promise<unknown>;
+    } | null>;
+  }>;
+}
+
+function getState(): FacadeIntegrationState {
+  return (globalThis as Record<string, unknown>)[
+    STATE_KEY
+  ] as FacadeIntegrationState;
+}
+
+async function linkInterfaces(folder: string): Promise<void> {
+  const scope = path.join(folder, "node_modules", "@antelopejs");
+  await fs.mkdir(scope, { recursive: true });
+  for (const packageName of [API_INTERFACE, AUTH_INTERFACE, CORE_INTERFACE]) {
+    const packageRoot = path.dirname(
+      require.resolve(`${packageName}/package.json`),
+    );
+    await fs.symlink(
+      packageRoot,
+      path.join(scope, packageName.slice("@antelopejs/".length)),
+      "dir",
+    );
+  }
+}
+
+async function writeModule(
+  root: string,
+  name: string,
+  source: string,
+  dependencies: string[],
+  implemented?: string,
+): Promise<string> {
+  const folder = path.join(root, name);
+  await fs.mkdir(folder, { recursive: true });
+  await fs.writeFile(
+    path.join(folder, "package.json"),
+    JSON.stringify({
+      name,
+      version: "1.0.0",
+      main: "index.js",
+      dependencies: Object.fromEntries(
+        dependencies.map((dependency) => [dependency, "*"]),
+      ),
+      antelopeJs: implemented ? { implements: [implemented] } : undefined,
+    }),
+  );
+  await fs.writeFile(path.join(folder, "index.js"), source);
+  await linkInterfaces(folder);
+  return folder;
+}
+
+function authProviderSource(prefix: string): string {
+  return `
+const Auth = require(${JSON.stringify(AUTH_INTERFACE)});
+const { ImplementInterface } = require(${JSON.stringify(CORE_INTERFACE)});
+exports.construct = () => ImplementInterface(Auth, {
+  internal: {
+    Verify: async (token) => ${JSON.stringify(prefix)} + token,
+    Sign: async (value) => JSON.stringify(value),
+  },
+});
+exports.destroy = () => {};
+`;
+}
+
+function apiProviderSource(): string {
+  return `
+const Api = require(${JSON.stringify(API_INTERFACE)});
+const { ImplementInterface } = require(${JSON.stringify(CORE_INTERFACE)});
+const routes = {
+  register: (_id, handler) => global.${STATE_KEY}.routes.push(handler),
+  unregister: (_id) => {},
+};
+exports.construct = () => ImplementInterface(Api, {
+  routesProxy: routes,
+  GetControllerInstance: async (Controller) => new Controller(),
+  Listen: async () => {},
+  GetCorsConfig: () => ({}),
+  SetCorsConfig: () => {},
+});
+exports.destroy = () => {};
+`;
+}
+
+function consumerSource(consumer: string): string {
+  return `
+const Api = require(${JSON.stringify(API_INTERFACE)});
+const Auth = require(${JSON.stringify(AUTH_INTERFACE)});
+class Controller {
+  handler(authenticated) { return authenticated; }
+}
+Auth.Authentication()(Controller.prototype, "handler", 0);
+Api.Get(${JSON.stringify(`/${consumer}`)})(
+  Controller.prototype,
+  "handler",
+  Object.getOwnPropertyDescriptor(Controller.prototype, "handler"),
+);
+exports.construct = async () => {
+  global.${STATE_KEY}.direct[${JSON.stringify(consumer)}] =
+    await Promise.resolve().then(() => Auth.ValidateRaw("direct"));
+};
+exports.destroy = () => {};
+`;
+}
+
+async function createManifest(folder: string, name: string) {
+  const source: ModuleSourceLocal = { type: "local", path: folder };
+  return ModuleManifest.create(folder, source, name);
+}
+
+describe("interface facade routing integration", () => {
+  it("routes real Auth decorators and async calls through ModuleManager", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "ajs-facade-routing-"),
+    );
+    (globalThis as Record<string, unknown>)[STATE_KEY] = {
+      direct: {},
+      routes: [],
+    } satisfies FacadeIntegrationState;
+    const folders = {
+      api: await writeModule(
+        root,
+        "api-provider",
+        apiProviderSource(),
+        [API_INTERFACE, CORE_INTERFACE],
+        API_INTERFACE,
+      ),
+      authA: await writeModule(
+        root,
+        "auth-provider-a",
+        authProviderSource("a:"),
+        [AUTH_INTERFACE, CORE_INTERFACE],
+        AUTH_INTERFACE,
+      ),
+      authB: await writeModule(
+        root,
+        "auth-provider-b",
+        authProviderSource("b:"),
+        [AUTH_INTERFACE, CORE_INTERFACE],
+        AUTH_INTERFACE,
+      ),
+      consumerA: await writeModule(
+        root,
+        "consumer-a",
+        consumerSource("consumer-a"),
+        [API_INTERFACE, AUTH_INTERFACE],
+      ),
+      consumerB: await writeModule(
+        root,
+        "consumer-b",
+        consumerSource("consumer-b"),
+        [API_INTERFACE, AUTH_INTERFACE],
+      ),
+    };
+    const manager = new ModuleManager();
+
+    try {
+      const manifests = await Promise.all([
+        createManifest(folders.api, "api-provider"),
+        createManifest(folders.authA, "auth-provider-a"),
+        createManifest(folders.authB, "auth-provider-b"),
+        createManifest(folders.consumerA, "consumer-a"),
+        createManifest(folders.consumerB, "consumer-b"),
+      ]);
+      manager.addModules([
+        { manifest: manifests[0] },
+        { manifest: manifests[1] },
+        { manifest: manifests[2] },
+        {
+          manifest: manifests[3],
+          config: {
+            importOverrides: new Map([
+              [AUTH_INTERFACE, [{ module: "auth-provider-a" }]],
+            ]),
+          },
+        },
+        {
+          manifest: manifests[4],
+          config: {
+            importOverrides: new Map([
+              [AUTH_INTERFACE, [{ module: "auth-provider-b" }]],
+            ]),
+          },
+        },
+      ]);
+
+      await manager.constructAll();
+
+      const state = getState();
+      assert.deepEqual(state.direct, {
+        "consumer-a": "a:direct",
+        "consumer-b": "b:direct",
+      });
+      assert.equal(state.routes.length, 2);
+      const response = {};
+      const results = await Promise.all(
+        state.routes.map((route) => {
+          const provider = route.parameters[0]?.provider;
+          assert(provider);
+          return Promise.resolve().then(() =>
+            provider({
+              rawRequest: {
+                headers: { "x-antelopejs-auth": "request" },
+              },
+              rawResponse: response,
+            }),
+          );
+        }),
+      );
+      assert.deepEqual(results.sort(), ["a:request", "b:request"]);
+      assert(state.routes.every((route) => route.callback.name === "handler"));
+    } finally {
+      await manager.destroyAll().catch(() => {});
+      delete (globalThis as Record<string, unknown>)[STATE_KEY];
+      Object.keys(require.cache)
+        .filter((entry) => entry.startsWith(`${root}${path.sep}`))
+        .forEach((entry) => {
+          delete require.cache[entry];
+        });
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/integration/launch.test.ts
+++ b/test/integration/launch.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { RunWithModuleContext } from "@antelopejs/interface-core/modules";
 import { expect } from "chai";
 import launch, { ModuleManager } from "../../src";
 
@@ -130,6 +131,7 @@ describe("Launch Function", () => {
             name: "consumer",
             version: "1.0.0",
             main: "index.js",
+            antelopeJs: { implements: ["interface-consumer"] },
             optionalDependencies: { "iface-pkg": "*" },
           },
           null,
@@ -143,6 +145,9 @@ describe("Launch Function", () => {
         module.exports = {
           construct() {
             global.__antelopeStubTest = iface;
+          },
+          start() {
+            iface.OnThing.register("during-start");
           },
         };
         `,
@@ -177,14 +182,32 @@ describe("Launch Function", () => {
         const captured = (global as any).__antelopeStubTest;
         expect(captured).to.exist;
         expect(captured.Iface.fetch).to.be.a("function");
+        expect(
+          (manager.getModule("consumer") as any).executionContext
+            .providerRoutes,
+        ).to.deep.equal({});
 
         // RegisteringProxy is sync and should not be neutralized
         let registered = false;
-        captured.OnThing.onRegister(() => {
+        const defaultLease = captured.OnThing.onRegister(() => {
           registered = true;
         }, true);
+        expect(registered).to.equal(false);
         captured.OnThing.register("id-1");
         expect(registered).to.equal(true);
+        captured.OnThing.detach(defaultLease);
+
+        const lateRegistrations: string[] = [];
+        const lateLease = RunWithModuleContext(
+          { module: "late-provider", provider: "late-provider" },
+          () =>
+            captured.OnThing.onRegister(
+              (id: string) => lateRegistrations.push(id),
+              true,
+            ),
+        );
+        expect(lateRegistrations).to.deep.equal([]);
+        captured.OnThing.detach(lateLease);
 
         // AsyncProxy-backed call should reject promptly instead of hanging
         let asyncError: Error | undefined;
@@ -201,9 +224,21 @@ describe("Launch Function", () => {
         expect(asyncError?.message ?? "").to.match(/iface-pkg/);
         expect(asyncError?.message ?? "").to.not.match(/HANG/);
       } finally {
-        delete (global as any).__antelopeStubTest;
+        const captured = (global as any).__antelopeStubTest;
         await manager.stopAll();
         await manager.destroyAll();
+        const replayedAfterDestroy: string[] = [];
+        const cleanupLease = RunWithModuleContext(
+          { module: "consumer", provider: "consumer" },
+          () =>
+            captured.OnThing.onRegister(
+              (id: string) => replayedAfterDestroy.push(id),
+              true,
+            ),
+        );
+        expect(replayedAfterDestroy).to.deep.equal([]);
+        captured.OnThing.detach(cleanupLease);
+        delete (global as any).__antelopeStubTest;
       }
     } finally {
       await fs.rm(projectFolder, { recursive: true, force: true });

--- a/test/integration/provider-routing.test.ts
+++ b/test/integration/provider-routing.test.ts
@@ -265,7 +265,7 @@ describe("provider-aware runtime", () => {
       const providerRoutes = buildProviderRoutes(REAL_CONSUMER_ID, [
         {
           interfaceName: "@antelopejs/interface-core",
-          packageEntry: require.resolve("@antelopejs/interface-core"),
+          declarationEntry: require.resolve("@antelopejs/interface-core"),
           provider: CORE_MODULE_ID,
           providerCount: 1,
         },
@@ -493,13 +493,13 @@ describe("provider-aware runtime", () => {
       buildProviderRoutes("consumer", [
         {
           interfaceName: "first-interface",
-          packageEntry: packageRoot,
+          declarationEntry: packageRoot,
           provider: "provider-a",
           providerCount: 2,
         },
         {
           interfaceName: "second-interface",
-          packageEntry: packageRoot,
+          declarationEntry: packageRoot,
           provider: "provider-b",
           providerCount: 2,
         },

--- a/test/integration/test-module.test.ts
+++ b/test/integration/test-module.test.ts
@@ -1,9 +1,13 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { RunWithModuleContext } from "@antelopejs/interface-core/modules";
 import { expect } from "chai";
 import sinon from "sinon";
 import { TestModule } from "../../src";
+
+const PROVIDER_CONSUMER_ID = "provider-consumer";
+const STUB_INTERFACE_ID = "optional-test-interface";
 
 async function writeMinimalAntelopeModule(folder: string): Promise<void> {
   await fs.writeFile(
@@ -16,6 +20,64 @@ async function writeMinimalAntelopeModule(folder: string): Promise<void> {
   await fs.writeFile(
     path.join(folder, "antelope.test.config.ts"),
     `export default ${JSON.stringify({ name: "tmp-module", modules: {} })};\n`,
+  );
+}
+
+async function writeProviderConsumerModule(folder: string): Promise<string> {
+  const interfaceFolder = path.join(folder, STUB_INTERFACE_ID);
+  const interfaceLink = path.join(folder, "node_modules", STUB_INTERFACE_ID);
+  await fs.mkdir(interfaceFolder, { recursive: true });
+  await fs.mkdir(path.dirname(interfaceLink), { recursive: true });
+  await fs.writeFile(
+    path.join(interfaceFolder, "package.json"),
+    JSON.stringify({
+      name: STUB_INTERFACE_ID,
+      version: "1.0.0",
+      main: "index.js",
+      antelopeJs: {},
+    }),
+  );
+  await fs.writeFile(
+    path.join(interfaceFolder, "index.js"),
+    `const { RegisteringProxy } = require("@antelopejs/interface-core"); exports.Registrations = new RegisteringProxy();`,
+  );
+  await fs.symlink(interfaceFolder, interfaceLink);
+  await writeProviderConsumerFiles(folder);
+  return path.join(folder, "provider-consumer.test.js");
+}
+
+async function writeProviderConsumerFiles(folder: string): Promise<void> {
+  await fs.writeFile(
+    path.join(folder, "package.json"),
+    JSON.stringify({
+      name: PROVIDER_CONSUMER_ID,
+      version: "1.0.0",
+      main: "index.js",
+      optionalDependencies: { [STUB_INTERFACE_ID]: "*" },
+      antelopeJs: {
+        implements: ["provider-consumer-interface"],
+        test: "./antelope.test.config.ts",
+      },
+    }),
+  );
+  await fs.writeFile(
+    path.join(folder, "index.js"),
+    `const iface = require("${STUB_INTERFACE_ID}"); const { GetModuleContext } = require("@antelopejs/interface-core/modules"); global.__testStubInterface = iface; exports.start = () => { global.__testStubContext = GetModuleContext(); iface.Registrations.register("during-start"); };`,
+  );
+  await fs.writeFile(
+    path.join(folder, "antelope.test.config.ts"),
+    `export default ${JSON.stringify({
+      name: PROVIDER_CONSUMER_ID,
+      modules: {
+        [PROVIDER_CONSUMER_ID]: {
+          source: { type: "local", path: ".", main: "index.js" },
+        },
+      },
+    })};\n`,
+  );
+  await fs.writeFile(
+    path.join(folder, "provider-consumer.test.js"),
+    `const assert = require("assert"); const { RegisteringProxy } = require("@antelopejs/interface-core"); const { RunWithModuleContext } = require("@antelopejs/interface-core/modules"); describe("provider consumer test stubs", () => { it("routes only the optional registration to its test stub", () => { assert.doesNotThrow(() => RunWithModuleContext(global.__testStubContext, () => global.__testStubInterface.Registrations.register("during-test"))); const unrelated = new RegisteringProxy(); assert.throws(() => RunWithModuleContext(global.__testStubContext, () => unrelated.register("missing")), { code: "ERR_NO_PROVIDER" }); }); });`,
   );
 }
 
@@ -67,6 +129,29 @@ describe("TestModule Function", () => {
       const failures = await TestModule(moduleFolder, [selectedFile]);
       expect(failures).to.equal(0);
     } finally {
+      await fs.rm(moduleFolder, { recursive: true, force: true });
+    }
+  });
+
+  it("routes explicit registration stubs for provider consumers", async () => {
+    const moduleFolder = await fs.mkdtemp(
+      path.join(os.tmpdir(), "ajs-provider-consumer-"),
+    );
+    try {
+      const testFile = await writeProviderConsumerModule(moduleFolder);
+      expect(await TestModule(moduleFolder, [testFile])).to.equal(0);
+
+      const registrations = (global as any).__testStubInterface.Registrations;
+      const replayed: string[] = [];
+      const lease = RunWithModuleContext(
+        { module: PROVIDER_CONSUMER_ID, provider: PROVIDER_CONSUMER_ID },
+        () => registrations.onRegister((id: string) => replayed.push(id), true),
+      );
+      expect(replayed).to.deep.equal([]);
+      registrations.detach(lease);
+    } finally {
+      delete (global as any).__testStubInterface;
+      delete (global as any).__testStubContext;
       await fs.rm(moduleFolder, { recursive: true, force: true });
     }
   });

--- a/test/integration/test-module.test.ts
+++ b/test/integration/test-module.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { internal } from "@antelopejs/interface-core/internal";
 import { RunWithModuleContext } from "@antelopejs/interface-core/modules";
 import { expect } from "chai";
 import sinon from "sinon";
@@ -137,19 +138,27 @@ describe("TestModule Function", () => {
     const moduleFolder = await fs.mkdtemp(
       path.join(os.tmpdir(), "ajs-provider-consumer-"),
     );
+    const previousReporter = internal.runtimeErrorReporter;
+    const runtimeErrors: unknown[] = [];
+    internal.runtimeErrorReporter = (error) => runtimeErrors.push(error);
     try {
       const testFile = await writeProviderConsumerModule(moduleFolder);
       expect(await TestModule(moduleFolder, [testFile])).to.equal(0);
 
       const registrations = (global as any).__testStubInterface.Registrations;
-      const replayed: string[] = [];
-      const lease = RunWithModuleContext(
-        { module: PROVIDER_CONSUMER_ID, provider: PROVIDER_CONSUMER_ID },
-        () => registrations.onRegister((id: string) => replayed.push(id), true),
-      );
-      expect(replayed).to.deep.equal([]);
-      registrations.detach(lease);
+      internal.testStubMode = true;
+      expect(() =>
+        RunWithModuleContext(
+          { module: PROVIDER_CONSUMER_ID, provider: PROVIDER_CONSUMER_ID },
+          () => registrations.register("after-destroy"),
+        ),
+      )
+        .to.throw()
+        .with.property("code", "ERR_NO_PROVIDER");
+      expect(runtimeErrors).to.deep.equal([]);
     } finally {
+      internal.testStubMode = false;
+      internal.runtimeErrorReporter = previousReporter;
       delete (global as any).__testStubInterface;
       delete (global as any).__testStubContext;
       await fs.rm(moduleFolder, { recursive: true, force: true });

--- a/test/package-consumer/run.ts
+++ b/test/package-consumer/run.ts
@@ -36,8 +36,8 @@ function packCore(): string {
 function inspectManifest(tarball: string): void {
   const content = run("tar", ["-xOf", tarball, "package/package.json"], root);
   const manifest = JSON.parse(content) as PackedManifest;
-  if (manifest.dependencies?.["@antelopejs/interface-core"] !== "^0.0.12") {
-    throw new Error("Packed core does not depend on interface-core ^0.0.12.");
+  if (manifest.dependencies?.["@antelopejs/interface-core"] !== "^0.0.13") {
+    throw new Error("Packed core does not depend on interface-core ^0.0.13.");
   }
   if (/github:AntelopeJS\/interface-core|patches\//.test(content)) {
     throw new Error(
@@ -54,7 +54,7 @@ function installConsumer(tarball: string): void {
       private: true,
       dependencies: {
         "@antelopejs/core": `file:${tarball}`,
-        "@antelopejs/interface-core": "0.0.12",
+        "@antelopejs/interface-core": "0.0.13",
         "reflect-metadata": "0.2.2",
       },
     }),

--- a/test/package-consumer/verify.cjs
+++ b/test/package-consumer/verify.cjs
@@ -5,6 +5,8 @@ const { createRequire } = require("node:module");
 
 const INTERFACE = "package-consumer-interface";
 const RESULTS_KEY = "__antelopePackageConsumer";
+const RELAUNCH_INTERFACE = "package-relaunch-interface";
+const RELAUNCH_STATE_KEY = "__antelopePackageRelaunch";
 
 function packageRoot(packageName) {
   return path.dirname(require.resolve(`${packageName}/package.json`));
@@ -20,9 +22,15 @@ async function copyInterfaceCore(folder, name) {
   await fs.cp(packageRoot("@antelopejs/interface-core"), destination, {
     recursive: true,
   });
+  const reflectMetadata = path.join(
+    destination,
+    "node_modules",
+    "reflect-metadata",
+  );
+  await fs.rm(reflectMetadata, { recursive: true, force: true });
   await link(
     path.dirname(require.resolve("reflect-metadata")),
-    path.join(destination, "node_modules", "reflect-metadata"),
+    reflectMetadata,
   );
   return destination;
 }
@@ -167,6 +175,150 @@ async function verifyPreloadedCopyDiagnostic(launch, root) {
   }
 }
 
+async function writeRelaunchProvider(folder) {
+  await fs.mkdir(folder, { recursive: true });
+  await fs.writeFile(
+    path.join(folder, "package.json"),
+    JSON.stringify({
+      name: RELAUNCH_INTERFACE,
+      version: "1.0.0",
+      main: "index.js",
+      exports: {
+        ".": "./index.js",
+        "./interface-declarations": "./interface-declarations.js",
+      },
+      dependencies: { "@antelopejs/interface-core": "*" },
+      antelopeJs: { implements: [RELAUNCH_INTERFACE] },
+    }),
+  );
+  await writeRelaunchProviderSources(folder);
+  await link(
+    packageRoot("@antelopejs/interface-core"),
+    path.join(folder, "node_modules", "@antelopejs", "interface-core"),
+  );
+}
+
+async function writeRelaunchProviderSources(folder) {
+  const state = `global.${RELAUNCH_STATE_KEY}`;
+  await fs.writeFile(
+    path.join(folder, "interface-declarations.js"),
+    `${state}.declarationEvaluations += 1; const { InterfaceFunction } = require("@antelopejs/interface-core"); exports.GetOwner = InterfaceFunction("package-relaunch.owner");`,
+  );
+  await fs.writeFile(
+    path.join(folder, "routes.js"),
+    `${state}.applicationEvaluations.push("routes");`,
+  );
+  await fs.writeFile(
+    path.join(folder, "db.js"),
+    `${state}.applicationEvaluations.push("db");`,
+  );
+  await fs.writeFile(
+    path.join(folder, "index.js"),
+    `const state = ${state}; state.applicationEvaluations.push("main"); const declarations = require("./interface-declarations"); require("./routes"); require("./db"); state.declarationReferences.push([declarations, declarations.GetOwner]); const { ImplementInterface } = require("@antelopejs/interface-core"); const { GetModuleContext } = require("@antelopejs/interface-core/modules"); exports.construct = () => ImplementInterface(declarations, { GetOwner: () => GetModuleContext().owner }); exports.destroy = () => {};`,
+  );
+}
+
+async function writeRelaunchConsumer(folder, providerFolder) {
+  await fs.mkdir(folder, { recursive: true });
+  await fs.writeFile(
+    path.join(folder, "package.json"),
+    JSON.stringify({
+      name: "package-relaunch-consumer",
+      version: "1.0.0",
+      main: "index.js",
+      dependencies: { [RELAUNCH_INTERFACE]: "^1.0.0" },
+    }),
+  );
+  await fs.writeFile(
+    path.join(folder, "index.js"),
+    `const declarations = require("${RELAUNCH_INTERFACE}/interface-declarations"); exports.construct = async () => global.${RELAUNCH_STATE_KEY}.owners.push(await declarations.GetOwner()); exports.destroy = () => {};`,
+  );
+  await link(
+    providerFolder,
+    path.join(folder, "node_modules", RELAUNCH_INTERFACE),
+  );
+}
+
+async function writeRelaunchProject(root) {
+  const providerFolder = path.join(root, RELAUNCH_INTERFACE);
+  const consumerFolder = path.join(root, "consumer");
+  await writeRelaunchProvider(providerFolder);
+  await writeRelaunchConsumer(consumerFolder, providerFolder);
+  const config = {
+    name: "package-relaunch",
+    modules: {
+      [RELAUNCH_INTERFACE]: localModule(RELAUNCH_INTERFACE),
+      consumer: localModule("consumer"),
+    },
+  };
+  await fs.writeFile(
+    path.join(root, "antelope.config.ts"),
+    `export default ${JSON.stringify(config)};`,
+  );
+}
+
+async function stopAndDestroy(manager) {
+  if (!manager) return;
+  await manager.stopAll();
+  await manager.destroyAll();
+}
+
+function verifyRelaunchState(state) {
+  const expectedApplications = ["main", "routes", "db", "main", "routes", "db"];
+  if (
+    state.applicationEvaluations.join(",") !== expectedApplications.join(",")
+  ) {
+    throw new Error(
+      `Application cache was not reloaded: ${state.applicationEvaluations}.`,
+    );
+  }
+  if (state.declarationEvaluations !== 1 || state.owners.length !== 2) {
+    throw new Error(
+      "Declaration cache or lifecycle generation count is invalid.",
+    );
+  }
+  if (state.owners[0] === state.owners[1]) {
+    throw new Error("Relaunch reused the previous lifecycle owner.");
+  }
+  if (state.runtimeErrors.length !== 0) {
+    throw new Error("Relaunch reported runtime cleanup errors.");
+  }
+  state.declarationReferences[1].forEach((reference, index) => {
+    if (reference !== state.declarationReferences[0][index]) {
+      throw new Error("Relaunch replaced a canonical declaration identity.");
+    }
+  });
+}
+
+async function verifyPackedRelaunch(launch, root) {
+  await writeRelaunchProject(root);
+  const internal = require("@antelopejs/interface-core/internal").internal;
+  const state = {
+    applicationEvaluations: [],
+    declarationEvaluations: 0,
+    declarationReferences: [],
+    owners: [],
+    runtimeErrors: [],
+  };
+  const previousRuntimeReporter = internal.runtimeErrorReporter;
+  internal.runtimeErrorReporter = (error) => state.runtimeErrors.push(error);
+  global[RELAUNCH_STATE_KEY] = state;
+  let manager;
+  try {
+    manager = await launch(root);
+    await stopAndDestroy(manager);
+    manager = undefined;
+    manager = await launch(root);
+    await stopAndDestroy(manager);
+    manager = undefined;
+    verifyRelaunchState(state);
+  } finally {
+    await stopAndDestroy(manager);
+    internal.runtimeErrorReporter = previousRuntimeReporter;
+    delete global[RELAUNCH_STATE_KEY];
+  }
+}
+
 async function main() {
   const launch = require("@antelopejs/core").default;
   const compatible = await fs.mkdtemp(
@@ -175,12 +327,17 @@ async function main() {
   const incompatible = await fs.mkdtemp(
     path.join(os.tmpdir(), "ajs-packed-incompatible-"),
   );
+  const relaunch = await fs.mkdtemp(
+    path.join(os.tmpdir(), "ajs-packed-relaunch-"),
+  );
   try {
     await verifyCompatibleCopies(launch, compatible);
     await verifyPreloadedCopyDiagnostic(launch, incompatible);
+    await verifyPackedRelaunch(launch, relaunch);
   } finally {
     await fs.rm(compatible, { recursive: true, force: true });
     await fs.rm(incompatible, { recursive: true, force: true });
+    await fs.rm(relaunch, { recursive: true, force: true });
   }
 }
 


### PR DESCRIPTION
## Summary
- preserve the declaration-only entry and CommonJS cache contract already validated on this branch
- create and cache an interface facade for each consumer lifecycle generation
- resolve both standalone interface roots and embedded interface subpaths through that facade
- leave implementing provider modules on canonical declarations for singleton identity and hot-path performance
- evict only the destroyed consumer's synthetic facades during unload/HMR
- run interface package tests in the configured module context

## Resolver behavior
The resolver already owns the mapping from a consumer to its selected providers. It now applies that mapping when Node resolves the consumer's interface import.

```text
consumer require(interface)
  -> canonical declaration singleton
  -> consumer/generation facade
  -> bound InterfaceFunction
  -> selected provider
```

Application syntax stays unchanged. Providers still receive canonical declarations for `ImplementInterface`; classes, symbols, metadata, proxies, and callbacks preserve strict identity.

## Bug reproduced
With two Auth providers, the old resolver returned the same canonical Auth module to both consumers. Direct calls could work while a lifecycle context was active, but `Authentication()` stored a parameter provider that ran later under API's provider context. That later `ValidateRaw()` call had no consumer provider route and failed with `AmbiguousProviderError`.

The integration regression builds two real consumer modules with different Auth `importOverrides`, registers real Auth and API decorators, waits across an async boundary, invokes both deferred parameter providers outside the consumers' lifecycle contexts, and proves results route to `auth-provider-a` and `auth-provider-b`. The registered HTTP callbacks remain strict-equal to the controller methods.

The self-implemented interface regression also imports `./interface-declarations` through a consumer facade and proves delayed nested calls, reconstruction, HMR, and declaration identity.

## Validation
- `pnpm lint` (exit 0; two pre-existing warnings and one informational finding outside this diff)
- `pnpm build`
- Core unit/integration command exit 0
- focused resolver, standalone Auth/API, embedded subpath, declaration lifecycle, and HMR tests: 6 passing
- interface-core full tests: 81 passing
- real API module suite through this Core: 94 passing
- interface-auth facade regression passing
- `git diff --check`

## Performance
The resolver performs facade construction only during module resolution. Implementing provider modules stay canonical, request callbacks are not wrapped, and the historical `AsyncProxy.call()` attached-provider path is unchanged.

An isolated A/B HTTP gate (Node 24.19.0, pinned server CPU, 8 repetitions, 8-second samples) measured +1.15% JSON c100, +2.46% dynamic routes, +1.68% POST echo, and -0.36% on the last of 1,000 routes. This shows no attributable steady-state regression; the rejected callback-wrapper branch measured roughly -8% to -14%.

## CI and release ordering
The stock Ubuntu install remains expected to fail until unpublished `@antelopejs/interface-core@0.0.13` (or its final next release version) exists in the registry. Do not work around that provenance gate in the lockfile.

Merge/release order starts with interface-core #12, then this Core PR, then interface-api #17 and interface-auth. No package is published by this PR.