### PR TITLE
fix(test): run module tests in provider context

### DIFF
--- a/src/core/test/test-module.ts
+++ b/src/core/test/test-module.ts
@@ -188,6 +188,21 @@ function registerTestDir(testDir: string, manager: ModuleManager): void {
   }
 }
 
+export function runInTestModuleContext<T>(
+  moduleRoot: string,
+  manager: ModuleManager | null,
+  callback: () => T,
+): T {
+  const loadedModules = [...(manager?.getLoadedModules() ?? [])];
+  const resolvedModuleRoot = path.resolve(moduleRoot);
+  const testModule =
+    loadedModules.find(
+      ({ module }) =>
+        path.resolve(module.manifest.folder) === resolvedModuleRoot,
+    )?.module ?? loadedModules[0]?.module;
+  return testModule ? testModule.runInContext(callback) : callback();
+}
+
 export async function executeTests(
   moduleRoot: string,
   test: AntelopeTestConfig,
@@ -211,9 +226,14 @@ export async function executeTests(
     mocha.addFile(file);
   }
 
-  return new Promise<number>((resolve) => {
-    mocha.run((count) => resolve(count));
-  });
+  return runInTestModuleContext(
+    moduleRoot,
+    manager,
+    () =>
+      new Promise<number>((resolve) => {
+        mocha.run((count) => resolve(count));
+      }),
+  );
 }
 
 async function discoverTestFiles(

--- a/test/core/test/test-module.test.ts
+++ b/test/core/test/test-module.test.ts
@@ -1,4 +1,8 @@
 import path from "node:path";
+import {
+  GetModuleContext,
+  RunWithModuleContext,
+} from "@antelopejs/interface-core/modules";
 import { expect } from "chai";
 import sinon from "sinon";
 import { ConfigLoader } from "../../../src/core/config/config-loader";
@@ -21,6 +25,10 @@ function resetProxy(interfaceFunction: unknown): void {
   const { proxy } = interfaceFunction as ProxiedInterfaceFunction;
   proxy.onCall(() => undefined, true);
   proxy.detach();
+}
+
+function runInLocalContext<T>(callback: () => T): T {
+  return RunWithModuleContext({ module: "local", provider: "local" }, callback);
 }
 
 async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
@@ -416,6 +424,30 @@ describe("test-module", () => {
       const result = await testModule.TestModule("/module");
 
       expect(result).to.equal(0);
+    });
+  });
+
+  describe("runInTestModuleContext", () => {
+    it("preserves the tested module context across asynchronous test work", async () => {
+      const module = {
+        manifest: { folder: "/module" },
+        runInContext: runInLocalContext,
+      };
+      const manager = {
+        getLoadedModules: () => new Map([["local", { module }]]).values(),
+      };
+
+      let activeModule: string | undefined;
+      await testModule.runInTestModuleContext(
+        "/module",
+        manager as ModuleManager,
+        async () => {
+          await Promise.resolve();
+          activeModule = GetModuleContext()?.module;
+        },
+      );
+
+      expect(activeModule).to.equal("local");
     });
   });
 


### PR DESCRIPTION
## Summary

- run Mocha inside the tested module's execution context
- preserve that context across asynchronous test work
- avoid ambiguous interface-provider resolution during `ajs module test`

## Why

`ajs module test` loaded interface tests, then ran Mocha outside the tested module context. Direct interface registrations could therefore see both the local implementation and the default provider and fail with `AmbiguousProviderError`.

## Verification

- `pnpm lint`
- `pnpm build`
- full core test suite: exit 0
- `ajs module test .` in `AntelopeJS/api` with its frozen lockfile: 174 passing
