### PR TITLE
docs: align introduction and architecture with hexagonal positioning

### DIFF
--- a/docs/1.get-started/1.introduction.md
+++ b/docs/1.get-started/1.introduction.md
@@ -1,46 +1,59 @@
 ---
 title: Introduction
-description: An overview of the Antelopejs framework — a TypeScript framework for building modular, scalable applications using interface-based architecture.
+description: AntelopeJS extends hexagonal architecture across application and ecosystem modules through explicit contracts and application-selected implementations.
 navigation:
   icon: i-ph-info
 ---
 
-## What is Antelopejs
+## Hexagonal architecture. Beyond your own code.
 
-Antelopejs is a TypeScript framework for building modular, scalable applications using interface-based architecture. Modules communicate through interfaces — well-defined contracts that describe what a module provides — rather than importing each other directly. This design enables loose coupling between components and makes it possible to hot-swap module implementations at runtime.
+AntelopeJS is a TypeScript framework and CLI for Node.js applications. It brings your business modules, local integrations and installed ecosystem modules into the same ports-and-adapters model. Consumers depend on explicit contracts, providers implement them, and the application selects the implementations.
 
-## Key Features
+If you already practice hexagonal architecture, the goal is not to teach you another folder structure. AntelopeJS supplies the interface binding, module lifecycle and application assembly mechanisms that make those boundaries usable across separately maintained modules.
+
+## Keep the boundary when you add a dependency
+
+An integration should not force business modules to import the provider that implements it. In AntelopeJS, a consumer calls an interface package. A provider registers an implementation of that interface, and the runtime connects the calls.
+
+For example, a consumer can depend on the shared database contract rather than a MongoDB module. An implementation may come from your own code or the ecosystem; both participate in the same module model. Calling a MongoDB-specific interface is also possible, but that choice intentionally reduces portability.
+
+## What AntelopeJS provides
 
 ::card-group
-::card{icon="i-ph-brackets-curly" title="Interface-Based Architecture"}
-Modules communicate through contracts, not direct dependencies. A module never needs to know which other module fulfills its requirements.
+::card{icon="i-ph-brackets-curly" title="Explicit contracts"}
+Describe the capabilities consumers need through typed interface APIs. Keep the provider choice outside the consuming module.
 ::
 
-::card{icon="i-ph-rocket-launch" title="Hot Module Reloading"}
-Swap modules at runtime during development. Changes take effect immediately without restarting the entire application.
+::card{icon="i-ph-puzzle-piece" title="One ecosystem model"}
+Compose local modules and published packages through the same application configuration and lifecycle. You do not need a separate integration model for each module source.
 ::
 
-::card{icon="i-ph-code" title="Full TypeScript Support"}
-End-to-end type safety across module boundaries. Interfaces are fully typed, so your editor catches errors before you run anything.
+::card{icon="i-ph-arrows-split" title="Application-owned choices"}
+Select an implementation in application configuration. A compatible replacement can preserve the consumer's import and calls while its provider-specific setup changes.
 ::
 
-::card{icon="i-ph-puzzle-piece" title="Modular Design"}
-Build applications as composable modules. Each module is an independent package that you can develop, test, and deploy on its own.
+::card{icon="i-ph-code" title="Shared runtime mechanisms"}
+Use interface binding and module lifecycle instead of rebuilding that infrastructure. Keep responsibility for your contracts, business behavior and integration tests.
 ::
 
-::card{icon="i-ph-arrows-split" title="Swap Without Rewriting"}
-Change your database, payment provider, or notification service by swapping one module for another. Dependent code stays the same because the interface contract holds.
+::card{icon="i-ph-rocket-launch" title="Development hot reload"}
+Reload changed local modules during development. This shortens the edit-and-run loop; it is separate from changing a production provider.
 ::
 ::
 
-::warning
-HMR is currently available only for development environments. Production-ready HMR is planned for a future release.
+## What stays your responsibility
+
+A replacement must support the contract version, capabilities and behavior your consumers require. Matching types alone does not guarantee compatibility. Configuration, credentials, data migrations and operational requirements still need attention.
+
+AntelopeJS provides the mechanisms for explicit boundaries; it does not prevent modules from importing a provider directly. Your design still determines which dependencies belong in business code, and consumers remain coupled to their contracts.
+
+::note
+Hot module reloading is a development feature, not a guarantee of live production migration between providers.
 ::
 
-## Philosophy
+## Start building
 
-Traditional frameworks pack too many features into their core, making them hard to customize and painful to upgrade. Antelopejs takes a different approach: instead of a monolithic framework, you compose applications from independent modules.
-
-Each module exports interfaces that describe what it provides and imports interfaces that describe what it needs. The core manages module lifecycle and routes interface calls between producers and consumers. You never wire modules together manually.
-
-This architecture means you can swap any module implementation without changing the code that depends on it. Switching from one database provider to another, or replacing a payment gateway, requires only a configuration change — the consuming modules keep working because the interface contract stays the same.
+- [Quick Start](/docs/get-started/quick-start) — Create a project and your first module.
+- [Architecture](/docs/get-started/architecture) — Map ports, adapters and application assembly to AntelopeJS.
+- [Interfaces](/docs/concepts/interfaces) — Define, consume and implement a contract.
+- [Explore the ecosystem](/modules) — Find modules and inspect the interfaces they support.

--- a/docs/1.get-started/4.architecture.md
+++ b/docs/1.get-started/4.architecture.md
@@ -1,34 +1,48 @@
 ---
 title: Architecture
-description: Understand the core architecture of Antelopejs — interfaces, modules, and the core — and how they create a flexible, modular system.
+description: Map hexagonal architecture to AntelopeJS contracts, provider modules and application assembly, including the limits of implementation compatibility.
 navigation:
   icon: i-ph-blueprint
 ---
 
 ## Overview
 
-Antelopejs follows an interface-based architecture built on three core concepts: **Interfaces**, **Modules**, and **the Core**. Together, they create a system where components are loosely coupled, independently replaceable, and easy to reason about.
+AntelopeJS extends the ports-and-adapters model across application and ecosystem modules. **Interfaces** define capabilities, **provider modules** implement them, and **application configuration** selects the modules to load. The **core** manages their bindings and lifecycle.
+
+| Hexagonal concept | AntelopeJS mechanism                   | Responsibility                                             |
+| ----------------- | -------------------------------------- | ---------------------------------------------------------- |
+| Port              | Interface contract                     | Describe the public capability consumers need.             |
+| Adapter           | Implementation in a provider module    | Translate that capability into provider-specific behavior. |
+| Consumer          | Module calling an interface            | Depend on the capability rather than its implementation.   |
+| Composition root  | Application configuration and assembly | Select and configure the implementations.                  |
+
+A module is a unit of composition, not necessarily an adapter. It can contain business behavior, implement contracts, consume other contracts, or combine these roles. You still choose the boundaries that suit your application.
 
 ## Interfaces — Contracts Between Modules
 
-An interface defines a contract: a set of functions, events, or registrations that a module provides to the rest of the application. Other modules import and call these interfaces without knowing which module implements them.
+An interface defines a public contract: functions, events or registrations that consumers and implementations agree on. It can also contain shared types, wrappers and provider-independent utilities. It is more than a TypeScript type declaration.
 
-This separation is the foundation of loose coupling in Antelopejs. A module that needs database access imports the database interface — it never imports the database module directly. The core resolves which module fulfills the contract at runtime.
+A standalone interface package has its own release cycle. A consumer imports that package, while a provider imports it to register an implementation. Embedded interfaces also exist; see [Interfaces](/docs/concepts/interfaces) for both forms.
 
-<Mermaid>
-graph LR
-    A["Module A (Producer)"] -->|exports| I((Interface X))
-    I -->|imports| B["Module B (Consumer)"]
-    style I fill:#f0ad4e,stroke:#333,color:#333
-    style A fill:#5cb85c,stroke:#333,color:#fff
-    style B fill:#337ab7,stroke:#333,color:#fff
-</Mermaid>
+The arrows below show dependencies on a shared contract, not the runtime call path:
 
-Module A exports Interface X, defining the contract. Module B imports Interface X and calls its methods. Module B has no dependency on Module A — only on the interface.
+```text
+Consumer ──depends on──▶ Contract ◀──implements── Provider
+```
+
+At runtime, the consumer calls the interface API, and its proxies route calls to the registered implementation. The consumer does not need to import the provider package, but it still depends on the contract's API and behavior.
+
+## Application Assembly — Choose the Implementation
+
+The application selects module sources in `antelope.config.ts`. Sources can be local modules, packages or Git repositories. A provider's `construct()` function registers its implementation with `ImplementInterface`; the consuming module does not make that choice.
+
+This separation also applies when the provider comes from the ecosystem. You can keep a critical integration in-house without changing the way the rest of the application consumes its contract. See [Configuration](/docs/concepts/configuration) for source types and module settings.
+
+An incoming adapter, such as an HTTP module, connects requests to application behavior. A business module can then call outgoing capabilities through contracts. Keep the dependency diagram separate from this request flow: an incoming adapter calling a use case does not require the use case to depend on that adapter.
 
 ## Modules — Building Blocks
 
-Each module is an independent package that exports and/or imports interfaces. Modules are self-contained: they have their own dependencies, configuration, and lifecycle.
+Modules declare the interfaces they provide or consume and have their own dependencies, configuration and lifecycle. Their boundaries support separate development and testing; they do not automatically imply separate deployment or process isolation.
 
 Every module follows the same lifecycle:
 
@@ -39,12 +53,12 @@ Every module follows the same lifecycle:
 
 Each lifecycle function maps to a specific state transition:
 
-| Function | Transition |
-|----------|-----------|
+| Function      | Transition           |
+| ------------- | -------------------- |
 | `construct()` | loaded → constructed |
-| `start()` | constructed → active |
-| `stop()` | active → constructed |
-| `destroy()` | constructed → loaded |
+| `start()`     | constructed → active |
+| `stop()`      | active → constructed |
+| `destroy()`   | constructed → loaded |
 
 <Mermaid>
 stateDiagram-v2
@@ -55,20 +69,21 @@ stateDiagram-v2
     Constructed --> Loaded: destroy()
 </Mermaid>
 
-Because modules only depend on interfaces, you can replace any module with another that implements the same interfaces. The consuming modules keep working without any code changes.
+## Replacing a Provider — Check Compatibility
 
-<Mermaid>
-graph TD
-    S[Stripe Module] -->|implements| P((Payment Interface))
-    O[Ogone Module] -->|implements| P
-    P -->|used by| C[Checkout Module]
-    style P fill:#f0ad4e,stroke:#333,color:#333
-    style S fill:#5cb85c,stroke:#333,color:#fff
-    style O fill:#5cb85c,stroke:#333,color:#fff
-    style C fill:#337ab7,stroke:#333,color:#fff
-</Mermaid>
+A consumer can keep the same import and calls when a replacement satisfies the contract version, capabilities and behavior it relies on. Selecting a different source moves the provider choice; it does not migrate data or establish behavioral equivalence.
 
-Both the Stripe module and the Ogone module implement the Payment interface. The Checkout module consumes the Payment interface. Swapping Stripe for Ogone requires only a configuration change — the Checkout module remains untouched.
+For example, the ecosystem's MongoDB and RethinkDB modules both declare the shared database interface, alongside provider-specific interfaces. A consumer using the shared API has a common boundary to evaluate. A consumer using MongoDB-specific operations has deliberately taken on a provider dependency.
+
+Before replacing a provider, check:
+
+- **Contract versions** — The replacement supports the interface versions your consumers use.
+- **Capabilities and behavior** — Required operations, error handling and side effects match your application's expectations.
+- **Configuration and data** — Credentials, provider settings and any migration are ready.
+- **Operational requirements** — Performance, durability and deployment characteristics suit the application.
+- **Tests** — Run available contract suites and your integration tests against the replacement. Passing tests provides evidence for the behaviors they cover, not a guarantee of universal interchangeability.
+
+AntelopeJS supplies binding and lifecycle mechanisms, not enforcement of dependency direction. Direct provider imports can still bypass the contract boundary. Development HMR is also separate from a production provider migration.
 
 ## The Core — The Conductor
 
@@ -82,12 +97,12 @@ The core does not contain business logic. Instead, the core acts as the conducto
 
 ## Benefits
 
-This architecture delivers practical advantages across the entire development lifecycle:
+The benefit is a shared integration model, not the absence of dependencies:
 
-- **Consistent patterns** — Every module follows the same structure and lifecycle, so onboarding is fast and code reviews are predictable
-- **Swap without rewriting** — Change your database, payment provider, or notification service by swapping one module for another. Dependent code stays the same because the interface contract holds
-- **Predictable contracts** — Interfaces define stable boundaries between modules. Changes to an interface are explicit and intentional, keeping dependent modules safe
-- **Live development updates** — HMR gives you immediate feedback during development. Change a module, save the file, and the updated code loads automatically
+- **Provider-independent consumers** — Keep implementation-specific imports out of modules that only need the shared contract.
+- **Local and ecosystem composition** — Apply the same assembly mechanisms to modules you write and modules you install.
+- **Focused changes** — Evolve an implementation behind a compatible contract without spreading provider choices through its consumers.
+- **Less runtime plumbing** — Use the core's interface binding and lifecycle instead of rebuilding them for each application.
 
 ## Error Handling
 

--- a/docs/6.community/1.getting-help.md
+++ b/docs/6.community/1.getting-help.md
@@ -125,5 +125,5 @@ Found a bug?
 
 Spot something confusing or missing in the docs?
 
-- For small fixes: [Edit the page on GitHub](https://github.com/AntelopeJS/antelopejs.com/tree/main/content/docs)
+- For small fixes: [Edit the page on GitHub](https://github.com/AntelopeJS/antelopejs/tree/main/docs)
 - For bigger changes: [Open an issue](https://github.com/antelopejs/antelopejs/issues/new) explaining what needs improvement


### PR DESCRIPTION
## Summary
- Apply the approved hexagonal-ecosystem positioning in the authoritative product documentation under docs/.
- Explain contract/provider/consumer/application responsibilities and compatibility limits.
- Correct the documentation contribution link to this repository.

## Source verification
Based on current main, after merged README PR #116. The current Introduction and Architecture were compared byte-for-byte with their prior versions before applying the editorial changes. Newer configuration, database, Data API, tutorial and CLI corrections are untouched.

Companion website source correction: https://github.com/AntelopeJS/antelope-web/pull/19

## Validation
- All three edited pages pass Markdown/MDC parsing and internal route checks.
- git diff --check passed.
- The Introduction/Architecture wording was previously rendered and inspected in the website preview; this PR relocates those edits to their proper source repository.

No runtime changes or release.