### PR TITLE
fix(config): canonicalize interface-core config imports

### DIFF
--- a/src/core/config/config-loader.ts
+++ b/src/core/config/config-loader.ts
@@ -16,6 +16,9 @@ import {
   getModuleConfigPath,
 } from "./config-paths";
 
+const CORE_CONFIG_PACKAGE = "@antelopejs/interface-core/config";
+const CORE_CONFIG_ENTRY = require.resolve(CORE_CONFIG_PACKAGE);
+
 export interface LoadedConfig {
   name: string;
   cacheFolder: string;
@@ -29,7 +32,9 @@ export async function loadTsConfigFile(
   configPath: string,
   environment?: string,
 ): Promise<AntelopeConfig> {
-  const jiti = createJiti(configPath);
+  const jiti = createJiti(configPath, {
+    alias: { [CORE_CONFIG_PACKAGE]: CORE_CONFIG_ENTRY },
+  });
   const loaded = await jiti.import(configPath);
   const configInput: ConfigInput = (loaded as any).default ?? loaded;
 

--- a/test/core/config/config-loader.test.ts
+++ b/test/core/config/config-loader.test.ts
@@ -1,3 +1,6 @@
+import { promises as nodeFs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { AntelopeConfig } from "@antelopejs/interface-core/config";
 import { expect } from "chai";
 import sinon from "sinon";
@@ -262,5 +265,47 @@ describe("ConfigLoader", () => {
         expect(error.message).to.include("antelope.config.ts");
       }
     });
+  });
+});
+
+describe("loadTsConfigFile", () => {
+  it("loads the recommended config helper from the core copy", async () => {
+    const root = await nodeFs.mkdtemp(path.join(os.tmpdir(), "ajs-config-"));
+    const packageRoot = path.join(
+      root,
+      "node_modules",
+      "@antelopejs",
+      "interface-core",
+    );
+    const sourceRoot = path.dirname(
+      require.resolve("@antelopejs/interface-core/package.json"),
+    );
+    const configPath = path.join(root, "antelope.config.ts");
+
+    try {
+      await nodeFs.mkdir(path.dirname(packageRoot), { recursive: true });
+      await nodeFs.cp(sourceRoot, packageRoot, { recursive: true });
+      await nodeFs.writeFile(
+        configPath,
+        `import { defineConfig } from "@antelopejs/interface-core/config";
+export default defineConfig({
+  name: require.resolve("@antelopejs/interface-core/config"),
+  modules: {},
+});`,
+      );
+
+      const loaded = await configLoader.loadTsConfigFile(configPath);
+
+      expect(loaded.name).to.equal(
+        require.resolve("@antelopejs/interface-core/config"),
+      );
+      expect(
+        Object.keys(require.cache).some((entry) =>
+          entry.startsWith(packageRoot),
+        ),
+      ).to.equal(false);
+    } finally {
+      await nodeFs.rm(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- resolve the recommended `@antelopejs/interface-core/config` import through Core's own interface-core copy while Jiti evaluates TypeScript configs
- prevent config evaluation from preloading a second physical copy before the runtime resolver has established canonical package roots
- retain the existing semver validation and preloaded-copy rejection for every other import/copy
- add a regression test with two physical, identical interface-core installations

## Root cause

The module test runner loads its TypeScript config before creating `ModuleManager`. Jiti therefore resolved the recommended `defineConfig` import from the tested module's local dependency tree. Later, Core selected its provider-side interface-core copy as canonical and `findPreloadedCopyErrors()` correctly observed that the local copy was already in `require.cache`, but incorrectly attributed that runner-created preload to unsafe application code.

The fix aliases only the documented config helper import during config evaluation. It does not clear `require.cache`, suppress preloaded-copy diagnostics, or change interface package ranges. Arbitrary interface imports that occur before canonicalization remain detectable.

## Reproduction

The regression fixture creates a separate physical `@antelopejs/interface-core` under a temporary test project and evaluates an `antelope.config.ts` that imports `defineConfig`. Before this change, Jiti loads the project copy. After this change, both the import and `require.resolve` identify Core's copy and no project-copy entry reaches `require.cache`.

This addresses the false positive seen while testing auth-jwt with modernized fixtures. The separate genuine incompatibility remains: `@antelopejs/api@1.0.0`, `@antelopejs/mongodb@1.0.0`, and `@antelopejs/database-decorators@1.0.0` still declare old 0.0.2 interface ranges and must be updated in auth-jwt rather than bypassed here.

## Validation

- `pnpm exec mocha --require ts-node/register --require test/setup.ts test/core/config/config-loader.test.ts test/core/module-manager.test.ts --exit` (674 passing due repository test setup loading the suite)
- `pnpm test:unit` (674 passing)
- `pnpm run lint` (passes; two existing warnings and one existing info)
- `pnpm run build`
- `pnpm test:package-consumer`
- `pnpm test:playground` attempted; existing workspace resolution failure: `playground/test-playground.ts` cannot resolve `@antelopejs/core` after playground install


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR canonicalizes the documented interface-core configuration-helper import while Jiti evaluates TypeScript configuration files.

- Resolves Core's interface-core configuration entry once and aliases the documented import to that entry.
- Adds a regression test with a separate physical interface-core installation and verifies that the project-local copy is not preloaded.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The alias targets the documented configuration-helper import, preserves normal loading behavior for other imports, and the regression test verifies that the duplicate project copy is not preloaded.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/core/config/config-loader.ts | Canonicalizes the documented interface-core configuration import through Core's resolved package entry during Jiti evaluation; no actionable defect was identified. |
| test/core/config/config-loader.test.ts | Adds an isolated two-copy regression test that verifies both canonical resolution and absence of the project-local package in require.cache. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[TypeScript project config] --> B[Jiti evaluation]
    B -->|alias documented config import| C[Core interface-core config entry]
    C --> D[Evaluated Antelope configuration]
    D --> E[Runtime module resolution]
```

<sub>Reviews (1): Last reviewed commit: ["fix(config): canonicalize interface-core..."](https://github.com/antelopejs/antelopejs/commit/364ca5e32d01e812be7d8277b224daa290e39d53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58237040)</sub>

<!-- /greptile_comment -->