### PR TITLE
fix(ci): pass release arguments correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,11 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Publish stable release
         if: inputs.channel == 'latest'
-        run: pnpm release -- --ci
+        run: pnpm release --ci
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
       - name: Publish next release
         if: inputs.channel == 'next'
-        run: pnpm release -- --ci --preRelease=next
+        run: pnpm release --ci --preRelease=next
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- pass `--ci` directly through pnpm to `release-it`
- preserve stable and prerelease channel behavior

## Why

`pnpm release -- --ci` forwards the extra `--` to `release-it` as the requested version increment. Changelogen then returns an empty recommended version, and the release finishes successfully without publishing anything.

The corrected commands are `pnpm release --ci` and `pnpm release --ci --preRelease=next`.
