### PR TITLE
fix(runtime): bind interface imports to selected providers

### DIFF
--- a/src/core/resolution/resolver-detour.ts
+++ b/src/core/resolution/resolver-detour.ts
@@ -9,6 +9,8 @@ type ModuleResolver = (
   options: any,
 ) => string;
 
+type ModuleLoader = (request: string, parent: any, isMain: boolean) => unknown;
+
 interface ResolverLease {
   owner: symbol;
   resolver: Resolver;
@@ -18,6 +20,8 @@ class ResolverDetourCoordinator {
   private readonly leases: ResolverLease[] = [];
   private originalResolver?: ModuleResolver;
   private installedResolver?: ModuleResolver;
+  private originalLoader?: ModuleLoader;
+  private installedLoader?: ModuleLoader;
 
   attach(owner: symbol, resolver: Resolver): boolean {
     if (this.leases.some((lease) => lease.owner === owner)) {
@@ -33,19 +37,25 @@ class ResolverDetourCoordinator {
     if (leaseIndex === -1) {
       return;
     }
+    this.leases[leaseIndex].resolver.clearCache();
     this.leases.splice(leaseIndex, 1);
-    if ((Module as any)._resolveFilename !== this.installedResolver) {
-      if (this.leases.length === 0) {
-        this.originalResolver = undefined;
-        this.installedResolver = undefined;
-      }
-      throw new Error("Node module resolver hook was replaced externally");
+    const ownsResolver =
+      (Module as any)._resolveFilename === this.installedResolver;
+    const ownsLoader = (Module as any)._load === this.installedLoader;
+    if (this.leases.length > 0 && (!ownsResolver || !ownsLoader)) {
+      this.throwHookReplacement(ownsResolver, ownsLoader);
     }
-    if (this.leases.length === 0) {
+    if (this.leases.length > 0) {
+      return;
+    }
+    if (ownsResolver) {
       (Module as any)._resolveFilename = this.originalResolver;
-      this.originalResolver = undefined;
-      this.installedResolver = undefined;
     }
+    if (ownsLoader) {
+      (Module as any)._load = this.originalLoader;
+    }
+    this.releaseHooks();
+    this.throwHookReplacement(ownsResolver, ownsLoader);
   }
 
   private ensureInstalled(): void {
@@ -54,15 +64,37 @@ class ResolverDetourCoordinator {
       return;
     }
     this.originalResolver = (Module as any)._resolveFilename;
+    this.originalLoader = (Module as any)._load;
     this.installedResolver = (request, parent, isMain, options) =>
       this.resolve(request, parent, isMain, options);
+    this.installedLoader = (request, parent, isMain) =>
+      this.load(request, parent, isMain);
     (Module as any)._resolveFilename = this.installedResolver;
+    (Module as any)._load = this.installedLoader;
   }
 
   private ensureHookOwnership(): void {
     if ((Module as any)._resolveFilename !== this.installedResolver) {
       throw new Error("Node module resolver hook was replaced externally");
     }
+    if ((Module as any)._load !== this.installedLoader) {
+      throw new Error("Node module loader hook was replaced externally");
+    }
+  }
+
+  private load(request: string, parent: any, isMain: boolean): unknown {
+    const activeResolver = this.findResolver(request, parent);
+    if (!activeResolver?.requiresPreResolution(request, parent)) {
+      return this.originalLoader?.(request, parent, isMain);
+    }
+    const resolvedPath = this.resolveWith(
+      activeResolver,
+      request,
+      parent,
+      isMain,
+      undefined,
+    );
+    return this.originalLoader?.(resolvedPath, parent, isMain);
   }
 
   private resolve(
@@ -71,7 +103,17 @@ class ResolverDetourCoordinator {
     isMain: boolean,
     options: any,
   ): string {
-    const activeResolver = this.leases.at(-1)?.resolver;
+    const activeResolver = this.findResolver(request, parent);
+    return this.resolveWith(activeResolver, request, parent, isMain, options);
+  }
+
+  private resolveWith(
+    activeResolver: Resolver | undefined,
+    request: string,
+    parent: any,
+    isMain: boolean,
+    options: any,
+  ): string {
     const result = activeResolver?.resolve(request, parent);
     if (!result) {
       return this.originalResolver?.(
@@ -81,15 +123,52 @@ class ResolverDetourCoordinator {
         options,
       ) as string;
     }
+    if (result.exact) {
+      return result.resolvedPath;
+    }
     const contextParent = result.resolveFrom
       ? { ...parent, filename: path.join(result.resolveFrom, "_") }
-      : parent;
-    return this.originalResolver?.(
+      : result.parentFilename
+        ? { ...parent, filename: result.parentFilename }
+        : parent;
+    const resolvedPath = this.originalResolver?.(
       result.resolvedPath,
       contextParent,
       isMain,
       options,
     ) as string;
+    return (
+      activeResolver?.applyAlias(resolvedPath, result.alias) ?? resolvedPath
+    );
+  }
+
+  private findResolver(request: string, parent: any): Resolver | undefined {
+    for (let index = this.leases.length - 1; index >= 0; index -= 1) {
+      const resolver = this.leases[index].resolver;
+      if (resolver.ownsResolutionContext(request, parent)) {
+        return resolver;
+      }
+    }
+    return this.leases.at(-1)?.resolver;
+  }
+
+  private releaseHooks(): void {
+    this.originalResolver = undefined;
+    this.installedResolver = undefined;
+    this.originalLoader = undefined;
+    this.installedLoader = undefined;
+  }
+
+  private throwHookReplacement(
+    ownsResolver: boolean,
+    ownsLoader: boolean,
+  ): void {
+    if (!ownsResolver) {
+      throw new Error("Node module resolver hook was replaced externally");
+    }
+    if (!ownsLoader) {
+      throw new Error("Node module loader hook was replaced externally");
+    }
   }
 }
 

--- a/src/core/resolution/resolver.ts
+++ b/src/core/resolution/resolver.ts
@@ -1,5 +1,12 @@
+import Module from "node:module";
+import path from "node:path";
+import { internal } from "@antelopejs/interface-core/internal";
 import type { ModuleManifest } from "../module-manifest";
-import { isPathWithin, resolvePackage } from "./package-resolution";
+import {
+  findPackageFromEntry,
+  isPathWithin,
+  resolvePackage,
+} from "./package-resolution";
 import type { PathMapper } from "./path-mapper";
 
 export interface ModuleRef {
@@ -10,12 +17,43 @@ export interface ModuleRef {
 export interface ResolveResult {
   resolvedPath: string;
   resolveFrom?: string;
+  exact?: boolean;
+  alias?: InterfacePackageAlias;
+  parentFilename?: string;
+}
+
+export interface InterfacePackageAlias {
+  root: string;
+  separatorCount: number;
+  coreFacadeEntries: Set<string>;
+}
+
+interface InterfacePackageRequest {
+  packageName: string;
+  result: ResolveResult;
+}
+
+interface ProxyConstructor {
+  new (identity?: string): object;
+}
+
+interface CoreFacadeExports {
+  AsyncProxy: ProxyConstructor;
+  EventProxy: ProxyConstructor;
+  InterfaceFunction(identity?: string): (...args: any[]) => Promise<unknown>;
+  RegisteringProxy: ProxyConstructor;
 }
 
 const CORE_PKG = "@antelopejs/interface-core";
 const CORE_PACKAGE = resolvePackage(CORE_PKG, __dirname);
 const CORE_RESOLVE_FROM = CORE_PACKAGE?.root ?? __dirname;
 const CORE_ENTRY = CORE_PACKAGE?.entry ?? CORE_PKG;
+const CORE_ENTRY_RELATIVE = CORE_PACKAGE
+  ? path.relative(CORE_PACKAGE.root, CORE_PACKAGE.entry)
+  : path.join("dist", "index.js");
+const CORE_PROXIES_RELATIVE = path.join("dist", "proxies.js");
+let nextResolverIdentity = 1;
+let nextAliasIdentity = 2;
 
 export class Resolver {
   public readonly moduleByFolder = new Map<string, ModuleRef>();
@@ -24,6 +62,16 @@ export class Resolver {
   public readonly interfacePackageEntries = new Map<string, string>();
   public readonly interfacePackageResolveFrom = new Map<string, string>();
   public stubModulePath?: string;
+  private readonly resolverIdentity = nextResolverIdentity++;
+  private readonly interfaceAliases = new Map<string, InterfacePackageAlias>();
+  private readonly facadeWrappers = new WeakMap<
+    InterfacePackageAlias,
+    Map<string, CoreFacadeExports>
+  >();
+  private readonly facadePaths = new WeakMap<
+    InterfacePackageAlias,
+    Map<string, string>
+  >();
 
   constructor(private pathMapper: PathMapper) {}
 
@@ -31,6 +79,16 @@ export class Resolver {
     request: string,
     parent?: { filename?: string },
   ): ResolveResult | undefined {
+    if (this.isExactResolverPath(request)) {
+      return { resolvedPath: request, exact: true };
+    }
+    const inheritedAlias = this.resolveInheritedAlias(
+      request,
+      parent?.filename,
+    );
+    if (inheritedAlias) {
+      return inheritedAlias;
+    }
     const matchingModule = this.resolveLocalModule(parent?.filename);
     if (matchingModule) {
       const mapped = this.pathMapper.resolve(request, matchingModule.manifest);
@@ -44,12 +102,73 @@ export class Resolver {
       return coreResult;
     }
 
-    const interfaceResult = this.resolveInterfacePackage(request);
-    if (interfaceResult) {
-      return interfaceResult;
+    const interfaceRequest = this.resolveInterfacePackage(request);
+    if (interfaceRequest) {
+      const provider = matchingModule
+        ? this.resolveProvider(matchingModule, interfaceRequest.packageName)
+        : undefined;
+      if (!provider) {
+        return interfaceRequest.result;
+      }
+      return {
+        ...interfaceRequest.result,
+        alias: this.getInterfaceAlias(interfaceRequest.packageName, provider),
+      };
     }
 
     return undefined;
+  }
+
+  ownsResolutionContext(
+    request: string,
+    parent?: { filename?: string },
+  ): boolean {
+    return Boolean(
+      this.isExactResolverPath(request) ||
+        (parent?.filename &&
+          (this.findAliasByPath(parent.filename) ||
+            this.resolveLocalModule(parent.filename))),
+    );
+  }
+
+  requiresPreResolution(
+    request: string,
+    parent?: { filename?: string },
+  ): boolean {
+    if (parent?.filename && this.findAliasByPath(parent.filename)) {
+      return true;
+    }
+    const matchingModule = this.resolveLocalModule(parent?.filename);
+    const interfaceRequest = this.findInterfacePackageRequest(request);
+    return Boolean(
+      matchingModule &&
+        interfaceRequest &&
+        this.resolveProvider(matchingModule, interfaceRequest),
+    );
+  }
+
+  applyAlias(resolvedPath: string, alias?: InterfacePackageAlias): string {
+    if (!alias) {
+      return resolvedPath;
+    }
+    const coreFacade = this.resolveCoreFacade(resolvedPath, alias);
+    if (coreFacade) {
+      return coreFacade;
+    }
+    if (!isPathWithin(resolvedPath, alias.root)) {
+      return resolvedPath;
+    }
+    const relativePath = path.relative(alias.root, resolvedPath);
+    return `${alias.root}${path.sep.repeat(alias.separatorCount)}${relativePath}`;
+  }
+
+  clearCache(): void {
+    for (const cachePath of Object.keys(require.cache)) {
+      if (this.isExactResolverPath(cachePath)) {
+        delete require.cache[cachePath];
+      }
+    }
+    this.interfaceAliases.clear();
   }
 
   private resolveInterfaceCore(request: string): ResolveResult | undefined {
@@ -62,21 +181,229 @@ export class Resolver {
     return undefined;
   }
 
-  private resolveInterfacePackage(request: string): ResolveResult | undefined {
+  private resolveInterfacePackage(
+    request: string,
+  ): InterfacePackageRequest | undefined {
     for (const [pkg, rootDir] of this.interfacePackages) {
       if (request === pkg) {
         return {
-          resolvedPath: this.interfacePackageEntries.get(pkg) ?? rootDir,
+          packageName: pkg,
+          result: {
+            resolvedPath: this.interfacePackageEntries.get(pkg) ?? rootDir,
+          },
         };
       }
       if (request.startsWith(`${pkg}/`)) {
         return {
-          resolvedPath: request,
-          resolveFrom: this.interfacePackageResolveFrom.get(pkg) ?? rootDir,
+          packageName: pkg,
+          result: {
+            resolvedPath: request,
+            resolveFrom: this.interfacePackageResolveFrom.get(pkg) ?? rootDir,
+          },
         };
       }
     }
     return undefined;
+  }
+
+  private resolveInheritedAlias(
+    request: string,
+    parentFilename?: string,
+  ): ResolveResult | undefined {
+    if (!parentFilename) {
+      return undefined;
+    }
+    const alias = this.findAliasByPath(parentFilename);
+    if (!alias) {
+      return undefined;
+    }
+    const coreResult = this.resolveInterfaceCore(request);
+    if (coreResult) {
+      return { ...coreResult, alias };
+    }
+    return {
+      resolvedPath: request,
+      parentFilename: this.removeAlias(parentFilename, alias),
+      alias,
+    };
+  }
+
+  private resolveProvider(
+    module: ModuleRef,
+    packageName: string,
+  ): string | undefined {
+    if (module.manifest.implements?.includes(packageName)) {
+      return module.id;
+    }
+    return internal.interfaceConnections[module.id]?.[packageName]?.find(
+      ({ selected }) => selected,
+    )?.provider;
+  }
+
+  private getInterfaceAlias(
+    packageName: string,
+    provider: string,
+  ): InterfacePackageAlias {
+    const key = `${packageName}\0${provider}`;
+    const existing = this.interfaceAliases.get(key);
+    if (existing) {
+      return existing;
+    }
+    const root = this.interfacePackages.get(packageName) as string;
+    const separatorCount = nextAliasIdentity++;
+    const alias = {
+      root,
+      separatorCount,
+      coreFacadeEntries: new Set<string>(),
+    };
+    this.facadeWrappers.set(alias, new Map());
+    this.facadePaths.set(alias, new Map());
+    this.interfaceAliases.set(key, alias);
+    return alias;
+  }
+
+  private resolveCoreFacade(
+    entry: string,
+    alias: InterfacePackageAlias,
+  ): string | undefined {
+    if (!path.isAbsolute(entry)) {
+      return undefined;
+    }
+    const corePackage = findPackageFromEntry(
+      entry,
+      CORE_PKG,
+      path.dirname(entry),
+    );
+    if (!corePackage || !this.isFacadeCoreEntry(entry, corePackage.root)) {
+      return undefined;
+    }
+    const paths = this.facadePaths.get(alias) as Map<string, string>;
+    const existing = paths.get(entry);
+    if (existing) {
+      return existing;
+    }
+    const wrappersByRoot = this.facadeWrappers.get(alias) as Map<
+      string,
+      CoreFacadeExports
+    >;
+    const namespace = `${this.resolverIdentity}:${alias.separatorCount}`;
+    const coreEntry = path.join(corePackage.root, CORE_ENTRY_RELATIVE);
+    const wrappers =
+      wrappersByRoot.get(corePackage.root) ??
+      this.createCoreWrappers(namespace, coreEntry);
+    wrappersByRoot.set(corePackage.root, wrappers);
+    const facadePath = this.createCoreFacade(entry, wrappers, namespace);
+    paths.set(entry, facadePath);
+    alias.coreFacadeEntries.add(facadePath);
+    return facadePath;
+  }
+
+  private createCoreWrappers(
+    namespace: string,
+    coreEntry: string,
+  ): CoreFacadeExports {
+    const core = require(coreEntry) as CoreFacadeExports;
+    let nextAnonymousIdentity = 1;
+    const namespacedIdentity = (identity?: string) =>
+      `${namespace}:${identity ?? `anonymous:${nextAnonymousIdentity++}`}`;
+    class AsyncProxy extends core.AsyncProxy {
+      constructor(identity?: string) {
+        super(namespacedIdentity(identity));
+      }
+    }
+    class EventProxy extends core.EventProxy {
+      constructor(identity?: string) {
+        super(namespacedIdentity(identity));
+      }
+    }
+    class RegisteringProxy extends core.RegisteringProxy {
+      constructor(identity?: string) {
+        super(namespacedIdentity(identity));
+      }
+    }
+    const InterfaceFunction = (identity?: string) => {
+      const proxy = new AsyncProxy(identity) as any;
+      const func = (...args: any[]) => proxy.call(...args);
+      func.proxy = proxy;
+      return func;
+    };
+    return { AsyncProxy, EventProxy, InterfaceFunction, RegisteringProxy };
+  }
+
+  private isFacadeCoreEntry(entry: string, coreRoot: string): boolean {
+    const relativeEntry = path.relative(coreRoot, entry);
+    return (
+      relativeEntry === CORE_ENTRY_RELATIVE ||
+      relativeEntry === CORE_PROXIES_RELATIVE
+    );
+  }
+
+  private facadeSuffix(entry: string): string {
+    return `-${path.basename(entry, path.extname(entry))}.js`;
+  }
+
+  private createCoreFacade(
+    entry: string,
+    wrappers: CoreFacadeExports,
+    namespace: string,
+  ): string {
+    const facadePath = path.join(
+      path.dirname(entry),
+      `.antelope-resolver-${namespace}${this.facadeSuffix(entry)}`,
+    );
+    const facade = Object.create(Object.getPrototypeOf(require(entry)));
+    Object.defineProperties(
+      facade,
+      Object.getOwnPropertyDescriptors(require(entry)),
+    );
+    Object.defineProperties(facade, {
+      AsyncProxy: { enumerable: true, value: wrappers.AsyncProxy },
+      EventProxy: { enumerable: true, value: wrappers.EventProxy },
+      InterfaceFunction: {
+        enumerable: true,
+        value: wrappers.InterfaceFunction,
+      },
+      RegisteringProxy: { enumerable: true, value: wrappers.RegisteringProxy },
+    });
+    const facadeModule = new Module(facadePath);
+    facadeModule.filename = facadePath;
+    facadeModule.exports = facade;
+    facadeModule.loaded = true;
+    require.cache[facadePath] = facadeModule;
+    return facadePath;
+  }
+
+  private findInterfacePackageRequest(request: string): string | undefined {
+    return [...this.interfacePackages.keys()].find(
+      (packageName) =>
+        request === packageName || request.startsWith(`${packageName}/`),
+    );
+  }
+
+  private findAliasByPath(fileName: string): InterfacePackageAlias | undefined {
+    return [...this.interfaceAliases.values()].find((alias) => {
+      if (!fileName.startsWith(alias.root)) {
+        return false;
+      }
+      const suffix = fileName.slice(alias.root.length);
+      const separators = suffix.match(new RegExp(`^\\${path.sep}+`))?.[0];
+      return separators?.length === alias.separatorCount;
+    });
+  }
+
+  private removeAlias(fileName: string, alias: InterfacePackageAlias): string {
+    return `${alias.root}${path.sep}${fileName.slice(
+      alias.root.length + alias.separatorCount,
+    )}`;
+  }
+
+  private isExactResolverPath(request: string): boolean {
+    if (this.findAliasByPath(request)) {
+      return true;
+    }
+    return [...this.interfaceAliases.values()].some((alias) =>
+      alias.coreFacadeEntries.has(request),
+    );
   }
 
   private resolveLocalModule(fileName?: string): ModuleRef | undefined {

--- a/test/core/resolution/resolver-detour.test.ts
+++ b/test/core/resolution/resolver-detour.test.ts
@@ -69,6 +69,40 @@ describe("ResolverDetour", () => {
     expect((Module as any)._resolveFilename).to.equal(originalResolver);
   });
 
+  it("uses the resolver that owns the requesting module", () => {
+    const firstResolver = createResolver("first");
+    const secondResolver = createResolver("second");
+    firstResolver.ownsResolutionContext = (_request, parent) =>
+      parent?.filename === "/first/index.js";
+    secondResolver.ownsResolutionContext = (_request, parent) =>
+      parent?.filename === "/second/index.js";
+    const first = new ResolverDetour(firstResolver);
+    const second = new ResolverDetour(secondResolver);
+
+    first.attach();
+    second.attach();
+
+    expect(
+      (Module as any)._resolveFilename(
+        "request",
+        { filename: "/first/index.js" },
+        false,
+        {},
+      ),
+    ).to.equal("first");
+    expect(
+      (Module as any)._resolveFilename(
+        "request",
+        { filename: "/second/index.js" },
+        false,
+        {},
+      ),
+    ).to.equal("second");
+
+    second.detach();
+    first.detach();
+  });
+
   it("attaches and detaches each lease idempotently", () => {
     const detour = new ResolverDetour(createResolver());
 

--- a/test/core/resolution/resolver.test.ts
+++ b/test/core/resolution/resolver.test.ts
@@ -125,6 +125,31 @@ describe("Resolver", () => {
     );
   });
 
+  it("allocates unique interface graph paths across concurrent resolvers", () => {
+    const packageName = "@antelopejs/interface-db";
+    const packageRoot = __dirname;
+    const packageEntry = __filename;
+    const aliases = ["first", "second"].map((id) => {
+      const resolver = new Resolver(new PathMapper(() => false));
+      resolver.interfacePackages.set(packageName, packageRoot);
+      resolver.interfacePackageEntries.set(packageName, packageEntry);
+      resolver.moduleByFolder.set(`/modules/${id}`, {
+        id,
+        manifest: {
+          implements: [packageName],
+          paths: [],
+          srcAliases: [],
+        } as any,
+      });
+      const result = resolver.resolve(packageName, {
+        filename: `/modules/${id}/index.js`,
+      });
+      return resolver.applyAlias(result?.resolvedPath as string, result?.alias);
+    });
+
+    expect(aliases[0]).not.to.equal(aliases[1]);
+  });
+
   it("does not redirect unknown packages", () => {
     const resolver = new Resolver(new PathMapper(() => false));
     resolver.interfacePackages.set(

--- a/test/integration/provider-routing.test.ts
+++ b/test/integration/provider-routing.test.ts
@@ -16,6 +16,10 @@ import {
 } from "../../src/core/runtime/module-loading";
 
 const ROUTING_RESULTS_KEY = "__antelopeProviderRouting";
+const ROUTING_CLOSURES_KEY = "__antelopeProviderRoutingClosures";
+const ROUTING_REGISTRATIONS_KEY = "__antelopeProviderRoutingRegistrations";
+const ROUTING_EMITTERS_KEY = "__antelopeProviderRoutingEmitters";
+const ROUTING_EVENTS_KEY = "__antelopeProviderRoutingEvents";
 const INTERFACE_NAME = "routing-interface";
 const STRESS_ITERATIONS = 40;
 
@@ -40,6 +44,14 @@ interface RoutingResults {
   [consumer: string]: RoutingResult;
 }
 
+interface RoutingClosures {
+  [consumer: string]: () => Promise<RoutingResult>;
+}
+
+interface RoutingEmits {
+  [provider: string]: (value: string) => void;
+}
+
 interface RoutingProject {
   folder: string;
   consumerAIndex: string;
@@ -59,7 +71,12 @@ exports.construct = async () => {
   await new Promise((resolve) => setTimeout(resolve, ${delayMs}));
   ImplementInterface(declaration, {
     GetValue: () => ({ value: ${JSON.stringify(value)}, module: GetModuleContext().module }),
+    RegisterValue: {
+      register: (id, registeredValue) => global[${JSON.stringify(ROUTING_REGISTRATIONS_KEY)}][${JSON.stringify(value)}].push([id, registeredValue]),
+      unregister: (id) => global[${JSON.stringify(ROUTING_REGISTRATIONS_KEY)}][${JSON.stringify(value)}].push([id, "unregistered"]),
+    },
   });
+  global[${JSON.stringify(ROUTING_EMITTERS_KEY)}][${JSON.stringify(value)}] = (eventValue) => declaration.ValueEvent.emit(eventValue);
 };
 exports.destroy = () => {};
 `;
@@ -71,6 +88,9 @@ const { GetInterfaceInstance, GetInterfaceInstances } = require("@antelopejs/int
 const declaration = require(${JSON.stringify(INTERFACE_NAME)});
 exports.construct = async () => {
   const result = await declaration.GetValue();
+  declaration.RegisterValue.register("shared", ${JSON.stringify(consumer)});
+  declaration.ValueEvent.register((value) => global[${JSON.stringify(ROUTING_EVENTS_KEY)}][${JSON.stringify(consumer)}].push(value));
+  global[${JSON.stringify(ROUTING_CLOSURES_KEY)}][${JSON.stringify(consumer)}] = declaration.CreateDeferred();
   global[${JSON.stringify(ROUTING_RESULTS_KEY)}][${JSON.stringify(consumer)}] = {
     ...result,
     connections: GetInterfaceInstances(${JSON.stringify(INTERFACE_NAME)}),
@@ -182,7 +202,11 @@ async function createRoutingProject(
   );
   await fs.writeFile(
     path.join(interfaceFolder, "index.js"),
-    `const { InterfaceFunction } = require(${JSON.stringify(interfaceCoreImport)}); exports.GetValue = InterfaceFunction();`,
+    `const declarations = require("./private"); Object.assign(exports, declarations); exports.CreateDeferred = () => () => require("./private").GetValue();`,
+  );
+  await fs.writeFile(
+    path.join(interfaceFolder, "private.js"),
+    `const { EventProxy, InterfaceFunction, RegisteringProxy } = require(${JSON.stringify(interfaceCoreImport)}); exports.GetValue = InterfaceFunction("routing.GetValue"); exports.RegisterValue = new RegisteringProxy("routing.RegisterValue"); exports.ValueEvent = new EventProxy("routing.ValueEvent");`,
   );
   await linkInterfaceCore(interfaceFolder);
 
@@ -218,6 +242,32 @@ function routingResults(): RoutingResults {
   ] as RoutingResults;
 }
 
+function routingClosures(): RoutingClosures {
+  return (global as Record<string, unknown>)[
+    ROUTING_CLOSURES_KEY
+  ] as RoutingClosures;
+}
+
+function routingEmitters(): RoutingEmits {
+  return (global as Record<string, unknown>)[
+    ROUTING_EMITTERS_KEY
+  ] as RoutingEmits;
+}
+
+function initializeRoutingGlobals(): void {
+  const globals = global as Record<string, unknown>;
+  globals[ROUTING_RESULTS_KEY] = {};
+  globals[ROUTING_CLOSURES_KEY] = {};
+  globals[ROUTING_REGISTRATIONS_KEY] = { a: [], b: [] };
+  globals[ROUTING_EMITTERS_KEY] = {};
+  globals[ROUTING_EVENTS_KEY] = {
+    "consumer-a": [],
+    "consumer-b": [],
+    "consumer-default": [],
+    "consumer-reloaded": [],
+  };
+}
+
 async function destroyProject(
   manager: ModuleManager | undefined,
   folder: string,
@@ -227,6 +277,10 @@ async function destroyProject(
     await manager.destroyAll();
   }
   delete (global as Record<string, unknown>)[ROUTING_RESULTS_KEY];
+  delete (global as Record<string, unknown>)[ROUTING_CLOSURES_KEY];
+  delete (global as Record<string, unknown>)[ROUTING_REGISTRATIONS_KEY];
+  delete (global as Record<string, unknown>)[ROUTING_EMITTERS_KEY];
+  delete (global as Record<string, unknown>)[ROUTING_EVENTS_KEY];
   await fs.rm(folder, { recursive: true, force: true });
 }
 
@@ -234,7 +288,7 @@ describe("provider-aware runtime", () => {
   it("routes explicit and default providers independently of construct timing", async function () {
     this.timeout(20000);
     const project = await createRoutingProject();
-    (global as Record<string, unknown>)[ROUTING_RESULTS_KEY] = {};
+    initializeRoutingGlobals();
     let manager: ModuleManager | undefined;
     try {
       manager = await launch(project.folder);
@@ -271,6 +325,32 @@ describe("provider-aware runtime", () => {
         provider: "provider-a",
         selected: true,
       });
+      expect(await routingClosures()["consumer-a"]()).to.include({
+        value: "a",
+        module: "provider-a",
+      });
+      expect(await routingClosures()["consumer-b"]()).to.include({
+        value: "b",
+        module: "provider-b",
+      });
+      expect(
+        (global as Record<string, any>)[ROUTING_REGISTRATIONS_KEY],
+      ).to.deep.equal({
+        a: [
+          ["shared", "consumer-default"],
+          ["shared", "consumer-a"],
+        ],
+        b: [["shared", "consumer-b"]],
+      });
+      routingEmitters().a("event-a");
+      routingEmitters().b("event-b");
+      expect(
+        (global as Record<string, any>)[ROUTING_EVENTS_KEY],
+      ).to.deep.include({
+        "consumer-a": ["event-a"],
+        "consumer-b": ["event-b"],
+        "consumer-default": ["event-a"],
+      });
     } finally {
       await destroyProject(manager, project.folder);
     }
@@ -279,7 +359,7 @@ describe("provider-aware runtime", () => {
   it("updates a selected provider through the hot-reload replacement path", async function () {
     this.timeout(20000);
     const project = await createRoutingProject();
-    (global as Record<string, unknown>)[ROUTING_RESULTS_KEY] = {};
+    initializeRoutingGlobals();
     let manager: ModuleManager | undefined;
     try {
       manager = await launch(project.folder);
@@ -322,13 +402,17 @@ describe("provider-aware runtime", () => {
     );
     require(copiedCore);
     const project = await createRoutingProject(copiedCore);
-    (global as Record<string, unknown>)[ROUTING_RESULTS_KEY] = {};
+    initializeRoutingGlobals();
     let manager: ModuleManager | undefined;
     try {
       manager = await launch(project.folder);
       expect(routingResults()["consumer-a"]).to.include({
         value: "a",
         module: "provider-a",
+      });
+      expect(await routingClosures()["consumer-b"]()).to.include({
+        value: "b",
+        module: "provider-b",
       });
     } finally {
       await destroyProject(manager, project.folder);


### PR DESCRIPTION
## Summary

- resolve each interface import to a provider-bound CommonJS graph while keeping the protocol package canonical
- make implementors self-bind to the interface they implement, independently from consumer import overrides
- isolate explicit and anonymous `AsyncProxy`, `RegisteringProxy`, and `EventProxy` identities per provider
- preserve provider routing through relative/subpath imports, deferred closures, HMR replacements, compatible preloaded core copies, and concurrent resolver leases
- clear synthetic resolver cache entries when their resolver detaches

## Why

A single cached interface package instance shared proxy state across providers. Import overrides could therefore select the right provider in metadata while calls still reached whichever implementation last attached to the shared proxy graph.

The resolver now gives every `(interface package, provider)` pair a stable cache identity. The whole interface package graph inherits that identity, while a synthetic `interface-core` facade namespaces its proxy identities without changing the canonical protocol implementation.

## Verification

- `pnpm lint`
- `pnpm build`
- `pnpm test:unit` — 673 passing
- `pnpm test:package-consumer`
- `pnpm test:playground`
- focused provider-routing qualification on Node 22, 24, and 26
- real built `@antelopejs/interface-auth` qualification with two providers, direct `ValidateRaw` calls, and deferred `CheckAuthentication` closures

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces provider-specific CommonJS identities for interface-package graphs so consumers and implementors bind to their selected providers without sharing proxy state.
- Adds provider-aware aliases and synthetic `interface-core` facades for proxy identity isolation.
- Extends the process-level resolver detour to intercept module loading and select the resolver that owns each import context.
- Clears synthetic cache entries when resolver leases detach.
- Expands unit and integration coverage for concurrent resolvers, deferred imports, registrations, events, preloaded core copies, and provider routing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no concrete blocking or independently actionable issue was established in the changed paths.

Provider-specific aliases, facade identities, resolver ownership, and cleanup are coherently implemented and covered by focused unit and integration tests without an accepted failure scenario.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/core/resolution/resolver.ts | Adds provider-bound interface aliases, inherited graph resolution, synthetic core facades, and cache cleanup; no actionable defect was established. |
| src/core/resolution/resolver-detour.ts | Adds loader interception, context-aware lease selection, dual-hook ownership checks, and resolver cache cleanup. |
| test/core/resolution/resolver-detour.test.ts | Adds coverage ensuring concurrent detours select the resolver that owns the requesting module. |
| test/core/resolution/resolver.test.ts | Adds coverage confirming interface graph paths remain unique across concurrent resolver instances. |
| test/integration/provider-routing.test.ts | Broadens provider-routing coverage across deferred closures, registrations, events, relative imports, and compatible preloaded core copies. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Managed module imports interface] --> B[Resolver detour selects owning resolver]
  B --> C[Resolve selected provider]
  C --> D[Assign provider-specific interface alias]
  D --> E[Load aliased interface graph]
  E --> F[Synthetic interface-core facade]
  F --> G[Namespaced proxy identities]
  G --> H[Calls and events reach selected provider]
```

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): bind interface imports to ..."](https://github.com/antelopejs/antelopejs/commit/518e1e100b3b3eedeab8163e73a91c5559e57106) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57888260)</sub>

**Context used:**

- Knowledge Base — [Dependency and interface resolution](https://app.greptile.com/altab-srl/-/custom-context/knowledge-base/antelopejs/antelopejs/-/docs/dependency-resolution.md)
- Knowledge Base — [Interface and package resolution](https://app.greptile.com/altab-srl/-/custom-context/knowledge-base/antelopejs/antelopejs/-/docs/interface-and-package-resolution.md)

<!-- /greptile_comment -->