### PR TITLE
fix(deps): require interface-core 0.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:coverage": "c8 --check-coverage --lines 90 --functions 90 --branches 90 --statements 90 mocha --require ts-node/register --require test/setup.ts 'test/**/*.test.ts' --exit"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.11",
+    "@antelopejs/interface-core": "^0.0.12",
     "@types/proper-lockfile": "^4.1.4",
     "boxen": "^8.0.1",
     "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:coverage": "c8 --check-coverage --lines 90 --functions 90 --branches 90 --statements 90 mocha --require ts-node/register --require test/setup.ts 'test/**/*.test.ts' --exit"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.12",
+    "@antelopejs/interface-core": ">=0.0.12 <1.0.0",
     "@types/proper-lockfile": "^4.1.4",
     "boxen": "^8.0.1",
     "chalk": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.12
+        specifier: '>=0.0.12 <1.0.0'
         version: 0.0.12
       '@types/proper-lockfile':
         specifier: ^4.1.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.11
-        version: 0.0.11
+        specifier: ^0.0.12
+        version: 0.0.12
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
@@ -128,8 +128,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.11':
-    resolution: {integrity: sha512-eKE3F9XY0eIzdLBXms8QAY4BHmA8+XXZnta0vZ411q9GiSbI2S1Q3lfYzmnXU4ZK9i+/SIYPplOsA02gIdxODg==}
+  '@antelopejs/interface-core@0.0.12':
+    resolution: {integrity: sha512-SuHSQXOFEa04JEErN3PprdwT/jrtXGP6Eiwrk19wZ9QRSjaYkq54xpwFnq9NkYh3BG2EdNmIB9CIwadiCZUsaw==}
 
   '@antelopejs/interface-core@0.0.6':
     resolution: {integrity: sha512-OMna86iT/ylL6wJl6FCPw9ieddULXGs4jTmeiDBNEXYQ9acnVXjS/+SaN0UR0h7oY7WTD9VwKXVwG95qjNIA1w==}
@@ -1789,7 +1789,7 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.11':
+  '@antelopejs/interface-core@0.0.12':
     dependencies:
       reflect-metadata: 0.2.2
 

--- a/test/integration/provider-routing.test.ts
+++ b/test/integration/provider-routing.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   GetInterfaceProxyIdentity,
+  GetRuntimeInfo,
   ImplementInterface,
   InterfaceFunction,
 } from "@antelopejs/interface-core";
@@ -21,6 +22,8 @@ const ROUTING_REGISTRATIONS_KEY = "__antelopeProviderRoutingRegistrations";
 const ROUTING_EMITTERS_KEY = "__antelopeProviderRoutingEmitters";
 const ROUTING_EVENTS_KEY = "__antelopeProviderRoutingEvents";
 const INTERFACE_NAME = "routing-interface";
+const CORE_INTERFACE_NAME = "@antelopejs/interface-core";
+const CORE_PROVIDER_ID = "antelopejs";
 const STRESS_ITERATIONS = 40;
 
 interface RoutingResult {
@@ -529,6 +532,23 @@ describe("provider-aware runtime", () => {
         },
       ]),
     ).to.throw(/resolves proxy.+both.+provider-a.+provider-b/);
+  });
+
+  it("discovers core runtime routes from the package root", () => {
+    const runtimeInfo = GetRuntimeInfo as unknown as RoutedFunction;
+    const runtimeInfoIdentity = GetInterfaceProxyIdentity(runtimeInfo.proxy);
+    const providerRoutes = buildProviderRoutes("api", [
+      {
+        interfaceName: CORE_INTERFACE_NAME,
+        packageEntry: require.resolve(CORE_INTERFACE_NAME),
+        provider: CORE_PROVIDER_ID,
+        providerCount: 1,
+      },
+    ]);
+
+    expect(providerRoutes[runtimeInfoIdentity as string]).to.equal(
+      CORE_PROVIDER_ID,
+    );
   });
 
   it("rejects an override whose module does not provide the interface", async () => {

--- a/test/package-consumer/run.ts
+++ b/test/package-consumer/run.ts
@@ -36,8 +36,8 @@ function packCore(): string {
 function inspectManifest(tarball: string): void {
   const content = run("tar", ["-xOf", tarball, "package/package.json"], root);
   const manifest = JSON.parse(content) as PackedManifest;
-  if (manifest.dependencies?.["@antelopejs/interface-core"] !== "^0.0.11") {
-    throw new Error("Packed core does not depend on interface-core ^0.0.11.");
+  if (manifest.dependencies?.["@antelopejs/interface-core"] !== "^0.0.12") {
+    throw new Error("Packed core does not depend on interface-core ^0.0.12.");
   }
   if (/github:AntelopeJS\/interface-core|patches\//.test(content)) {
     throw new Error(
@@ -54,7 +54,7 @@ function installConsumer(tarball: string): void {
       private: true,
       dependencies: {
         "@antelopejs/core": `file:${tarball}`,
-        "@antelopejs/interface-core": "0.0.11",
+        "@antelopejs/interface-core": "0.0.12",
         "reflect-metadata": "0.2.2",
       },
     }),

--- a/test/package-consumer/run.ts
+++ b/test/package-consumer/run.ts
@@ -36,8 +36,12 @@ function packCore(): string {
 function inspectManifest(tarball: string): void {
   const content = run("tar", ["-xOf", tarball, "package/package.json"], root);
   const manifest = JSON.parse(content) as PackedManifest;
-  if (manifest.dependencies?.["@antelopejs/interface-core"] !== "^0.0.12") {
-    throw new Error("Packed core does not depend on interface-core ^0.0.12.");
+  if (
+    manifest.dependencies?.["@antelopejs/interface-core"] !== ">=0.0.12 <1.0.0"
+  ) {
+    throw new Error(
+      "Packed core does not support compatible interface-core 0.x releases.",
+    );
   }
   if (/github:AntelopeJS\/interface-core|patches\//.test(content)) {
     throw new Error(


### PR DESCRIPTION
## Summary
- require `@antelopejs/interface-core` through the controlled range `>=0.0.12 <1.0.0`, keeping 0.0.12 as the minimum while allowing compatible 0.x releases without a Core release
- keep the lockfile and packed-consumer fixture resolved to the minimum supported 0.0.12 release
- add a regression test proving the Core runtime proxy is discovered from the canonical package root

## Why
Core 1.4.9 currently requires `^0.0.11`, which excludes 0.0.12 under pre-1.0 semver. With 0.0.11, API can log `GetRuntimeInfo has no provider for route api` and fail to start its listening server even though auth-jwt's assertions still pass. Interface-core 0.0.12 fixes the declaration surface by re-exporting the existing canonical runtime/module proxies from the package root.

The explicit `<1.0.0` upper bound establishes the same compatibility policy already used by AntelopeJS interface consumers: compatible interface-core 0.x releases do not require a Core release; a breaking interface-core change must move to 1.0.0.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm test` — 676 unit tests, packed consumer, and playground phases pass
- `PATH=/tmp/node22-runtime/node_modules/.bin:$PATH pnpm test:coverage` — 94.69% statements/lines, 92.31% branches, 92.44% functions
- `pnpm pack`
- packed Core candidate + registry `interface-core@0.0.12` + auth-jwt integration — API server starts, 4 JWT tests pass, no runtime warning/error
- range contract check — rejects 0.0.11 and 1.0.0; accepts 0.0.12 and later 0.x releases

`@antelopejs/interface-core@0.0.12` is already published on npm.