### PR TITLE
feat(embedded): run the runtime as a guest of another framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,12 +43,13 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "test": "pnpm test:unit && pnpm test:package-consumer && pnpm test:playground",
+    "test": "pnpm test:unit && pnpm test:embedded && pnpm test:package-consumer && pnpm test:playground",
     "test:unit": "mocha --require ts-node/register --require test/setup.ts 'test/**/*.test.ts' --exit",
     "test:package-consumer": "pnpm build && ts-node test/package-consumer/run.ts",
     "test:playground": "pnpm build && pnpm --dir playground install && ts-node playground/test-playground.ts",
     "test:watch": "mocha --require ts-node/register --require test/setup.ts --watch --watch-extensions ts 'test/**/*.test.ts'",
-    "test:coverage": "c8 --check-coverage --lines 90 --functions 90 --branches 90 --statements 90 mocha --require ts-node/register --require test/setup.ts 'test/**/*.test.ts' --exit"
+    "test:coverage": "c8 --check-coverage --lines 90 --functions 90 --branches 90 --statements 90 mocha --require ts-node/register --require test/setup.ts 'test/**/*.test.ts' --exit",
+    "test:embedded": "pnpm build && ts-node test/embedded/run.ts"
   },
   "dependencies": {
     "@antelopejs/interface-core": ">=0.0.12 <1.0.0",

--- a/src/core/cli/terminal-display.ts
+++ b/src/core/cli/terminal-display.ts
@@ -3,6 +3,19 @@ import { Spinner } from "./cli-ui";
 export class TerminalDisplay {
   private currentSpinner?: Spinner;
   private currentSpinnerTexts: string[] = [];
+  private silent = false;
+
+  setSilent(silent: boolean): void {
+    this.silent = silent;
+    if (silent) {
+      this.currentSpinnerTexts = [];
+      this.destroySpinner();
+    }
+  }
+
+  isSilent(): boolean {
+    return this.silent;
+  }
 
   private updateSpinnerText(): void {
     if (this.currentSpinnerTexts.length > 0) {
@@ -40,6 +53,9 @@ export class TerminalDisplay {
   }
 
   async startSpinner(text: string): Promise<void> {
+    if (this.silent) {
+      return;
+    }
     this.currentSpinnerTexts.push(text);
 
     if (!this.currentSpinner) {

--- a/src/core/embedded/host-module.ts
+++ b/src/core/embedded/host-module.ts
@@ -1,0 +1,7 @@
+export async function construct(): Promise<void> {}
+
+export async function start(): Promise<void> {}
+
+export async function stop(): Promise<void> {}
+
+export async function destroy(): Promise<void> {}

--- a/src/core/embedded/prepare-embedded.ts
+++ b/src/core/embedded/prepare-embedded.ts
@@ -1,0 +1,136 @@
+import path from "node:path";
+import type { ModuleSource } from "@antelopejs/interface-core/config";
+import { NodeFileSystem } from "../filesystem";
+import { ModuleManifest } from "../module-manifest";
+import { resolvePackage } from "../resolution/package-resolution";
+import { memoizeLoaderContext } from "../runtime/launch-sequence";
+import {
+  buildModuleOverrides,
+  createLoaderContext,
+} from "../runtime/module-loading";
+import type {
+  ModuleManifestEntry,
+  ProjectPreparer,
+} from "../runtime/runtime-types";
+import type { EmbeddedModuleConfig, EmbeddedRuntimeOptions } from "./types";
+
+export const HOST_MODULE_ID = "__antelope_host__";
+export const HOST_MODULE_VERSION = "0.0.0";
+
+const HOST_FOLDER_SEGMENTS = [".antelope", "host"];
+const HOST_MODULE_ENTRY = path.join(__dirname, "host-module");
+const EMBEDDED_CACHE_SEGMENTS = [".antelope", "embedded-cache"];
+const HOST_DEPENDENCY_RANGE = "latest";
+
+export function getHostModuleFolder(projectFolder: string): string {
+  return path.join(projectFolder, ...HOST_FOLDER_SEGMENTS);
+}
+
+function resolveModuleFolder(name: string, projectFolder: string): string {
+  const resolved = resolvePackage(name, projectFolder);
+  if (!resolved) {
+    throw new Error(
+      `Embedded module '${name}' could not be resolved from '${projectFolder}'. Install it as a dependency of the host application.`,
+    );
+  }
+  return resolved.realRoot;
+}
+
+function getModuleFolder(
+  name: string,
+  moduleConfig: EmbeddedModuleConfig,
+  projectFolder: string,
+): string {
+  if (!moduleConfig.path) {
+    return resolveModuleFolder(name, projectFolder);
+  }
+  return path.resolve(projectFolder, moduleConfig.path);
+}
+
+function buildEntryConfig(
+  moduleConfig: EmbeddedModuleConfig,
+): ModuleManifestEntry["config"] {
+  return {
+    config: moduleConfig.config,
+    importOverrides: buildModuleOverrides(moduleConfig.importOverrides),
+    disabledExports: new Set(moduleConfig.disabledExports ?? []),
+  };
+}
+
+function createHostEntry(
+  projectFolder: string,
+  options: EmbeddedRuntimeOptions,
+): ModuleManifestEntry {
+  const folder = getHostModuleFolder(projectFolder);
+  const source: ModuleSource = { type: "local", id: HOST_MODULE_ID };
+  const provides = options.provides ?? [];
+  const declared = [...new Set([...(options.uses ?? []), ...provides])];
+  const dependencies = Object.fromEntries(
+    declared.map((interfacePackage) => [
+      interfacePackage,
+      HOST_DEPENDENCY_RANGE,
+    ]),
+  );
+
+  const manifest = ModuleManifest.fromBuildEntry({
+    folder,
+    source,
+    name: HOST_MODULE_ID,
+    version: HOST_MODULE_VERSION,
+    main: HOST_MODULE_ENTRY,
+    manifest: {
+      name: HOST_MODULE_ID,
+      version: HOST_MODULE_VERSION,
+      dependencies,
+      antelopeJs: { implements: provides },
+    },
+    implements: provides,
+    baseUrl: folder,
+    paths: [],
+  });
+
+  return { manifest, config: buildEntryConfig({}) };
+}
+
+async function createEmbeddedEntries(
+  options: EmbeddedRuntimeOptions,
+  projectFolder: string,
+  fs: NodeFileSystem,
+): Promise<ModuleManifestEntry[]> {
+  const modules = Object.entries(options.modules ?? {});
+  const entries = await Promise.all(
+    modules.map(async ([name, moduleConfig]) => {
+      const folder = getModuleFolder(name, moduleConfig, projectFolder);
+      const source: ModuleSource = { type: "local", id: name };
+      const manifest = await ModuleManifest.create(folder, source, name, fs);
+      return { manifest, config: buildEntryConfig(moduleConfig) };
+    }),
+  );
+
+  return [...entries, createHostEntry(projectFolder, options)];
+}
+
+export function prepareEmbedded(
+  options: EmbeddedRuntimeOptions,
+  projectFolder: string,
+): ProjectPreparer {
+  return async () => {
+    const fs = new NodeFileSystem();
+    return {
+      fs,
+      dev: false,
+      logging: options.logging,
+      loadContext: memoizeLoaderContext(() =>
+        createLoaderContext(
+          {
+            projectFolder,
+            cacheFolder: path.join(projectFolder, ...EMBEDDED_CACHE_SEGMENTS),
+          },
+          fs,
+        ),
+      ),
+      verify: async () => {},
+      createEntries: () => createEmbeddedEntries(options, projectFolder, fs),
+    };
+  };
+}

--- a/src/core/embedded/proxy-ownership.ts
+++ b/src/core/embedded/proxy-ownership.ts
@@ -1,0 +1,64 @@
+import {
+  getModuleContext,
+  internal,
+  type RuntimeCleanup,
+} from "@antelopejs/interface-core/internal";
+
+type OwnedProxy = RuntimeCleanup | { detach(): void };
+type OwnedProxyMap = Map<string, Set<OwnedProxy>>;
+
+const OWNERSHIP_MAPS: Array<(runtime: typeof internal) => OwnedProxyMap> = [
+  (runtime) => runtime.knownAsync,
+  (runtime) => runtime.knownRegisters,
+];
+
+function getOwnedProxies(owner: string): Set<OwnedProxy>[] {
+  return OWNERSHIP_MAPS.map(
+    (select) => select(internal).get(owner) ?? new Set<OwnedProxy>(),
+  );
+}
+
+function releaseProxy(proxy: OwnedProxy): void {
+  const cleanup = (proxy as RuntimeCleanup).cleanup;
+  if (typeof cleanup === "function") {
+    cleanup.call(proxy);
+    return;
+  }
+  (proxy as { detach(): void }).detach();
+}
+
+function forgetProxy(owner: string, proxy: OwnedProxy): void {
+  OWNERSHIP_MAPS.forEach((select) => {
+    select(internal).get(owner)?.delete(proxy);
+  });
+}
+
+export function captureOwnedProxies(attach: () => void): () => void {
+  const owner = getModuleContext()?.owner;
+  if (!owner) {
+    attach();
+    return () => {};
+  }
+
+  const before = getOwnedProxies(owner).map((proxies) => new Set(proxies));
+  attach();
+  const attached = getOwnedProxies(owner).flatMap((proxies, index) =>
+    [...proxies].filter((proxy) => !before[index].has(proxy)),
+  );
+
+  return () => {
+    const errors: unknown[] = [];
+    attached.forEach((proxy) => {
+      try {
+        releaseProxy(proxy);
+      } catch (error) {
+        errors.push(error);
+      }
+      forgetProxy(owner, proxy);
+    });
+    attached.length = 0;
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "Failed to release host registrations");
+    }
+  };
+}

--- a/src/core/embedded/runtime.ts
+++ b/src/core/embedded/runtime.ts
@@ -23,6 +23,16 @@ const attachImplementation = ImplementInterface as unknown as InterfaceAttacher;
 
 const Logger = new Logging.Channel("loader.embedded");
 
+function findInterfacePackage(
+  started: StartedProject,
+  request: string,
+): string | undefined {
+  return [...started.manager.resolver.interfacePackages.keys()].find(
+    (packageName) =>
+      request === packageName || request.startsWith(`${packageName}/`),
+  );
+}
+
 const NOT_STARTED_MESSAGE =
   "The embedded runtime has not been started. Call start() first.";
 
@@ -130,15 +140,15 @@ export class AntelopeRuntime {
     }
   }
 
-  /** Returns the runtime's own copy of an interface package, provider-bound for the host. */
-  use<T>(packageName: string): T {
+  /** Returns the runtime's own copy of an interface package or one of its subpaths, provider-bound for the host. */
+  use<T>(request: string): T {
     const started = this.requireStarted();
-    if (!started.manager.resolver.interfacePackages.has(packageName)) {
+    if (!findInterfacePackage(started, request)) {
       throw new Error(
-        `Interface '${packageName}' is not provided by any loaded module. Declare it in 'uses' and load a module that implements it.`,
+        `Interface '${request}' is not provided by any loaded module. Declare it in 'uses' and load a module that implements it.`,
       );
     }
-    return this.hostModule().runInContext(() => require(packageName) as T);
+    return this.hostModule().runInContext(() => require(request) as T);
   }
 
   /** Implements an interface from host code, released through the returned handle. */

--- a/src/core/embedded/runtime.ts
+++ b/src/core/embedded/runtime.ts
@@ -1,0 +1,182 @@
+import { ImplementInterface } from "@antelopejs/interface-core";
+import { Logging } from "@antelopejs/interface-core/logging";
+import { DEFAULT_ENV } from "../config/config-paths";
+import type { Module } from "../module";
+import type { ModuleManager } from "../module-manager";
+import { startProject } from "../runtime/project-launch";
+import {
+  EMBEDDED_RUNTIME_POLICY,
+  type RuntimePolicy,
+  resolveRuntimePolicy,
+} from "../runtime/runtime-policy";
+import type { StartedProject } from "../runtime/runtime-types";
+import { HOST_MODULE_ID, prepareEmbedded } from "./prepare-embedded";
+import { captureOwnedProxies } from "./proxy-ownership";
+import type { EmbeddedRuntimeOptions, ProvideHandle } from "./types";
+
+type InterfaceAttacher = (
+  declaration: Record<string, unknown>,
+  implementation: unknown,
+) => unknown;
+
+const attachImplementation = ImplementInterface as unknown as InterfaceAttacher;
+
+const Logger = new Logging.Channel("loader.embedded");
+
+const NOT_STARTED_MESSAGE =
+  "The embedded runtime has not been started. Call start() first.";
+
+/** An AntelopeJS runtime running as a guest inside a host that owns the process. */
+export class AntelopeRuntime {
+  private started?: StartedProject;
+  private pending?: Promise<StartedProject>;
+  private readonly projectFolder: string;
+  private readonly env: string;
+  private readonly policy: RuntimePolicy;
+
+  constructor(private readonly options: EmbeddedRuntimeOptions = {}) {
+    this.projectFolder = options.projectFolder ?? process.cwd();
+    this.env = options.env ?? DEFAULT_ENV;
+    this.policy = resolveRuntimePolicy(
+      { ...(options.logging ? { logging: true } : {}), ...options.policy },
+      EMBEDDED_RUNTIME_POLICY,
+    );
+  }
+
+  get manager(): ModuleManager {
+    return this.requireStarted().manager;
+  }
+
+  get isRunning(): boolean {
+    return this.started !== undefined;
+  }
+
+  /** Boots the runtime. Concurrent calls share a single launch. */
+  async start(): Promise<void> {
+    this.pending ??= this.launch();
+    try {
+      this.started = await this.pending;
+    } finally {
+      this.pending = undefined;
+    }
+  }
+
+  /** Shuts the runtime down, waiting for an in-flight start to settle first. */
+  async stop(): Promise<void> {
+    if (this.pending) {
+      await this.pending.catch(() => undefined);
+    }
+    const started = this.started;
+    if (!started) {
+      return;
+    }
+    this.started = undefined;
+    await started.shutdownManager.shutdown();
+  }
+
+  private async launch(): Promise<StartedProject> {
+    if (this.started) {
+      return this.started;
+    }
+    const started = await startProject(
+      prepareEmbedded(this.options, this.projectFolder),
+      this.projectFolder,
+      this.env,
+      {},
+      this.policy,
+    );
+    try {
+      this.verifyDeclaredInterfaces(started);
+      this.warnOnContestedProviders(started);
+    } catch (error) {
+      await started.shutdownManager.shutdown();
+      throw error;
+    }
+    return started;
+  }
+
+  private verifyDeclaredInterfaces(started: StartedProject): void {
+    const declared = [
+      ...(this.options.uses ?? []),
+      ...(this.options.provides ?? []),
+    ];
+    const missing = declared.filter(
+      (packageName) =>
+        !started.manager.resolver.interfacePackages.has(packageName),
+    );
+    if (missing.length > 0) {
+      throw new Error(
+        `Declared interfaces were not resolved: ${missing.join(", ")}. Check the package names, and that each is installed alongside a module that implements it.`,
+      );
+    }
+  }
+
+  private warnOnContestedProviders(started: StartedProject): void {
+    const provides = this.options.provides ?? [];
+    for (const { module, config } of started.manager.getLoadedModules()) {
+      if (module.id === HOST_MODULE_ID) {
+        continue;
+      }
+      const contested = (module.manifest.implements ?? []).filter(
+        (packageName) =>
+          provides.includes(packageName) &&
+          !config.disabledExports?.has(packageName),
+      );
+      if (contested.length > 0) {
+        Logger.Warn(
+          `Host and module '${module.id}' both provide ${contested.join(", ")}; the host is selected by default. Use importOverrides to route consumers to '${module.id}'.`,
+        );
+      }
+    }
+  }
+
+  /** Returns the runtime's own copy of an interface package, provider-bound for the host. */
+  use<T>(packageName: string): T {
+    const started = this.requireStarted();
+    if (!started.manager.resolver.interfacePackages.has(packageName)) {
+      throw new Error(
+        `Interface '${packageName}' is not provided by any loaded module. Declare it in 'uses' and load a module that implements it.`,
+      );
+    }
+    return this.hostModule().runInContext(() => require(packageName) as T);
+  }
+
+  /** Implements an interface from host code, released through the returned handle. */
+  provide(packageName: string, implementation: unknown): ProvideHandle {
+    if (!this.options.provides?.includes(packageName)) {
+      throw new Error(
+        `Interface '${packageName}' is not declared in 'provides', so nothing routes to a host implementation of it. Add it to 'provides' before calling provide().`,
+      );
+    }
+    const declaration = this.use<Record<string, unknown>>(packageName);
+    const release = this.hostModule().runInContext(() =>
+      captureOwnedProxies(() => {
+        attachImplementation(declaration, implementation);
+      }),
+    );
+    return { detach: release };
+  }
+
+  private hostModule(): Module {
+    const started = this.requireStarted();
+    const module = started.manager.getModule(HOST_MODULE_ID);
+    if (!module) {
+      throw new Error(NOT_STARTED_MESSAGE);
+    }
+    return module;
+  }
+
+  private requireStarted(): StartedProject {
+    if (!this.started) {
+      throw new Error(NOT_STARTED_MESSAGE);
+    }
+    return this.started;
+  }
+}
+
+/** Creates an AntelopeJS runtime that runs as a guest of the calling process. It is not started. */
+export function createRuntime(
+  options: EmbeddedRuntimeOptions = {},
+): AntelopeRuntime {
+  return new AntelopeRuntime(options);
+}

--- a/src/core/embedded/types.ts
+++ b/src/core/embedded/types.ts
@@ -1,0 +1,35 @@
+import type {
+  AntelopeLogging,
+  ImportOverride,
+} from "@antelopejs/interface-core/config";
+import type { RuntimePolicy } from "../runtime/runtime-policy";
+
+/** One module the embedded runtime should load, keyed by its package name. */
+export interface EmbeddedModuleConfig {
+  /** Absolute, or relative to the project folder. Defaults to the host's `node_modules`. */
+  path?: string;
+  config?: unknown;
+  importOverrides?: ImportOverride[];
+  disabledExports?: string[];
+}
+
+export interface EmbeddedRuntimeOptions {
+  /** Directory modules and relative paths resolve from. Defaults to `process.cwd()`. */
+  projectFolder?: string;
+  env?: string;
+  /** Modules to load, keyed by package name. */
+  modules?: Record<string, EmbeddedModuleConfig>;
+  /** Interface packages the host consumes. Each is verified at startup. */
+  uses?: string[];
+  /** Interface packages the host implements, registering it as their provider. */
+  provides?: string[];
+  /** Supplying this turns the `logging` policy on. Leave unset to keep the host's logger. */
+  logging?: AntelopeLogging;
+  /** Process responsibilities to reclaim from the host. All default to off. */
+  policy?: Partial<RuntimePolicy>;
+}
+
+/** A host registration that must be released explicitly. */
+export interface ProvideHandle {
+  detach(): void;
+}

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -57,6 +57,11 @@ export class Module {
     };
   }
 
+  /** Runs a callback under this module's execution context. */
+  runInContext<T>(callback: () => T): T {
+    return RunWithModuleContext(this.executionContext, callback);
+  }
+
   private updateProviderRoutes(
     providerRoutes: Readonly<Record<string, string>>,
   ): Readonly<Record<string, string>> {

--- a/src/core/runtime/launch-sequence.ts
+++ b/src/core/runtime/launch-sequence.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { setupAntelopeProjectLogging } from "../../logging";
 import type { LaunchOptions } from "../../types";
+import { terminalDisplay } from "../cli/terminal-display";
 import { NodeFileSystem } from "../filesystem";
 import { ModuleManager } from "../module-manager";
 import { ShutdownManager } from "../shutdown";
@@ -27,6 +28,7 @@ import {
   setupProcessHandlers,
   withRaisedMaxListeners,
 } from "./runtime-bootstrap";
+import { DEFAULT_RUNTIME_POLICY, type RuntimePolicy } from "./runtime-policy";
 import type {
   LoaderConfig,
   LoaderContext,
@@ -36,12 +38,22 @@ import type {
   StartedProject,
 } from "./runtime-types";
 
-function memoize(create: () => Promise<LoaderContext>): LoaderContextProvider {
+export function memoizeLoaderContext(
+  create: () => Promise<LoaderContext>,
+): LoaderContextProvider {
   let pending: Promise<LoaderContext> | undefined;
   return () => {
     pending ??= create();
     return pending;
   };
+}
+
+interface LaunchRequest {
+  prepare: ProjectPreparer;
+  projectFolder: string;
+  env: string;
+  options: LaunchOptions;
+  policy: RuntimePolicy;
 }
 
 function resolveRuntimeLoaderConfig(
@@ -77,7 +89,9 @@ export const prepareFromConfig: ProjectPreparer = async (
   env,
 ) => {
   const { fs, normalizedConfig } = await loadProjectConfig(projectFolder, env);
-  const loadContext = memoize(() => createLoaderContext(normalizedConfig, fs));
+  const loadContext = memoizeLoaderContext(() =>
+    createLoaderContext(normalizedConfig, fs),
+  );
 
   return {
     fs,
@@ -116,7 +130,9 @@ export const prepareFromArtifact: ProjectPreparer = async (
     fs,
     dev: false,
     logging: artifact.config.logging,
-    loadContext: memoize(() => createLoaderContext(loaderConfig, fs)),
+    loadContext: memoizeLoaderContext(() =>
+      createLoaderContext(loaderConfig, fs),
+    ),
     verify: async () => {
       logEnvironmentMismatch(env, artifact.env);
       await warnIfBuildIsStale(projectFolder, artifact, fs);
@@ -143,20 +159,25 @@ export async function runLaunchSequence(
   projectFolder: string,
   env: string,
   options: LaunchOptions,
+  policy: RuntimePolicy = DEFAULT_RUNTIME_POLICY,
 ): Promise<StartedProject> {
   const shutdownManager = new ShutdownManager();
   const manager = new ModuleManager();
-  setupProcessHandlers(shutdownManager);
+  const request: LaunchRequest = {
+    prepare,
+    projectFolder,
+    env,
+    options,
+    policy,
+  };
+  if (policy.processHandlers) {
+    setupProcessHandlers(shutdownManager);
+  }
 
+  const previouslySilent = terminalDisplay.isSilent();
+  terminalDisplay.setSilent(!policy.terminal);
   try {
-    return await completeLaunchSequence(
-      prepare,
-      projectFolder,
-      env,
-      options,
-      shutdownManager,
-      manager,
-    );
+    return await completeLaunchSequence(request, shutdownManager, manager);
   } catch (error) {
     const cleanupErrors = await cleanupFailedLaunch(manager, shutdownManager);
     releaseProcessShutdownManager(shutdownManager);
@@ -167,21 +188,23 @@ export async function runLaunchSequence(
       [...unpackErrors(error), ...cleanupErrors],
       "Failed to launch project",
     );
+  } finally {
+    terminalDisplay.setSilent(previouslySilent);
   }
 }
 
 async function completeLaunchSequence(
-  prepare: ProjectPreparer,
-  projectFolder: string,
-  env: string,
-  options: LaunchOptions,
+  request: LaunchRequest,
   shutdownManager: ShutdownManager,
   manager: ModuleManager,
 ): Promise<StartedProject> {
-  const project = await prepare(projectFolder, env);
+  const { projectFolder, env, options, policy } = request;
+  const project = await request.prepare(projectFolder, env);
 
-  setupAntelopeProjectLogging(project.logging);
-  applyVerboseChannels(options.verbose);
+  if (policy.logging) {
+    setupAntelopeProjectLogging(project.logging);
+    applyVerboseChannels(options.verbose);
+  }
 
   await project.verify();
 
@@ -201,6 +224,7 @@ async function completeLaunchSequence(
     loadContext: project.loadContext,
     fs: project.fs,
     shutdownManager,
+    policy,
   };
 }
 

--- a/src/core/runtime/module-loading.ts
+++ b/src/core/runtime/module-loading.ts
@@ -215,7 +215,7 @@ export async function registerCoreInterfaces(
   return coreManifest;
 }
 
-function buildModuleOverrides(
+export function buildModuleOverrides(
   importOverrides?: ExpandedModuleConfig["importOverrides"],
 ): ModuleOverrideMap {
   const overrides: ModuleOverrideMap = new Map();

--- a/src/core/runtime/project-launch.ts
+++ b/src/core/runtime/project-launch.ts
@@ -11,6 +11,7 @@ import {
   runLaunchSequence,
 } from "./launch-sequence";
 import { releaseProcessShutdownManager } from "./runtime-bootstrap";
+import { DEFAULT_RUNTIME_POLICY, type RuntimePolicy } from "./runtime-policy";
 import type {
   LoaderContext,
   ProjectPreparer,
@@ -171,7 +172,9 @@ async function setupPostLaunchFeatures(
     repl.start(INTERACTIVE_PROMPT);
   }
 
-  setActiveShutdownManager(shutdownManager);
+  if (started.policy.signals) {
+    setActiveShutdownManager(shutdownManager);
+  }
 }
 
 export async function startProject(
@@ -179,11 +182,18 @@ export async function startProject(
   projectFolder: string,
   env: string,
   options: LaunchOptions,
-): Promise<ModuleManager> {
-  const started = await runLaunchSequence(prepare, projectFolder, env, options);
+  policy: RuntimePolicy = DEFAULT_RUNTIME_POLICY,
+): Promise<StartedProject> {
+  const started = await runLaunchSequence(
+    prepare,
+    projectFolder,
+    env,
+    options,
+    policy,
+  );
   try {
     await setupPostLaunchFeatures(started, projectFolder, env, options);
-    return started.manager;
+    return started;
   } catch (error) {
     await started.shutdownManager.shutdown();
     throw error;
@@ -217,10 +227,11 @@ export async function launchFromBuild(
   env: string = DEFAULT_ENV,
   options: LaunchOptions = {},
 ): Promise<ModuleManager> {
-  return startProject(
+  const started = await startProject(
     prepareFromArtifact,
     projectFolder,
     env || DEFAULT_ENV,
     options,
   );
+  return started.manager;
 }

--- a/src/core/runtime/runtime-policy.ts
+++ b/src/core/runtime/runtime-policy.ts
@@ -1,0 +1,32 @@
+/** Process-level responsibilities the runtime claims from whoever owns the process. */
+export interface RuntimePolicy {
+  /** Install `uncaughtException` / `unhandledRejection` / `warning` handlers. */
+  processHandlers: boolean;
+  /** Claim `SIGINT` and `SIGTERM`. */
+  signals: boolean;
+  /** Draw progress spinners on stdout. */
+  terminal: boolean;
+  /** Reset the global logger and take over the log transport. */
+  logging: boolean;
+}
+
+export const DEFAULT_RUNTIME_POLICY: Readonly<RuntimePolicy> = Object.freeze({
+  processHandlers: true,
+  signals: true,
+  terminal: true,
+  logging: true,
+});
+
+export const EMBEDDED_RUNTIME_POLICY: Readonly<RuntimePolicy> = Object.freeze({
+  processHandlers: false,
+  signals: false,
+  terminal: false,
+  logging: false,
+});
+
+export function resolveRuntimePolicy(
+  overrides: Partial<RuntimePolicy> = {},
+  base: Readonly<RuntimePolicy> = DEFAULT_RUNTIME_POLICY,
+): RuntimePolicy {
+  return { ...base, ...overrides };
+}

--- a/src/core/runtime/runtime-types.ts
+++ b/src/core/runtime/runtime-types.ts
@@ -7,6 +7,7 @@ import type { ModuleCache } from "../module-cache";
 import type { ModuleConfig, ModuleManager } from "../module-manager";
 import type { ModuleManifest } from "../module-manifest";
 import type { ShutdownManager } from "../shutdown";
+import type { RuntimePolicy } from "./runtime-policy";
 
 export interface ModuleOverrideRef {
   module: string;
@@ -79,4 +80,5 @@ export interface StartedProject {
   loadContext: LoaderContextProvider;
   fs: NodeFileSystem;
   shutdownManager: ShutdownManager;
+  policy: RuntimePolicy;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,11 +21,21 @@ import type { LaunchOptions } from "./types";
 export { ConfigLoader } from "./core/config/config-loader";
 export { DEFAULT_ENV } from "./core/config/config-paths";
 export { DownloaderRegistry } from "./core/downloaders/registry";
+export {
+  AntelopeRuntime,
+  createRuntime,
+} from "./core/embedded/runtime";
+export type {
+  EmbeddedModuleConfig,
+  EmbeddedRuntimeOptions,
+  ProvideHandle,
+} from "./core/embedded/types";
 export { Module } from "./core/module";
 export { ModuleCache } from "./core/module-cache";
 export { ModuleManager } from "./core/module-manager";
 export { ModuleManifest } from "./core/module-manifest";
 export { launchFromBuild } from "./core/runtime/project-launch";
+export type { RuntimePolicy } from "./core/runtime/runtime-policy";
 export type { BuildOptions } from "./core/runtime/runtime-types";
 export { TestModule } from "./core/test/test-module";
 export { LaunchOptions } from "./types";
@@ -35,7 +45,13 @@ export async function launch(
   env: string = DEFAULT_ENV,
   options: LaunchOptions = {},
 ): Promise<ModuleManager> {
-  return startProject(prepareFromConfig, projectFolder, env, options);
+  const started = await startProject(
+    prepareFromConfig,
+    projectFolder,
+    env,
+    options,
+  );
+  return started.manager;
 }
 
 export async function build(

--- a/test/embedded/esm-host.mjs
+++ b/test/embedded/esm-host.mjs
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+const [projectFolder, corePath] = process.argv.slice(2);
+
+const failures = [];
+
+function check(label, actual, expected) {
+  if (actual !== expected) {
+    failures.push(`${label}: expected ${expected}, got ${actual}`);
+    return;
+  }
+  console.log(`ok - ${label}`);
+}
+
+const sigintBefore = process.listenerCount("SIGINT");
+const sigtermBefore = process.listenerCount("SIGTERM");
+
+const { createRuntime } = await import(pathToFileURL(corePath).href);
+check(
+  "named import of createRuntime from an ESM host",
+  typeof createRuntime,
+  "function",
+);
+
+const runtime = createRuntime({
+  projectFolder,
+  modules: {
+    "provider-mod": { path: "./provider-mod", config: { prefix: "Hello" } },
+  },
+  uses: ["iface-pkg"],
+});
+
+await runtime.start();
+
+const greeter = runtime.use("iface-pkg");
+check(
+  "use() returns the interface object",
+  typeof greeter.Greeter.greet,
+  "function",
+);
+
+const greeting = await Promise.race([
+  greeter.Greeter.greet("esm"),
+  new Promise((_, reject) => setTimeout(() => reject(new Error("HANG")), 5000)),
+]);
+check(
+  "interface call routes to the module implementation",
+  greeting,
+  "Hello esm",
+);
+
+check(
+  "host did not surrender SIGINT",
+  process.listenerCount("SIGINT"),
+  sigintBefore,
+);
+check(
+  "host did not surrender SIGTERM",
+  process.listenerCount("SIGTERM"),
+  sigtermBefore,
+);
+
+const cacheFolder = path.join(projectFolder, ".antelope", "embedded-cache");
+const cacheExists = await fs.stat(cacheFolder).then(
+  () => true,
+  () => false,
+);
+check("no module cache was created", cacheExists, false);
+
+await runtime.stop();
+check("runtime reports stopped", runtime.isRunning, false);
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} check(s) failed:`);
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("\nESM host verification passed.");

--- a/test/embedded/run.ts
+++ b/test/embedded/run.ts
@@ -1,0 +1,58 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  createEmbeddedFixture,
+  type EmbeddedFixture,
+  removeEmbeddedFixture,
+} from "../helpers/embedded-fixture";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const CORE_ENTRY = path.join(REPO_ROOT, "dist", "index.js");
+const HOST_SCRIPT = path.join(__dirname, "esm-host.mjs");
+const EXIT_CODE_ERROR = 1;
+
+async function markProjectAsEsm(fixture: EmbeddedFixture): Promise<void> {
+  await fs.writeFile(
+    path.join(fixture.projectFolder, "package.json"),
+    JSON.stringify(
+      { name: "esm-host-app", version: "1.0.0", type: "module", private: true },
+      null,
+      2,
+    ),
+  );
+}
+
+function runHost(projectFolder: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [HOST_SCRIPT, projectFolder, CORE_ENTRY],
+      { stdio: "inherit", cwd: projectFolder },
+    );
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code ?? EXIT_CODE_ERROR));
+  });
+}
+
+async function main(): Promise<void> {
+  if (!(await fs.stat(CORE_ENTRY).catch(() => undefined))) {
+    throw new Error(`Missing build output at ${CORE_ENTRY}. Run 'pnpm build'.`);
+  }
+
+  const fixture = await createEmbeddedFixture();
+  try {
+    await markProjectAsEsm(fixture);
+    const code = await runHost(fixture.projectFolder);
+    if (code !== 0) {
+      throw new Error(`ESM host exited with code ${code}`);
+    }
+  } finally {
+    await removeEmbeddedFixture(fixture);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(EXIT_CODE_ERROR);
+});

--- a/test/helpers/embedded-fixture.ts
+++ b/test/helpers/embedded-fixture.ts
@@ -6,6 +6,7 @@ export const INTERFACE_PACKAGE = "iface-pkg";
 export const HOST_INTERFACE_PACKAGE = "host-pkg";
 export const PROVIDER_MODULE = "provider-mod";
 export const DEFAULT_PREFIX = "Hello";
+export const INTERFACE_SUBPATH = "greeting";
 
 export interface EmbeddedFixture {
   projectFolder: string;
@@ -18,6 +19,7 @@ export interface InterfacePackageOptions {
   name: string;
   source: string;
   version?: string;
+  subpaths?: Record<string, string>;
 }
 
 const GREETER_SOURCE = `
@@ -25,6 +27,10 @@ const core = require("@antelopejs/interface-core");
 exports.Greeter = {
   greet: core.InterfaceFunction("iface-pkg.greet"),
 };
+`;
+
+const GREETER_SUBPATH_SOURCE = `
+exports.Greeter = require("./index.js").Greeter;
 `;
 
 const HOST_CLOCK_SOURCE = `
@@ -77,6 +83,9 @@ export async function createInterfacePackage(
     antelopeJs: {},
   });
   await fs.writeFile(path.join(folder, "index.js"), options.source);
+  for (const [name, source] of Object.entries(options.subpaths ?? {})) {
+    await fs.writeFile(path.join(folder, `${name}.js`), source);
+  }
   return folder;
 }
 
@@ -114,6 +123,7 @@ export async function createEmbeddedFixture(
     name: INTERFACE_PACKAGE,
     source: GREETER_SOURCE,
     version: options.interfaceVersion,
+    subpaths: { [INTERFACE_SUBPATH]: GREETER_SUBPATH_SOURCE },
   });
   const hostInterfaceFolder = await createInterfacePackage(projectFolder, {
     name: HOST_INTERFACE_PACKAGE,

--- a/test/helpers/embedded-fixture.ts
+++ b/test/helpers/embedded-fixture.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export const INTERFACE_PACKAGE = "iface-pkg";
+export const HOST_INTERFACE_PACKAGE = "host-pkg";
+export const PROVIDER_MODULE = "provider-mod";
+export const DEFAULT_PREFIX = "Hello";
+
+export interface EmbeddedFixture {
+  projectFolder: string;
+  interfaceFolder: string;
+  hostInterfaceFolder: string;
+  providerFolder: string;
+}
+
+export interface InterfacePackageOptions {
+  name: string;
+  source: string;
+  version?: string;
+}
+
+const GREETER_SOURCE = `
+const core = require("@antelopejs/interface-core");
+exports.Greeter = {
+  greet: core.InterfaceFunction("iface-pkg.greet"),
+};
+`;
+
+const HOST_CLOCK_SOURCE = `
+const core = require("@antelopejs/interface-core");
+exports.HostClock = {
+  now: core.InterfaceFunction("host-pkg.now"),
+};
+`;
+
+const PROVIDER_SOURCE = `
+const core = require("@antelopejs/interface-core");
+const iface = require("iface-pkg");
+module.exports = {
+  construct(config) {
+    core.ImplementInterface(iface.Greeter, {
+      greet: (name) =>
+        (config && config.prefix ? config.prefix : "${DEFAULT_PREFIX}") + " " + name,
+    });
+  },
+};
+`;
+
+async function writeJson(
+  filePath: string,
+  value: Record<string, unknown>,
+): Promise<void> {
+  await fs.writeFile(filePath, JSON.stringify(value, null, 2));
+}
+
+export async function linkInto(
+  consumerFolder: string,
+  target: string,
+  name: string,
+): Promise<void> {
+  const modulesFolder = path.join(consumerFolder, "node_modules");
+  await fs.mkdir(modulesFolder, { recursive: true });
+  await fs.symlink(target, path.join(modulesFolder, name));
+}
+
+export async function createInterfacePackage(
+  projectFolder: string,
+  options: InterfacePackageOptions,
+): Promise<string> {
+  const folder = path.join(projectFolder, options.name);
+  await fs.mkdir(folder, { recursive: true });
+  await writeJson(path.join(folder, "package.json"), {
+    name: options.name,
+    version: options.version ?? "1.0.0",
+    main: "index.js",
+    antelopeJs: {},
+  });
+  await fs.writeFile(path.join(folder, "index.js"), options.source);
+  return folder;
+}
+
+export async function createProviderModule(
+  projectFolder: string,
+  interfaceFolder: string,
+  interfaceRange = "*",
+): Promise<string> {
+  const folder = path.join(projectFolder, PROVIDER_MODULE);
+  await fs.mkdir(folder, { recursive: true });
+  await writeJson(path.join(folder, "package.json"), {
+    name: PROVIDER_MODULE,
+    version: "1.0.0",
+    main: "index.js",
+    dependencies: { [INTERFACE_PACKAGE]: interfaceRange },
+    antelopeJs: { implements: [INTERFACE_PACKAGE] },
+  });
+  await fs.writeFile(path.join(folder, "index.js"), PROVIDER_SOURCE);
+  await linkInto(folder, interfaceFolder, INTERFACE_PACKAGE);
+  return folder;
+}
+
+export interface EmbeddedFixtureOptions {
+  interfaceVersion?: string;
+  providerRange?: string;
+}
+
+export async function createEmbeddedFixture(
+  options: EmbeddedFixtureOptions = {},
+): Promise<EmbeddedFixture> {
+  const projectFolder = await fs.mkdtemp(
+    path.join(os.tmpdir(), "ajs-embedded-"),
+  );
+  const interfaceFolder = await createInterfacePackage(projectFolder, {
+    name: INTERFACE_PACKAGE,
+    source: GREETER_SOURCE,
+    version: options.interfaceVersion,
+  });
+  const hostInterfaceFolder = await createInterfacePackage(projectFolder, {
+    name: HOST_INTERFACE_PACKAGE,
+    source: HOST_CLOCK_SOURCE,
+  });
+  const providerFolder = await createProviderModule(
+    projectFolder,
+    interfaceFolder,
+    options.providerRange,
+  );
+  await linkInto(projectFolder, interfaceFolder, INTERFACE_PACKAGE);
+  await linkInto(projectFolder, hostInterfaceFolder, HOST_INTERFACE_PACKAGE);
+  return {
+    projectFolder,
+    interfaceFolder,
+    hostInterfaceFolder,
+    providerFolder,
+  };
+}
+
+export async function removeEmbeddedFixture(
+  fixture: EmbeddedFixture,
+): Promise<void> {
+  await fs.rm(fixture.projectFolder, { recursive: true, force: true });
+}

--- a/test/integration/embedded.test.ts
+++ b/test/integration/embedded.test.ts
@@ -1,0 +1,235 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { internal } from "@antelopejs/interface-core/internal";
+import { expect } from "chai";
+import { type AntelopeRuntime, createRuntime } from "../../src";
+import { terminalDisplay } from "../../src/core/cli/terminal-display";
+import { HOST_MODULE_ID } from "../../src/core/embedded/prepare-embedded";
+import {
+  createEmbeddedFixture,
+  type EmbeddedFixture,
+  HOST_INTERFACE_PACKAGE,
+  INTERFACE_PACKAGE,
+  PROVIDER_MODULE,
+  removeEmbeddedFixture,
+} from "../helpers/embedded-fixture";
+
+const HANG_TIMEOUT_MS = 1000;
+
+interface GreeterInterface {
+  Greeter: { greet(name: string): Promise<string> };
+}
+
+interface ClockInterface {
+  HostClock: { now(): Promise<string> };
+}
+
+function startEmbedded(
+  fixture: EmbeddedFixture,
+  overrides: Record<string, unknown> = {},
+): AntelopeRuntime {
+  return createRuntime({
+    projectFolder: fixture.projectFolder,
+    modules: {
+      [PROVIDER_MODULE]: {
+        path: `./${PROVIDER_MODULE}`,
+        config: { prefix: "Hello" },
+      },
+    },
+    uses: [INTERFACE_PACKAGE],
+    ...overrides,
+  });
+}
+
+function withHangGuard<T>(promise: Promise<T>): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error("HANG")), HANG_TIMEOUT_MS),
+    ),
+  ]);
+}
+
+describe("Embedded runtime", () => {
+  let fixture: EmbeddedFixture;
+  let runtime: AntelopeRuntime | undefined;
+
+  beforeEach(async () => {
+    fixture = await createEmbeddedFixture();
+  });
+
+  afterEach(async () => {
+    await runtime?.stop();
+    runtime = undefined;
+    await removeEmbeddedFixture(fixture);
+  });
+
+  it("routes a host interface call to a module implementation", async () => {
+    runtime = startEmbedded(fixture);
+    await runtime.start();
+
+    const greeter = runtime.use<GreeterInterface>(INTERFACE_PACKAGE);
+
+    expect(await withHangGuard(greeter.Greeter.greet("world"))).to.equal(
+      "Hello world",
+    );
+  });
+
+  it("rejects an interface no loaded module provides", async () => {
+    runtime = startEmbedded(fixture);
+    await runtime.start();
+
+    expect(() => runtime?.use("missing-pkg")).to.throw(/not provided/);
+  });
+
+  it("refuses to hand out interfaces before start", () => {
+    runtime = startEmbedded(fixture);
+    expect(() => runtime?.use(INTERFACE_PACKAGE)).to.throw(/not been started/);
+  });
+
+  it("gives the host a module identity that survives an association rebuild", async () => {
+    runtime = startEmbedded(fixture);
+    await runtime.start();
+
+    runtime.manager.refreshAssociations();
+
+    const tracked = internal.moduleByFolder.filter(
+      (entry) => entry.id === HOST_MODULE_ID,
+    );
+    expect(tracked).to.have.lengthOf(1);
+    expect(internal.interfaceConnections[HOST_MODULE_ID]).to.have.property(
+      INTERFACE_PACKAGE,
+    );
+  });
+
+  it("keeps host calls working after an association rebuild", async () => {
+    runtime = startEmbedded(fixture);
+    await runtime.start();
+
+    runtime.manager.refreshAssociations();
+    const greeter = runtime.use<GreeterInterface>(INTERFACE_PACKAGE);
+
+    expect(await withHangGuard(greeter.Greeter.greet("again"))).to.equal(
+      "Hello again",
+    );
+  });
+
+  it("leaves process signal handlers to the host", async () => {
+    const before = {
+      sigint: process.listenerCount("SIGINT"),
+      sigterm: process.listenerCount("SIGTERM"),
+      uncaught: process.listenerCount("uncaughtException"),
+    };
+
+    runtime = startEmbedded(fixture);
+    await runtime.start();
+
+    expect(process.listenerCount("SIGINT")).to.equal(before.sigint);
+    expect(process.listenerCount("SIGTERM")).to.equal(before.sigterm);
+    expect(process.listenerCount("uncaughtException")).to.equal(
+      before.uncaught,
+    );
+  });
+
+  it("never creates a module cache directory", async () => {
+    runtime = startEmbedded(fixture);
+    await runtime.start();
+
+    const cacheFolder = path.join(
+      fixture.projectFolder,
+      ".antelope",
+      "embedded-cache",
+    );
+    expect(
+      await fs
+        .stat(cacheFolder)
+        .then(() => true)
+        .catch(() => false),
+    ).to.equal(false);
+  });
+
+  it("fails to start when a declared interface resolves to nothing", async () => {
+    runtime = startEmbedded(fixture, {
+      uses: [INTERFACE_PACKAGE, "not-installed-pkg"],
+    });
+
+    const error = await runtime.start().then(
+      () => undefined,
+      (reason: Error) => reason,
+    );
+    expect(error?.message).to.match(/not-installed-pkg/);
+  });
+
+  it("does not itself reject a prerelease interface package", async () => {
+    await removeEmbeddedFixture(fixture);
+    fixture = await createEmbeddedFixture({
+      interfaceVersion: "1.0.0-beta.1",
+      providerRange: "latest",
+    });
+
+    runtime = startEmbedded(fixture);
+    await runtime.start();
+
+    const greeter = runtime.use<GreeterInterface>(INTERFACE_PACKAGE);
+    expect(await withHangGuard(greeter.Greeter.greet("beta"))).to.equal(
+      "Hello beta",
+    );
+  });
+
+  it("shares one launch between concurrent start calls", async () => {
+    runtime = startEmbedded(fixture);
+
+    await Promise.all([runtime.start(), runtime.start()]);
+
+    expect(runtime.manager.listModules()).to.have.lengthOf(3);
+  });
+
+  it("waits for an in-flight start before shutting down", async () => {
+    runtime = startEmbedded(fixture);
+
+    const starting = runtime.start();
+    await runtime.stop();
+    await starting;
+
+    expect(runtime.isRunning).to.equal(false);
+  });
+
+  it("restores spinner output after a failed launch", async () => {
+    runtime = startEmbedded(fixture, { uses: ["not-installed-pkg"] });
+    await runtime.start().catch(() => undefined);
+
+    expect(terminalDisplay.isSilent()).to.equal(false);
+  });
+
+  it("refuses to provide an interface the host did not declare", async () => {
+    runtime = startEmbedded(fixture);
+    await runtime.start();
+
+    expect(() =>
+      runtime?.provide(INTERFACE_PACKAGE, { Greeter: { greet: () => "x" } }),
+    ).to.throw(/not declared in 'provides'/);
+  });
+
+  it("attaches a host implementation and releases it on detach", async () => {
+    runtime = startEmbedded(fixture, {
+      uses: [INTERFACE_PACKAGE, HOST_INTERFACE_PACKAGE],
+      provides: [HOST_INTERFACE_PACKAGE],
+    });
+    await runtime.start();
+
+    const handle = runtime.provide(HOST_INTERFACE_PACKAGE, {
+      HostClock: { now: () => "host-time" },
+    });
+
+    const clock = runtime.use<ClockInterface>(HOST_INTERFACE_PACKAGE);
+    expect(await withHangGuard(clock.HostClock.now())).to.equal("host-time");
+
+    handle.detach();
+
+    const afterDetach = await withHangGuard(clock.HostClock.now()).then(
+      () => "resolved",
+      (error: Error) => error.message,
+    );
+    expect(afterDetach).to.equal("HANG");
+  });
+});

--- a/test/integration/embedded.test.ts
+++ b/test/integration/embedded.test.ts
@@ -10,6 +10,7 @@ import {
   type EmbeddedFixture,
   HOST_INTERFACE_PACKAGE,
   INTERFACE_PACKAGE,
+  INTERFACE_SUBPATH,
   PROVIDER_MODULE,
   removeEmbeddedFixture,
 } from "../helpers/embedded-fixture";
@@ -73,6 +74,26 @@ describe("Embedded runtime", () => {
     expect(await withHangGuard(greeter.Greeter.greet("world"))).to.equal(
       "Hello world",
     );
+  });
+
+  it("routes a host call made through an interface package subpath", async () => {
+    runtime = startEmbedded(fixture);
+    await runtime.start();
+
+    const greeter = runtime.use<GreeterInterface>(
+      `${INTERFACE_PACKAGE}/${INTERFACE_SUBPATH}`,
+    );
+
+    expect(await withHangGuard(greeter.Greeter.greet("world"))).to.equal(
+      "Hello world",
+    );
+  });
+
+  it("rejects a subpath of an interface no loaded module provides", async () => {
+    runtime = startEmbedded(fixture);
+    await runtime.start();
+
+    expect(() => runtime?.use("missing-pkg/sub")).to.throw(/not provided/);
   });
 
   it("rejects an interface no loaded module provides", async () => {


### PR DESCRIPTION
### 🔗 Linked issue

None. This implements the embedded-runtime proposal as a first working trial; the design questions it settles are recorded under "Design notes" below.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

AntelopeJS currently assumes it owns the process: `launch()` installs `uncaughtException`/`unhandledRejection` handlers, claims `SIGINT`/`SIGTERM`, draws spinners on stdout and resets the global logger. That makes it unusable as a subsystem of an application that already owns those responsibilities, which is what running an AntelopeJS project inside a host framework requires.

This adds a guest mode that boots the same runtime while leaving process ownership to the host, plus a small handle API so host code can reach interfaces without importing interface packages itself.

```ts
import { createRuntime } from "@antelopejs/core";

const runtime = createRuntime({
  modules: { "@antelopejs/api": { config: { servers: [/* … */] } } },
  uses: ["@antelopejs/interface-api"],
  provides: ["@antelopejs/interface-clock"],
});

await runtime.start();
const api = runtime.use<ApiInterface>("@antelopejs/interface-api");
const handle = runtime.provide("@antelopejs/interface-clock", hostClock);
// …
handle.detach();
await runtime.stop();
```

**Process policy.** `RuntimePolicy` names the four responsibilities the runtime claims — `processHandlers`, `signals`, `terminal`, `logging` — and threads through the existing launch sequence. `launch()` and `launchFromBuild()` pass `DEFAULT_RUNTIME_POLICY` (all enabled), so their behaviour is unchanged; embedded mode starts from `EMBEDDED_RUNTIME_POLICY` (all disabled) and lets a host reclaim any individual one. `TerminalDisplay` gains a `silent` flag rather than dependency injection, which keeps its 27 call sites untouched.

**Guest boot path.** `prepareEmbedded` is a fourth `ProjectPreparer` alongside `prepareFromConfig` and `prepareFromArtifact`, so it reuses the whole existing sequence rather than duplicating it. It reads no config file, downloads nothing, and skips the outdated-module check; modules resolve straight from the host application's own `node_modules` via `resolvePackage`. Its `loadContext` is lazy and never called, so an embedded runtime never creates a module cache directory.

**Handle API.** `use()` and `provide()` run their `require` inside the host module's execution context through the new `Module.runInContext`. That is what makes the host's own module system irrelevant — an ESM host behaves identically to a CommonJS one — and it avoids the second, unattached copy of an interface package that a direct host import would produce. `provide()` returns a handle whose `detach()` releases exactly the proxies that attachment created, since host code has no module lifecycle to release them for it.

#### Design notes

Three decisions are not obvious from the diff:

- **The host is registered as a real module** (`__antelope_host__`) rather than having an identity pushed in from outside. `collectInterfaceSources` wipes and rebuilds every identity structure — `moduleByFolder`, `modulesById`, the module tracker, `interfaceConnections` — from the manager's loaded set on each association rebuild, so an externally injected identity would not survive the next module load. Registering it normally also puts the host's declared interfaces through graph validation.
- **The host module's folder is `<projectFolder>/.antelope/host`, deliberately not the application root.** `destroyAll` drops every `require.cache` entry beneath a loaded module's folder; pointed at the application root it would evict the host application itself. Nothing reads the folder from disk, so it need not exist.
- **The host records `"latest"` as its dependency range.** The host pins nothing — modules own the version contract — and `validRange("latest")` is `null`, so version validation skips the host entirely. A real range would also reject a prerelease interface outright, because `semver.satisfies` excludes prereleases from every range including `*` unless explicitly asked not to.

Interfaces the host declares in `uses`/`provides` are verified at startup, so a misspelt or uninstalled name fails the boot instead of becoming a call that queues forever. Concurrent `start()` calls share one launch, and `stop()` waits for an in-flight start rather than returning before there is anything to tear down.

### ✅ Validation

- `npx tsc --noEmit` — clean
- `pnpm lint` — passes (two pre-existing warnings and one info, outside this diff)
- `pnpm test:unit` — 702 passing, including 14 new embedded integration tests
- `pnpm test:embedded` — new; a real ESM host under plain `node` against the built `dist`, 7 assertions
- `pnpm test:package-consumer` — passes
- `pnpm test:playground` — passes, all phases (the regression guard proving `launch()` behaviour is unchanged)

The embedded suite covers routing a host call to a module implementation, refusing an unprovided or undeclared interface, refusing use before start, host identity surviving an association rebuild, leaving signal handlers to the host, never creating a cache directory, failing to start on an unresolved declared interface, sharing one launch across concurrent starts, waiting for an in-flight start before shutdown, restoring spinner output after a failed launch, and releasing a host implementation on `detach()`.

Beyond CI, the branch was validated end to end in a real AdonisJS 6.18 (ESM) application: an npm-installed `@antelopejs/api` module loads and keeps its identity, a route registered from host code is attributed to `__antelope_host__` and serves HTTP, `SIGTERM` shuts down cleanly, and an unhandled rejection is left to the host's own policy with no AntelopeJS logging or `process.exit`.

### ⚠️ Residual considerations

- **Module identity relies on the async execution context**, not the call stack. `GetResponsibleModule()` in interface-core 0.0.12 reads `internal.executionContext` before falling back to `findResponsibleFile`, which is why modules resolved from the host's `node_modules` keep their identity despite that walk skipping `/node_modules/` frames. Anything a host does through the runtime must therefore run inside the host module's context — `use()` and `provide()` handle this, but it is the load-bearing assumption.
- **No bundler support.** Resolver interception cannot survive a webpack/Vite build; this is a plain Node process only.
- **Modules opening their own listeners still do so.** Mounting an AntelopeJS HTTP module into a host's server needs a mountable handler on the module side and is out of scope here.
- **Hot reload across the boundary is not addressed**; the watcher is off in embedded mode, which `dev: false` already implies.
- Pre-existing and unrelated: `semver.satisfies` excludes prereleases from every range, so any module declaring a normal range against a prerelease interface package fails `validateInterfacePackages`. Embedded mode sidesteps it for the host only; the general case is untouched here.

### 📝 Checklist

- [ ] I have linked an issue or discussion. (No existing issue; the proposal was relayed directly.)
- [ ] I have updated the documentation accordingly. (Public API is documented via TSDoc; a docs PR should follow if this direction is accepted.)
- [ ] I have run `ajs module exports generate` and committed any updated interface files. (No generated interface files changed.)
