### PR TITLE
fix(runtime): canonicalize interface declarations

### DIFF
--- a/src/core/module-manager.ts
+++ b/src/core/module-manager.ts
@@ -294,6 +294,7 @@ export class ModuleManager {
     const leaseAcquired = this.resolverDetour.attach();
     const modules = [...this.loaded.values()];
     try {
+      this.configureModuleContexts();
       this.validateInterfacePackages();
       this.applyInterfaceStubs();
     } catch (error) {
@@ -335,6 +336,7 @@ export class ModuleManager {
   async constructModules(modules: ManagedModule[]): Promise<void> {
     const leaseAcquired = this.resolverDetour.attach();
     try {
+      this.configureModuleContexts();
       this.validateInterfacePackages();
       this.applyInterfaceStubs();
       await Promise.all(
@@ -481,7 +483,6 @@ export class ModuleManager {
   private rebuildAssociations(): void {
     const interfaceSources = this.collectInterfaceSources();
     this.buildModuleAssociations(interfaceSources);
-    this.configureModuleContexts();
   }
 
   private collectInterfaceSources(): Map<string, Module[]> {

--- a/test/core/module-manager.test.ts
+++ b/test/core/module-manager.test.ts
@@ -67,6 +67,7 @@ async function writeInterfacePackage(
   packageRoot: string,
   packageName: string,
   version: string,
+  source = `module.exports = ${JSON.stringify(version)};`,
 ): Promise<void> {
   await mkdir(path.join(packageRoot, "dist"), { recursive: true });
   await writeFile(
@@ -78,10 +79,7 @@ async function writeInterfacePackage(
       antelopeJs: {},
     }),
   );
-  await writeFile(
-    path.join(packageRoot, "dist", "index.js"),
-    `module.exports = ${JSON.stringify(version)};`,
-  );
+  await writeFile(path.join(packageRoot, "dist", "index.js"), source);
 }
 
 async function createResolutionFixture(
@@ -166,6 +164,124 @@ async function createResolutionManager(
     sinon.stub(module, "construct").resolves();
   });
   return manager;
+}
+
+async function writeModulePackage(
+  folder: string,
+  name: string,
+  dependencies: Record<string, string>,
+  implementedInterface?: string,
+): Promise<void> {
+  await mkdir(folder, { recursive: true });
+  await writeFile(
+    path.join(folder, "package.json"),
+    JSON.stringify({
+      name,
+      version: "1.0.0",
+      dependencies,
+      antelopeJs: implementedInterface
+        ? { implements: [implementedInterface] }
+        : undefined,
+    }),
+  );
+}
+
+interface NestedInterfacePaths {
+  parentProvider: string;
+  childProvider: string;
+  consumer: string;
+  parentRoot: string;
+  localChildRoot: string;
+  canonicalChildRoot: string;
+}
+
+interface NestedInterfaceFixture {
+  root: string;
+  modulePaths: string[];
+  noncanonicalEntry: string;
+}
+
+function createNestedInterfacePaths(root: string): NestedInterfacePaths {
+  const parentProvider = path.join(root, "parent-provider");
+  const childProvider = path.join(root, "child-provider");
+  return {
+    parentProvider,
+    childProvider,
+    consumer: path.join(root, "consumer"),
+    parentRoot: path.join(parentProvider, "node_modules", "interface-parent"),
+    localChildRoot: path.join(
+      parentProvider,
+      "node_modules",
+      "interface-child",
+    ),
+    canonicalChildRoot: path.join(
+      childProvider,
+      "node_modules",
+      "interface-child",
+    ),
+  };
+}
+
+async function writeNestedModulePackages(
+  paths: NestedInterfacePaths,
+): Promise<void> {
+  await writeModulePackage(
+    paths.parentProvider,
+    "parent-provider",
+    { "interface-parent": "*", "interface-child": "*" },
+    "interface-parent",
+  );
+  await writeModulePackage(
+    paths.childProvider,
+    "child-provider",
+    { "interface-child": "*" },
+    "interface-child",
+  );
+  await writeModulePackage(paths.consumer, "consumer", {
+    "interface-parent": "*",
+  });
+}
+
+async function writeNestedInterfacePackages(
+  paths: NestedInterfacePaths,
+): Promise<void> {
+  await writeInterfacePackage(
+    paths.parentRoot,
+    "interface-parent",
+    "1.0.0",
+    'module.exports = require("interface-child");',
+  );
+  await writeInterfacePackage(paths.localChildRoot, "interface-child", "1.0.0");
+  await writeInterfacePackage(
+    paths.canonicalChildRoot,
+    "interface-child",
+    "1.0.0",
+  );
+}
+
+async function createNestedInterfaceFixture(): Promise<NestedInterfaceFixture> {
+  const root = await mkdtemp(path.join(tmpdir(), "ajs-interface-nested-"));
+  const paths = createNestedInterfacePaths(root);
+  await writeNestedModulePackages(paths);
+  await writeNestedInterfacePackages(paths);
+  return {
+    root,
+    modulePaths: [paths.parentProvider, paths.childProvider, paths.consumer],
+    noncanonicalEntry: path.join(paths.localChildRoot, "dist", "index.js"),
+  };
+}
+
+async function createLocalManifest(folder: string): Promise<ModuleManifest> {
+  const source: ModuleSourceLocal = { type: "local", path: folder };
+  return ModuleManifest.create(folder, source, path.basename(folder));
+}
+
+function clearRequireCacheWithin(root: string): void {
+  Object.keys(require.cache)
+    .filter((entry) => entry.startsWith(root))
+    .forEach((entry) => {
+      delete require.cache[entry];
+    });
 }
 
 describe("ModuleManager", () => {
@@ -658,6 +774,7 @@ describe("ModuleManager", () => {
   it("waits for sibling constructs and aggregates rollback errors", async () => {
     const calls: string[] = [];
     const manager = new ModuleManager();
+    sinon.stub(manager as any, "configureModuleContexts");
     const detour = (manager as any).resolverDetour;
     const detach = sinon.stub(detour, "detach");
     sinon.stub(detour, "attach").returns(true);
@@ -892,6 +1009,30 @@ describe("ModuleManager", () => {
       ).to.equal(path.join(fixture.providerPackageRoot, "dist", "index.js"));
       await manager.destroyAll();
     } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("canonicalizes nested interface imports while preparing routes", async () => {
+    const fixture = await createNestedInterfaceFixture();
+    try {
+      const manifests = await Promise.all(
+        fixture.modulePaths.map(createLocalManifest),
+      );
+      const manager = new ModuleManager();
+      const modules = manager.addModules(
+        manifests.map((manifest) => ({ manifest })),
+      );
+      modules.forEach(({ module }) => {
+        sinon.stub(module, "construct").resolves();
+      });
+
+      await manager.constructAll();
+
+      expect(require.cache[fixture.noncanonicalEntry]).to.equal(undefined);
+      await manager.destroyAll();
+    } finally {
+      clearRequireCacheWithin(fixture.root);
       await rm(fixture.root, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary

- prepare module provider contexts only after the resolver detour is attached
- canonicalize nested imports made while Core inspects interface declarations
- preserve semver validation and rejection of genuinely preloaded noncanonical copies
- add a regression graph with a parent interface that imports a second interface from a different physical installation

## Root cause

Core 1.4.9 canonicalizes the documented `@antelopejs/interface-core/config` import while Jiti evaluates configuration, but `ModuleManager.addModules()` still prepared provider routes before `constructAll()` attached the runtime resolver.

Preparing a route requires the canonical parent interface declaration. If that declaration imports another interface, Node resolved the nested import from the parent provider's local dependency tree. Core then selected the second interface's provider copy as canonical and rejected the local copy that Core itself had preloaded.

Context preparation now runs inside `constructAll()` and `constructModules()`, immediately after resolver attachment and before compatibility validation. Metadata associations remain available after `addModules()`, while declaration execution uses the same canonical resolver and provider identities as module construction.

## Reproduction

The regression fixture creates:

- a parent provider implementing `interface-parent`;
- a child provider implementing `interface-child`;
- a consumer of `interface-parent`;
- separate physical copies of `interface-child` under both providers;
- an `interface-parent` declaration that imports `interface-child`.

Before this change, route preparation preloads the parent provider's child copy and construction fails with `preloaded interface copies cannot be redirected`. After this change, the nested import resolves to the selected child provider and the noncanonical entry never reaches `require.cache`.

This also allows the real auth-jwt module tests to construct with current API fixtures after removing their separate obsolete MongoDB/database-decorators fixtures.

## Validation

- `pnpm test:unit` — 675 passing
- `pnpm lint` — passes with two existing warnings and one existing info
- `pnpm build`
- `pnpm test:package-consumer`
- `pnpm test:playground` — all three phases pass
- real auth-jwt module suite against the built Core change — 4 passing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves module-context route preparation under the active resolver detour so nested interface declarations resolve through canonical provider packages.

- Configures provider contexts immediately before interface validation and stub application in both full and subset construction.
- Leaves association rebuilding responsible only for collecting sources and rebuilding associations.
- Adds a regression fixture with nested interface imports from separate physical installations and verifies that the noncanonical copy is not loaded.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

Context preparation now executes while canonical resolution is active, and the examined startup, dynamic-load, replacement, retry, and cleanup flows continue to prepare routes before lifecycle callbacks consume them.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/core/module-manager.ts | Moves context preparation into resolver-scoped construction while preserving validation, stubbing, construction, and cleanup ordering. |
| test/core/module-manager.test.ts | Adds reusable filesystem fixture helpers and regression coverage proving nested interface imports avoid loading a noncanonical package copy. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant Manager as ModuleManager
    participant Detour as Resolver Detour
    participant Context as Module Contexts
    participant Node as Node Resolver
    Caller->>Manager: constructAll / constructModules
    Manager->>Detour: attach()
    Manager->>Context: configureModuleContexts()
    Context->>Node: load nested interface declaration
    Node->>Detour: resolve interface import
    Detour-->>Node: canonical provider package
    Manager->>Manager: validate packages and apply stubs
    Manager->>Manager: construct modules
```

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): canonicalize interface dec..."](https://github.com/antelopejs/antelopejs/commit/f46ed6e464282582de821e1911c3f12013991386) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58245095)</sub>

<!-- /greptile_comment -->