### PR TITLE
ci: authenticate protected release pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
@@ -45,9 +46,9 @@ jobs:
         if: inputs.channel == 'latest'
         run: pnpm release -- --ci
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
       - name: Publish next release
         if: inputs.channel == 'next'
         run: pnpm release -- --ci --preRelease=next
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}


### PR DESCRIPTION
Use the protected npm-publish environment's GitHub token for the release checkout and GitHub release API. This lets release-it push its version commit through the administrator bypass while npm publishing remains tokenless through OIDC.\n\nNo package is published by this PR.